### PR TITLE
headset-off handling: master output + opt-in steelseries detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,6 +2172,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.12.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2679,6 +2680,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2991,6 +3016,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "thiserror 2.0.18",
 ]
 
@@ -3360,6 +3386,64 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e126abc9e84e35cdfd01596140a73a1850cdb0df0a23acf0185776c30b469a6e"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -4417,6 +4501,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4448,11 +4541,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4486,6 +4596,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4496,6 +4612,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4510,10 +4632,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4528,6 +4662,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4538,6 +4678,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4552,6 +4698,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4562,6 +4714,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ processed virtual microphone for voice chat.
 - **Mixes** — recordable sources for OBS. Master Mix carries everything;
   custom mixes can carry "everything except music" and stay current as
   channels change. In OBS, add a mix as an audio input — not Desktop Audio.
+- **Equalizer** — per-channel parametric EQ (up to 10 bands) with a
+  draggable response curve, bundled community presets, and import/export
+  including AutoEq text blocks
 - **Microphone** — noise gate, compressor and limiter into a virtual mic
   you select in Discord or OBS. Pairs well with
   [NoiseTorch](https://github.com/noisetorch/NoiseTorch) on the input for

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "material-symbols": "^0.44.11",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1885,6 +1886,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "material-symbols": "^0.44.11",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/presets/eq/bass-boost.json
+++ b/presets/eq/bass-boost.json
@@ -1,0 +1,13 @@
+{
+  "schema": 1,
+  "name": "Bass Boost",
+  "author": "Sink",
+  "description": "Warm low-end lift for music, with headroom trimmed to match.",
+  "preamp_db": -4,
+  "bands": [
+    { "kind": "low_shelf", "freq_hz": 110, "gain_db": 6, "q": 0.71 },
+    { "kind": "peaking", "freq_hz": 250, "gain_db": 1.5, "q": 1.0 },
+    { "kind": "peaking", "freq_hz": 800, "gain_db": -1, "q": 1.2 },
+    { "kind": "high_shelf", "freq_hz": 9000, "gain_db": 1, "q": 0.71 }
+  ]
+}

--- a/presets/eq/flat.json
+++ b/presets/eq/flat.json
@@ -1,0 +1,14 @@
+{
+  "schema": 1,
+  "name": "Flat",
+  "author": "Sink",
+  "description": "The neutral 5-band starting point. Apply to undo any preset.",
+  "preamp_db": 0,
+  "bands": [
+    { "kind": "low_shelf", "freq_hz": 100, "gain_db": 0, "q": 0.71 },
+    { "kind": "peaking", "freq_hz": 500, "gain_db": 0, "q": 1.0 },
+    { "kind": "peaking", "freq_hz": 1500, "gain_db": 0, "q": 1.0 },
+    { "kind": "peaking", "freq_hz": 5000, "gain_db": 0, "q": 1.0 },
+    { "kind": "high_shelf", "freq_hz": 10000, "gain_db": 0, "q": 0.71 }
+  ]
+}

--- a/presets/eq/fps-footsteps.json
+++ b/presets/eq/fps-footsteps.json
@@ -1,0 +1,13 @@
+{
+  "schema": 1,
+  "name": "FPS Footsteps",
+  "author": "Sink",
+  "description": "Boosts the footstep band and tames explosions and rumble.",
+  "preamp_db": -3,
+  "bands": [
+    { "kind": "low_shelf", "freq_hz": 120, "gain_db": -4, "q": 0.71 },
+    { "kind": "peaking", "freq_hz": 2000, "gain_db": 2.5, "q": 1.0 },
+    { "kind": "peaking", "freq_hz": 4000, "gain_db": 4, "q": 1.4 },
+    { "kind": "high_shelf", "freq_hz": 8000, "gain_db": 1.5, "q": 0.71 }
+  ]
+}

--- a/presets/eq/vocal-clarity.json
+++ b/presets/eq/vocal-clarity.json
@@ -1,0 +1,13 @@
+{
+  "schema": 1,
+  "name": "Vocal Clarity",
+  "author": "Sink",
+  "description": "Presence lift for chat and podcasts; rumble rolled off.",
+  "preamp_db": -2,
+  "bands": [
+    { "kind": "high_pass", "freq_hz": 90, "gain_db": 0, "q": 0.71 },
+    { "kind": "peaking", "freq_hz": 2500, "gain_db": 3, "q": 1.0 },
+    { "kind": "peaking", "freq_hz": 5000, "gain_db": 2, "q": 1.4 },
+    { "kind": "high_shelf", "freq_hz": 10000, "gain_db": 1, "q": 0.71 }
+  ]
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,9 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png", "protocol-asset"] }
+# Native open/save pickers for EQ preset import/export; the file I/O itself
+# stays in our own commands (no fs plugin / scope surface needed).
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,49 @@
+use std::fmt::Write as _;
+use std::path::Path;
+
+/// Embed the community EQ presets (../presets/eq/*.json) into the binary:
+/// generate `OUT_DIR/eq_presets_generated.rs` with one include_str! per
+/// file. Compile-time embedding means zero packaging changes (the deb/rpm/
+/// AUR/COPR payloads stay identical) and presets can never be missing at
+/// runtime. Dropping a .json into presets/eq/ is picked up automatically.
+fn embed_eq_presets() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("cargo sets CARGO_MANIFEST_DIR");
+    let out_dir = std::env::var("OUT_DIR").expect("cargo sets OUT_DIR");
+    let presets_dir = Path::new(&manifest_dir).join("../presets/eq");
+    println!("cargo:rerun-if-changed={}", presets_dir.display());
+
+    let mut entries: Vec<(String, String)> = Vec::new();
+    if let Ok(dir) = std::fs::read_dir(&presets_dir) {
+        for entry in dir.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            println!("cargo:rerun-if-changed={}", path.display());
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default()
+                .to_string();
+            entries.push((stem, path.display().to_string()));
+        }
+    }
+    entries.sort();
+
+    let mut code = String::from(
+        "/// (file stem, raw JSON) of every bundled community EQ preset.\n\
+         pub static BUNDLED_EQ_PRESET_SOURCES: &[(&str, &str)] = &[\n",
+    );
+    for (stem, path) in &entries {
+        let _ = writeln!(code, "    ({stem:?}, include_str!({path:?})),");
+    }
+    code.push_str("];\n");
+
+    std::fs::write(Path::new(&out_dir).join("eq_presets_generated.rs"), code)
+        .expect("write eq presets codegen");
+}
+
 fn main() {
+    embed_eq_presets();
     tauri_build::build()
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,8 @@
     "core:window:allow-show",
     "core:window:allow-close",
     "core:window:allow-set-focus",
-    "core:window:allow-toggle-maximize"
+    "core:window:allow-toggle-maximize",
+    "dialog:allow-open",
+    "dialog:allow-save"
   ]
 }

--- a/src-tauri/src/audio/backend.rs
+++ b/src-tauri/src/audio/backend.rs
@@ -1,4 +1,4 @@
-use crate::audio::types::{AppStream, MicConfig, OutputDevice};
+use crate::audio::types::{AppStream, EqConfig, MicConfig, OutputDevice};
 use crate::error::SinkError;
 
 /// Abstraction over the underlying audio system.
@@ -41,6 +41,11 @@ pub trait AudioBackend: Send + Sync {
     fn set_channel_failover(&self, _sink_name: &str, _enabled: bool) -> Result<(), SinkError> {
         Ok(())
     }
+
+    /// Apply a channel's parametric EQ (insert/re-tune/remove the biquad
+    /// chain in the channel's output path). Native-only: the pactl fallback
+    /// has no in-graph insert point, mirroring `set_mic_config`.
+    fn set_channel_eq(&self, sink_name: &str, config: &EqConfig) -> Result<(), SinkError>;
 
     /// Per-channel resolved output: the `node.name` of the device each channel
     /// is actually routed to right now, after explicit/default/fallback

--- a/src-tauri/src/audio/eq_import.rs
+++ b/src-tauri/src/audio/eq_import.rs
@@ -1,0 +1,187 @@
+//! AutoEq text-format import. AutoEq (the community headphone-correction
+//! project) publishes parametric EQs as plain text:
+//!
+//! ```text
+//! Preamp: -6.0 dB
+//! Filter 1: ON PK Fc 105 Hz Gain -2.4 dB Q 0.70
+//! ```
+//!
+//! Tolerant token parsing, no regex: disabled and unrecognized filter
+//! lines are skipped (a partial import beats a hard failure over one
+//! exotic filter type); it errors only when nothing usable remains.
+
+use crate::audio::types::{EqBand, EqBandKind, EqConfig, MAX_EQ_BANDS};
+use crate::error::SinkError;
+
+fn kind_from_token(token: &str) -> Option<EqBandKind> {
+    match token {
+        "PK" | "PEQ" | "Modal" => Some(EqBandKind::Peaking),
+        "LS" | "LSC" => Some(EqBandKind::LowShelf),
+        "HS" | "HSC" => Some(EqBandKind::HighShelf),
+        "LP" | "LPQ" => Some(EqBandKind::LowPass),
+        "HP" | "HPQ" => Some(EqBandKind::HighPass),
+        _ => None,
+    }
+}
+
+/// Value following a `label` token (e.g. "Fc" -> 105.0 from "Fc 105 Hz").
+fn value_after(tokens: &[&str], label: &str) -> Option<f32> {
+    tokens
+        .iter()
+        .position(|t| t.eq_ignore_ascii_case(label))
+        .and_then(|i| tokens.get(i + 1))
+        .and_then(|v| v.parse().ok())
+}
+
+fn parse_filter_line(line: &str) -> Option<EqBand> {
+    // "Filter N: ON PK Fc 105 Hz Gain -2.4 dB Q 0.70"
+    let rest = line.split(':').nth(1)?.trim();
+    let tokens: Vec<&str> = rest.split_whitespace().collect();
+    if tokens.first().map(|t| t.eq_ignore_ascii_case("ON")) != Some(true) {
+        return None; // disabled ("OFF") or malformed
+    }
+    let kind = kind_from_token(tokens.get(1)?)?;
+    let freq_hz = value_after(&tokens, "Fc")?;
+    let gain_db = value_after(&tokens, "Gain").unwrap_or(0.0);
+    // Shelf lines in AutoEq's fixed-band output often omit Q.
+    let q = value_after(&tokens, "Q").unwrap_or(match kind {
+        EqBandKind::LowShelf | EqBandKind::HighShelf => 0.71,
+        _ => 1.0,
+    });
+    let mut band = EqBand {
+        kind,
+        freq_hz,
+        gain_db,
+        q,
+    };
+    band.clamp_ranges();
+    Some(band)
+}
+
+/// Parse an AutoEq result block into a (disabled, preview-ready) EqConfig.
+/// Keeps the first MAX_EQ_BANDS filters in file order — AutoEq emits them
+/// in descending importance already.
+pub fn parse_autoeq(text: &str) -> Result<EqConfig, SinkError> {
+    let mut preamp_db = 0.0f32;
+    let mut bands: Vec<EqBand> = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.to_ascii_lowercase().starts_with("preamp") {
+            if let Some(v) = line
+                .split(':')
+                .nth(1)
+                .and_then(|rest| rest.split_whitespace().next())
+                .and_then(|v| v.parse::<f32>().ok())
+            {
+                preamp_db = v;
+            }
+        } else if line.to_ascii_lowercase().starts_with("filter") && bands.len() < MAX_EQ_BANDS {
+            if let Some(band) = parse_filter_line(line) {
+                bands.push(band);
+            }
+        }
+    }
+    if bands.is_empty() {
+        return Err(SinkError::Parse(
+            "no usable filters found (expected AutoEq lines like \
+             'Filter 1: ON PK Fc 105 Hz Gain -2.4 dB Q 0.70')"
+                .into(),
+        ));
+    }
+    let mut config = EqConfig {
+        enabled: false,
+        preamp_db,
+        bands,
+    };
+    config.clamp_ranges();
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_preamp_and_peaking_filter() {
+        let config = parse_autoeq(
+            "Preamp: -6.0 dB\nFilter 1: ON PK Fc 105 Hz Gain -2.4 dB Q 0.70\n",
+        )
+        .expect("parses");
+        assert_eq!(config.preamp_db, -6.0);
+        assert_eq!(config.bands.len(), 1);
+        let b = &config.bands[0];
+        assert_eq!(b.kind, EqBandKind::Peaking);
+        assert_eq!(b.freq_hz, 105.0);
+        assert_eq!(b.gain_db, -2.4);
+        assert_eq!(b.q, 0.7);
+        assert!(!config.enabled, "imports preview disabled");
+    }
+
+    #[test]
+    fn skips_disabled_filters() {
+        let config = parse_autoeq(
+            "Filter 1: OFF PK Fc 100 Hz Gain 3.0 dB Q 1.0\n\
+             Filter 2: ON PK Fc 200 Hz Gain 1.0 dB Q 1.0\n",
+        )
+        .expect("parses");
+        assert_eq!(config.bands.len(), 1);
+        assert_eq!(config.bands[0].freq_hz, 200.0);
+    }
+
+    #[test]
+    fn maps_shelf_and_pass_abbreviations() {
+        let config = parse_autoeq(
+            "Filter 1: ON LSC Fc 105 Hz Gain 2.0 dB\n\
+             Filter 2: ON HSC Fc 10000 Hz Gain -1.0 dB Q 0.71\n\
+             Filter 3: ON HP Fc 80 Hz\n",
+        )
+        .expect("parses");
+        assert_eq!(config.bands[0].kind, EqBandKind::LowShelf);
+        assert_eq!(config.bands[0].q, 0.71, "shelf without Q gets the slope default");
+        assert_eq!(config.bands[1].kind, EqBandKind::HighShelf);
+        assert_eq!(config.bands[2].kind, EqBandKind::HighPass);
+    }
+
+    #[test]
+    fn skips_unknown_filter_kinds() {
+        let config = parse_autoeq(
+            "Filter 1: ON XYZ Fc 100 Hz Gain 3.0 dB Q 1.0\n\
+             Filter 2: ON PK Fc 200 Hz Gain 1.0 dB Q 1.0\n",
+        )
+        .expect("parses");
+        assert_eq!(config.bands.len(), 1);
+    }
+
+    #[test]
+    fn caps_at_max_bands_keeping_file_order() {
+        let mut text = String::from("Preamp: -1.0 dB\n");
+        for i in 1..=14 {
+            text.push_str(&format!(
+                "Filter {i}: ON PK Fc {} Hz Gain 1.0 dB Q 1.0\n",
+                i * 100
+            ));
+        }
+        let config = parse_autoeq(&text).expect("parses");
+        assert_eq!(config.bands.len(), MAX_EQ_BANDS);
+        assert_eq!(config.bands[0].freq_hz, 100.0, "first filters win");
+        assert_eq!(config.bands[9].freq_hz, 1000.0);
+    }
+
+    #[test]
+    fn errors_on_text_with_no_usable_filters() {
+        assert!(parse_autoeq("hello world").is_err());
+        assert!(parse_autoeq("Preamp: -3.0 dB\n").is_err());
+    }
+
+    #[test]
+    fn out_of_range_values_are_clamped() {
+        let config = parse_autoeq(
+            "Preamp: -80.0 dB\nFilter 1: ON PK Fc 99999 Hz Gain 80 dB Q 900\n",
+        )
+        .expect("parses");
+        assert_eq!(config.preamp_db, -24.0);
+        assert_eq!(config.bands[0].freq_hz, 20000.0);
+        assert_eq!(config.bands[0].gain_db, 24.0);
+        assert_eq!(config.bands[0].q, 10.0);
+    }
+}

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,5 +1,7 @@
 pub mod backend;
+pub mod eq_import;
 pub mod icons;
 pub mod pactl;
+pub mod presets;
 pub mod pw_native;
 pub mod types;

--- a/src-tauri/src/audio/pactl.rs
+++ b/src-tauri/src/audio/pactl.rs
@@ -331,6 +331,16 @@ impl AudioBackend for PactlBackend {
         ))
     }
 
+    fn set_channel_eq(
+        &self,
+        _sink_name: &str,
+        _config: &crate::audio::types::EqConfig,
+    ) -> Result<(), SinkError> {
+        Err(SinkError::Config(
+            "parametric EQ requires the native PipeWire backend".into(),
+        ))
+    }
+
     fn create_bus(&self, _name: &str, _label: &str) -> Result<(), SinkError> {
         Err(SinkError::Config(
             "mix buses require the native PipeWire backend".into(),

--- a/src-tauri/src/audio/presets.rs
+++ b/src-tauri/src/audio/presets.rs
@@ -1,0 +1,135 @@
+//! Community EQ presets: a versioned JSON schema, with the "community
+//! approved" set living in the repo's `presets/eq/` directory and embedded
+//! into the binary at build time (see build.rs).
+
+use serde::{Deserialize, Serialize};
+
+use crate::audio::types::{EqBand, EqConfig};
+
+/// The shareable preset file format (schema 1). Deliberately has no
+/// `enabled` flag: applying a preset sets bands + preamp and enables.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EqPreset {
+    pub schema: u32,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub preamp_db: f32,
+    pub bands: Vec<EqBand>,
+}
+
+pub const PRESET_SCHEMA: u32 = 1;
+
+impl EqPreset {
+    /// The channel config this preset applies (enabled, clamped).
+    pub fn to_config(&self) -> EqConfig {
+        let mut config = EqConfig {
+            enabled: true,
+            preamp_db: self.preamp_db,
+            bands: self.bands.clone(),
+        };
+        config.clamp_ranges();
+        config
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/eq_presets_generated.rs"));
+
+/// Parse one bundled source, or explain why it's unusable.
+fn parse_bundled(stem: &str, raw: &str) -> Result<EqPreset, String> {
+    let preset: EqPreset =
+        serde_json::from_str(raw).map_err(|e| format!("preset {stem}: {e}"))?;
+    if preset.schema != PRESET_SCHEMA {
+        return Err(format!(
+            "preset {stem}: unsupported schema {}",
+            preset.schema
+        ));
+    }
+    if preset.bands.is_empty() {
+        return Err(format!("preset {stem}: no bands"));
+    }
+    Ok(preset)
+}
+
+/// All bundled presets, sorted by name. Malformed entries are logged and
+/// skipped — defense in depth even though these ship inside the binary
+/// (a bad community PR must degrade one preset, not the whole menu).
+pub fn bundled_presets() -> Vec<EqPreset> {
+    let mut presets: Vec<EqPreset> = BUNDLED_EQ_PRESET_SOURCES
+        .iter()
+        .filter_map(|(stem, raw)| match parse_bundled(stem, raw) {
+            Ok(preset) => Some(preset),
+            Err(e) => {
+                eprintln!("sink: skipping bundled eq {e}");
+                None
+            }
+        })
+        .collect();
+    presets.sort_by(|a, b| a.name.cmp(&b.name));
+    presets
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio::types::EqBandKind;
+
+    #[test]
+    fn bundled_presets_parse_and_sort_by_name() {
+        let presets = bundled_presets();
+        assert!(
+            presets.iter().any(|p| p.name == "Flat"),
+            "the Flat reference preset must ship"
+        );
+        let names: Vec<&str> = presets.iter().map(|p| p.name.as_str()).collect();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+        for p in &presets {
+            assert_eq!(p.schema, PRESET_SCHEMA);
+            assert!(!p.bands.is_empty());
+        }
+    }
+
+    #[test]
+    fn flat_preset_is_numerically_flat() {
+        let presets = bundled_presets();
+        let flat = presets.iter().find(|p| p.name == "Flat").expect("shipped");
+        assert_eq!(flat.preamp_db, 0.0);
+        assert!(flat.bands.iter().all(|b| b.gain_db == 0.0));
+    }
+
+    #[test]
+    fn malformed_bundled_entry_is_skipped_not_panicked() {
+        assert!(parse_bundled("bad", "{not json").is_err());
+        assert!(parse_bundled("bad", r#"{"schema":2,"name":"x","bands":[]}"#).is_err());
+        assert!(
+            parse_bundled("bad", r#"{"schema":1,"name":"x","bands":[]}"#).is_err(),
+            "zero bands is rejected"
+        );
+    }
+
+    #[test]
+    fn to_config_enables_and_clamps() {
+        let preset = EqPreset {
+            schema: 1,
+            name: "Hot".into(),
+            author: None,
+            description: None,
+            preamp_db: -99.0,
+            bands: vec![EqBand {
+                kind: EqBandKind::Peaking,
+                freq_hz: 90000.0,
+                gain_db: 4.0,
+                q: 1.0,
+            }],
+        };
+        let config = preset.to_config();
+        assert!(config.enabled);
+        assert_eq!(config.preamp_db, -24.0);
+        assert_eq!(config.bands[0].freq_hz, 20000.0);
+    }
+}

--- a/src-tauri/src/audio/pw_native/eq.rs
+++ b/src-tauri/src/audio/pw_native/eq.rs
@@ -1,0 +1,530 @@
+//! Per-channel parametric EQ core: RBJ Audio EQ Cookbook biquads in a
+//! cascade of up to MAX_EQ_BANDS, preceded by a preamp trim.
+//!
+//! Pure Rust, no external DSP crates (same stance as the mic chain in
+//! `dsp.rs`). The frequency-response math is hand-mirrored in
+//! `src/lib/eqMath.ts` for the UI curve — keep both in sync.
+//!
+//! Threading model: the command thread writes band parameters into
+//! `EqParams` (plain atomics) and bumps a generation counter with Release
+//! ordering; the RT capture callback owns an `EqEngine` and redesigns its
+//! coefficients only when an Acquire load of the generation sees a change.
+//! Coefficient design (a few sin/cos) off the hot path per *change*, not
+//! per buffer, and never a lock on the RT thread.
+
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering};
+
+use crate::audio::types::{EqBand, EqBandKind, EqConfig, MAX_EQ_BANDS};
+
+/// Biquad transfer-function coefficients, normalized so a0 == 1.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BiquadCoeffs {
+    pub b0: f32,
+    pub b1: f32,
+    pub b2: f32,
+    pub a1: f32,
+    pub a2: f32,
+}
+
+impl BiquadCoeffs {
+    /// Pass-through (unity) filter.
+    pub fn identity() -> Self {
+        Self {
+            b0: 1.0,
+            b1: 0.0,
+            b2: 0.0,
+            a1: 0.0,
+            a2: 0.0,
+        }
+    }
+
+    /// RBJ Audio EQ Cookbook design. For shelves, `q` is the shelf slope S
+    /// (not a resonance Q) — the schema shares one field for both, see
+    /// `EqBand::q`. LowPass/HighPass ignore `gain_db`.
+    pub fn design(kind: EqBandKind, freq_hz: f32, gain_db: f32, q: f32, sample_rate: f32) -> Self {
+        // Guard the math: freq must sit below Nyquist and q must be
+        // positive. Config-level clamps enforce this for real input; this
+        // is the last line of defense against a divide-by-zero.
+        let freq = freq_hz.clamp(1.0, sample_rate * 0.49);
+        let q = q.max(0.01);
+        let w0 = 2.0 * std::f32::consts::PI * freq / sample_rate;
+        let (sin_w0, cos_w0) = w0.sin_cos();
+        let a = 10.0f32.powf(gain_db / 40.0);
+
+        let (b0, b1, b2, a0, a1, a2) = match kind {
+            EqBandKind::Peaking => {
+                let alpha = sin_w0 / (2.0 * q);
+                (
+                    1.0 + alpha * a,
+                    -2.0 * cos_w0,
+                    1.0 - alpha * a,
+                    1.0 + alpha / a,
+                    -2.0 * cos_w0,
+                    1.0 - alpha / a,
+                )
+            }
+            EqBandKind::LowShelf | EqBandKind::HighShelf => {
+                // Shelf slope form: alpha from S, the cookbook's
+                // "shelf slope" parameterization.
+                let s = q;
+                let alpha =
+                    sin_w0 / 2.0 * ((a + 1.0 / a) * (1.0 / s - 1.0) + 2.0).max(0.0).sqrt();
+                let two_sqrt_a_alpha = 2.0 * a.sqrt() * alpha;
+                let (ap1, am1) = (a + 1.0, a - 1.0);
+                if kind == EqBandKind::LowShelf {
+                    (
+                        a * (ap1 - am1 * cos_w0 + two_sqrt_a_alpha),
+                        2.0 * a * (am1 - ap1 * cos_w0),
+                        a * (ap1 - am1 * cos_w0 - two_sqrt_a_alpha),
+                        ap1 + am1 * cos_w0 + two_sqrt_a_alpha,
+                        -2.0 * (am1 + ap1 * cos_w0),
+                        ap1 + am1 * cos_w0 - two_sqrt_a_alpha,
+                    )
+                } else {
+                    (
+                        a * (ap1 + am1 * cos_w0 + two_sqrt_a_alpha),
+                        -2.0 * a * (am1 + ap1 * cos_w0),
+                        a * (ap1 + am1 * cos_w0 - two_sqrt_a_alpha),
+                        ap1 - am1 * cos_w0 + two_sqrt_a_alpha,
+                        2.0 * (am1 - ap1 * cos_w0),
+                        ap1 - am1 * cos_w0 - two_sqrt_a_alpha,
+                    )
+                }
+            }
+            EqBandKind::LowPass => {
+                let alpha = sin_w0 / (2.0 * q);
+                let b1 = 1.0 - cos_w0;
+                (
+                    b1 / 2.0,
+                    b1,
+                    b1 / 2.0,
+                    1.0 + alpha,
+                    -2.0 * cos_w0,
+                    1.0 - alpha,
+                )
+            }
+            EqBandKind::HighPass => {
+                let alpha = sin_w0 / (2.0 * q);
+                let b1 = 1.0 + cos_w0;
+                (
+                    b1 / 2.0,
+                    -b1,
+                    b1 / 2.0,
+                    1.0 + alpha,
+                    -2.0 * cos_w0,
+                    1.0 - alpha,
+                )
+            }
+        };
+
+        Self {
+            b0: b0 / a0,
+            b1: b1 / a0,
+            b2: b2 / a0,
+            a1: a1 / a0,
+            a2: a2 / a0,
+        }
+    }
+}
+
+/// Per-channel filter memory (transposed direct form II: two states, good
+/// numerical behavior at f32).
+#[derive(Debug, Default, Clone, Copy)]
+struct BiquadState {
+    z1: f32,
+    z2: f32,
+}
+
+impl BiquadState {
+    #[inline]
+    fn process(&mut self, x: f32, c: &BiquadCoeffs) -> f32 {
+        let y = c.b0 * x + self.z1;
+        self.z1 = c.b1 * x - c.a1 * y + self.z2;
+        self.z2 = c.b2 * x - c.a2 * y;
+        y
+    }
+}
+
+const KIND_PEAKING: u8 = 0;
+const KIND_LOW_SHELF: u8 = 1;
+const KIND_HIGH_SHELF: u8 = 2;
+const KIND_LOW_PASS: u8 = 3;
+const KIND_HIGH_PASS: u8 = 4;
+
+fn kind_to_u8(kind: EqBandKind) -> u8 {
+    match kind {
+        EqBandKind::Peaking => KIND_PEAKING,
+        EqBandKind::LowShelf => KIND_LOW_SHELF,
+        EqBandKind::HighShelf => KIND_HIGH_SHELF,
+        EqBandKind::LowPass => KIND_LOW_PASS,
+        EqBandKind::HighPass => KIND_HIGH_PASS,
+    }
+}
+
+fn kind_from_u8(v: u8) -> EqBandKind {
+    match v {
+        KIND_LOW_SHELF => EqBandKind::LowShelf,
+        KIND_HIGH_SHELF => EqBandKind::HighShelf,
+        KIND_LOW_PASS => EqBandKind::LowPass,
+        KIND_HIGH_PASS => EqBandKind::HighPass,
+        _ => EqBandKind::Peaking,
+    }
+}
+
+struct AtomicBand {
+    kind: AtomicU8,
+    freq_bits: AtomicU32,
+    gain_bits: AtomicU32,
+    q_bits: AtomicU32,
+}
+
+impl AtomicBand {
+    fn flat() -> Self {
+        Self {
+            kind: AtomicU8::new(KIND_PEAKING),
+            freq_bits: AtomicU32::new(1000.0f32.to_bits()),
+            gain_bits: AtomicU32::new(0.0f32.to_bits()),
+            q_bits: AtomicU32::new(1.0f32.to_bits()),
+        }
+    }
+
+    fn store(&self, band: &EqBand) {
+        self.kind.store(kind_to_u8(band.kind), Ordering::Relaxed);
+        self.freq_bits
+            .store(band.freq_hz.to_bits(), Ordering::Relaxed);
+        self.gain_bits
+            .store(band.gain_db.to_bits(), Ordering::Relaxed);
+        self.q_bits.store(band.q.to_bits(), Ordering::Relaxed);
+    }
+
+    fn load(&self) -> EqBand {
+        EqBand {
+            kind: kind_from_u8(self.kind.load(Ordering::Relaxed)),
+            freq_hz: f32::from_bits(self.freq_bits.load(Ordering::Relaxed)),
+            gain_db: f32::from_bits(self.gain_bits.load(Ordering::Relaxed)),
+            q: f32::from_bits(self.q_bits.load(Ordering::Relaxed)),
+        }
+    }
+}
+
+/// Live-tunable EQ parameters shared with the RT capture callback.
+///
+/// Single writer (the loop thread handling commands), single reader (the RT
+/// callback). Field writes are Relaxed; the trailing Release bump of
+/// `generation` publishes them all to the reader's Acquire load — no locks,
+/// no retries, and torn *intermediate* states are impossible because the
+/// reader only redesigns after seeing a new generation.
+pub struct EqParams {
+    enabled: AtomicBool,
+    preamp_bits: AtomicU32,
+    band_count: AtomicUsize,
+    bands: [AtomicBand; MAX_EQ_BANDS],
+    generation: AtomicU64,
+}
+
+impl EqParams {
+    pub fn from_config(config: &EqConfig) -> Self {
+        let p = Self {
+            enabled: AtomicBool::new(false),
+            preamp_bits: AtomicU32::new(0.0f32.to_bits()),
+            band_count: AtomicUsize::new(0),
+            bands: std::array::from_fn(|_| AtomicBand::flat()),
+            generation: AtomicU64::new(0),
+        };
+        p.apply(config);
+        p
+    }
+
+    /// Publish a new config to the RT reader (command thread only).
+    pub fn apply(&self, config: &EqConfig) {
+        let count = config.bands.len().min(MAX_EQ_BANDS);
+        for (slot, band) in self.bands.iter().zip(config.bands.iter()) {
+            slot.store(band);
+        }
+        self.band_count.store(count, Ordering::Relaxed);
+        self.enabled.store(config.enabled, Ordering::Relaxed);
+        self.preamp_bits
+            .store(config.preamp_db.to_bits(), Ordering::Relaxed);
+        self.generation.fetch_add(1, Ordering::Release);
+    }
+
+    fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+}
+
+/// The RT-side processor: owns coefficient + filter state, refreshed from
+/// `EqParams` when the generation changes or the sample rate renegotiates.
+pub struct EqEngine {
+    sample_rate: f32,
+    /// u64::MAX = "must refresh" sentinel (set on rate change / creation).
+    seen_generation: u64,
+    enabled: bool,
+    preamp_linear: f32,
+    coeffs: [BiquadCoeffs; MAX_EQ_BANDS],
+    count: usize,
+    /// Per band, per stereo channel. A rate change resets filter memory —
+    /// accepted, same as the mic chain rebuilding DspChain on rate change.
+    state: [[BiquadState; 2]; MAX_EQ_BANDS],
+}
+
+impl EqEngine {
+    pub fn new(sample_rate: f32) -> Self {
+        Self {
+            sample_rate: sample_rate.max(1.0),
+            seen_generation: u64::MAX,
+            enabled: false,
+            preamp_linear: 1.0,
+            coeffs: [BiquadCoeffs::identity(); MAX_EQ_BANDS],
+            count: 0,
+            state: [[BiquadState::default(); 2]; MAX_EQ_BANDS],
+        }
+    }
+
+    /// Coefficients are frequency-relative, so a renegotiated rate forces a
+    /// redesign on the next process() even if the params are unchanged.
+    pub fn set_sample_rate(&mut self, sample_rate: f32) {
+        if sample_rate > 0.0 && sample_rate != self.sample_rate {
+            self.sample_rate = sample_rate;
+            self.seen_generation = u64::MAX;
+            self.state = [[BiquadState::default(); 2]; MAX_EQ_BANDS];
+        }
+    }
+
+    fn refresh(&mut self, params: &EqParams) {
+        let generation = params.generation();
+        if generation == self.seen_generation {
+            return;
+        }
+        self.seen_generation = generation;
+        self.enabled = params.enabled.load(Ordering::Relaxed);
+        let preamp_db = f32::from_bits(params.preamp_bits.load(Ordering::Relaxed));
+        self.preamp_linear = 10.0f32.powf(preamp_db / 20.0);
+        self.count = params.band_count.load(Ordering::Relaxed).min(MAX_EQ_BANDS);
+        for i in 0..self.count {
+            let band = params.bands[i].load();
+            self.coeffs[i] =
+                BiquadCoeffs::design(band.kind, band.freq_hz, band.gain_db, band.q, self.sample_rate);
+        }
+    }
+
+    /// Process an interleaved stereo buffer in place. Pass-through when the
+    /// config is disabled (the chain is normally torn down on disable; this
+    /// covers the window between a disable apply() and the relink).
+    pub fn process_interleaved(&mut self, buf: &mut [f32], params: &EqParams) {
+        self.refresh(params);
+        if !self.enabled {
+            return;
+        }
+        for frame in buf.chunks_exact_mut(2) {
+            for (ch, sample) in frame.iter_mut().enumerate() {
+                let mut x = *sample * self.preamp_linear;
+                for i in 0..self.count {
+                    x = self.state[i][ch].process(x, &self.coeffs[i]);
+                }
+                *sample = x;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Analytic magnitude response |H(e^jw)| in dB — exact, no time-domain
+    /// sampling artifacts. This is the same formula the UI curve uses
+    /// (src/lib/eqMath.ts), so these tests also pin the shared math.
+    fn measured_gain_db(c: &BiquadCoeffs, freq: f32, sample_rate: f32) -> f32 {
+        let w = 2.0 * std::f64::consts::PI * f64::from(freq) / f64::from(sample_rate);
+        let (b0, b1, b2) = (f64::from(c.b0), f64::from(c.b1), f64::from(c.b2));
+        let (a1, a2) = (f64::from(c.a1), f64::from(c.a2));
+        let num_re = b0 + b1 * w.cos() + b2 * (2.0 * w).cos();
+        let num_im = -(b1 * w.sin() + b2 * (2.0 * w).sin());
+        let den_re = 1.0 + a1 * w.cos() + a2 * (2.0 * w).cos();
+        let den_im = -(a1 * w.sin() + a2 * (2.0 * w).sin());
+        let mag = ((num_re * num_re + num_im * num_im) / (den_re * den_re + den_im * den_im))
+            .sqrt();
+        (20.0 * mag.log10()) as f32
+    }
+
+    fn config(bands: Vec<EqBand>, preamp_db: f32) -> EqConfig {
+        EqConfig {
+            enabled: true,
+            preamp_db,
+            bands,
+        }
+    }
+
+    fn band(kind: EqBandKind, freq_hz: f32, gain_db: f32, q: f32) -> EqBand {
+        EqBand {
+            kind,
+            freq_hz,
+            gain_db,
+            q,
+        }
+    }
+
+    const SR: f32 = 48000.0;
+
+    #[test]
+    fn identity_passes_signal_unchanged() {
+        let c = BiquadCoeffs::identity();
+        let mut state = BiquadState::default();
+        for x in [0.0f32, 1.0, -0.5, 0.25] {
+            assert_eq!(state.process(x, &c), x);
+        }
+    }
+
+    #[test]
+    fn peaking_matches_gain_at_center_freq() {
+        let c = BiquadCoeffs::design(EqBandKind::Peaking, 1000.0, 6.0, 1.0, SR);
+        let g = measured_gain_db(&c, 1000.0, SR);
+        assert!((g - 6.0).abs() < 0.3, "expected ~+6 dB at center, got {g}");
+    }
+
+    #[test]
+    fn peaking_is_flat_far_from_center() {
+        let c = BiquadCoeffs::design(EqBandKind::Peaking, 1000.0, 12.0, 2.0, SR);
+        let g = measured_gain_db(&c, 60.0, SR);
+        assert!(g.abs() < 0.5, "expected ~0 dB two+ octaves away, got {g}");
+    }
+
+    #[test]
+    fn low_shelf_boosts_below_corner_flat_above() {
+        let c = BiquadCoeffs::design(EqBandKind::LowShelf, 200.0, 6.0, 0.71, SR);
+        let low = measured_gain_db(&c, 40.0, SR);
+        let high = measured_gain_db(&c, 4000.0, SR);
+        assert!((low - 6.0).abs() < 0.5, "low end should be ~+6 dB, got {low}");
+        assert!(high.abs() < 0.5, "high end should be flat, got {high}");
+    }
+
+    #[test]
+    fn high_shelf_boosts_above_corner_flat_below() {
+        let c = BiquadCoeffs::design(EqBandKind::HighShelf, 5000.0, -6.0, 0.71, SR);
+        let low = measured_gain_db(&c, 200.0, SR);
+        let high = measured_gain_db(&c, 15000.0, SR);
+        assert!(low.abs() < 0.5, "low end should be flat, got {low}");
+        assert!((high + 6.0).abs() < 0.6, "high end should be ~-6 dB, got {high}");
+    }
+
+    #[test]
+    fn low_pass_attenuates_above_cutoff() {
+        let c = BiquadCoeffs::design(EqBandKind::LowPass, 1000.0, 0.0, 0.71, SR);
+        let pass = measured_gain_db(&c, 100.0, SR);
+        let stop = measured_gain_db(&c, 8000.0, SR);
+        assert!(pass.abs() < 0.5, "passband should be flat, got {pass}");
+        assert!(stop < -30.0, "stopband should be strongly attenuated, got {stop}");
+    }
+
+    #[test]
+    fn high_pass_attenuates_below_cutoff() {
+        let c = BiquadCoeffs::design(EqBandKind::HighPass, 1000.0, 0.0, 0.71, SR);
+        let stop = measured_gain_db(&c, 100.0, SR);
+        let pass = measured_gain_db(&c, 8000.0, SR);
+        assert!(stop < -30.0, "stopband should be strongly attenuated, got {stop}");
+        assert!(pass.abs() < 0.5, "passband should be flat, got {pass}");
+    }
+
+    #[test]
+    fn params_apply_then_engine_refresh_picks_up_bands() {
+        let params = EqParams::from_config(&config(
+            vec![band(EqBandKind::Peaking, 2000.0, 4.0, 1.5)],
+            -3.0,
+        ));
+        let mut engine = EqEngine::new(SR);
+        engine.refresh(&params);
+        assert!(engine.enabled);
+        assert_eq!(engine.count, 1);
+        assert!((engine.preamp_linear - 10.0f32.powf(-3.0 / 20.0)).abs() < 1e-6);
+        let expected = BiquadCoeffs::design(EqBandKind::Peaking, 2000.0, 4.0, 1.5, SR);
+        assert_eq!(engine.coeffs[0], expected);
+
+        // A second apply with different bands is picked up on next refresh.
+        params.apply(&config(vec![band(EqBandKind::HighPass, 80.0, 0.0, 0.71)], 0.0));
+        engine.refresh(&params);
+        assert_eq!(engine.count, 1);
+        let expected = BiquadCoeffs::design(EqBandKind::HighPass, 80.0, 0.0, 0.71, SR);
+        assert_eq!(engine.coeffs[0], expected);
+    }
+
+    #[test]
+    fn set_sample_rate_forces_recompute_at_new_rate() {
+        let params = EqParams::from_config(&config(
+            vec![band(EqBandKind::Peaking, 2000.0, 4.0, 1.5)],
+            0.0,
+        ));
+        let mut engine = EqEngine::new(48000.0);
+        engine.refresh(&params);
+        let at_48k = engine.coeffs[0];
+        engine.set_sample_rate(96000.0);
+        engine.refresh(&params);
+        assert_ne!(engine.coeffs[0], at_48k);
+        assert_eq!(
+            engine.coeffs[0],
+            BiquadCoeffs::design(EqBandKind::Peaking, 2000.0, 4.0, 1.5, 96000.0)
+        );
+    }
+
+    #[test]
+    fn preamp_is_linear_multiply_before_cascade() {
+        let params = EqParams::from_config(&config(vec![], 6.0));
+        let mut engine = EqEngine::new(SR);
+        let mut buf = vec![0.5f32, -0.5, 0.25, -0.25];
+        engine.process_interleaved(&mut buf, &params);
+        let expected = 10.0f32.powf(6.0 / 20.0);
+        assert!((buf[0] - 0.5 * expected).abs() < 1e-6);
+        assert!((buf[1] + 0.5 * expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn disabled_config_passes_through_untouched() {
+        let mut cfg = config(vec![band(EqBandKind::Peaking, 1000.0, 12.0, 1.0)], 12.0);
+        cfg.enabled = false;
+        let params = EqParams::from_config(&cfg);
+        let mut engine = EqEngine::new(SR);
+        let original = vec![0.5f32, -0.5, 0.25, -0.25];
+        let mut buf = original.clone();
+        engine.process_interleaved(&mut buf, &params);
+        assert_eq!(buf, original);
+    }
+
+    #[test]
+    fn cascade_of_ten_flat_bands_is_still_flat() {
+        let bands: Vec<EqBand> = (0..MAX_EQ_BANDS)
+            .map(|i| band(EqBandKind::Peaking, 100.0 * (i as f32 + 1.0) * 2.0, 0.0, 1.0))
+            .collect();
+        let params = EqParams::from_config(&config(bands, 0.0));
+        let mut engine = EqEngine::new(SR);
+        // A 1 kHz sine through ten 0 dB bands should come out at unity.
+        let mut buf: Vec<f32> = (0..2000)
+            .flat_map(|n| {
+                let s = (2.0 * std::f32::consts::PI * 1000.0 * n as f32 / SR).sin() * 0.5;
+                [s, s]
+            })
+            .collect();
+        let peak_in = 0.5f32;
+        engine.process_interleaved(&mut buf, &params);
+        let peak_out = buf[2000..].iter().fold(0.0f32, |m, s| m.max(s.abs()));
+        assert!(
+            (peak_out - peak_in).abs() < 0.01,
+            "flat cascade drifted: in {peak_in}, out {peak_out}"
+        );
+    }
+
+    #[test]
+    fn stereo_channels_are_processed_independently() {
+        // A DC-blocking high-pass fed L=DC, R=silence must not bleed.
+        let params = EqParams::from_config(&config(
+            vec![band(EqBandKind::HighPass, 500.0, 0.0, 0.71)],
+            0.0,
+        ));
+        let mut engine = EqEngine::new(SR);
+        let mut buf: Vec<f32> = (0..2000).flat_map(|_| [1.0f32, 0.0]).collect();
+        engine.process_interleaved(&mut buf, &params);
+        let right_energy: f32 = buf.iter().skip(1).step_by(2).map(|s| s.abs()).sum();
+        assert_eq!(right_energy, 0.0, "silent right channel picked up energy");
+        let left_tail = buf[3000..].iter().step_by(2).fold(0.0f32, |m, s| m.max(s.abs()));
+        assert!(left_tail < 0.01, "DC should be blocked on the left, got {left_tail}");
+    }
+}

--- a/src-tauri/src/audio/pw_native/eq_chain.rs
+++ b/src-tauri/src/audio/pw_native/eq_chain.rs
@@ -1,0 +1,244 @@
+//! Per-channel EQ insert: captures a channel sink's monitor (post-fader,
+//! the same tap point as the meters), runs the biquad cascade, and plays
+//! the processed signal back out through a stream whose ports the loop
+//! links to the channel's real targets (device, buses) instead of the raw
+//! monitor.
+//!
+//! Topology:  channel sink ──monitor──▶ capture ──EQ──▶ ring ──▶ playback ──▶ device/buses
+//!
+//! Same construction as the mic chain (`mic.rs`), minus metering: EQ taps
+//! add no LevelStore slots, so the MAX_METERS budget is untouched.
+
+use std::sync::Arc;
+
+use pipewire as pw;
+use pw::spa;
+use spa::pod::Pod;
+
+use crate::audio::pw_native::eq::{EqEngine, EqParams};
+use crate::audio::pw_native::ring::Ring;
+use crate::audio::types::EqConfig;
+use crate::error::SinkError;
+
+/// node.name prefixes of the EQ helper streams (under INTERNAL_PREFIX, so
+/// they never show up in app/stream listings).
+pub const EQ_CAPTURE_PREFIX: &str = "sink-internal-eq-capture-";
+pub const EQ_PLAYBACK_PREFIX: &str = "sink-internal-eq-playback-";
+
+struct EqCaptureCtx {
+    engine: EqEngine,
+    params: Arc<EqParams>,
+    ring: Arc<Ring>,
+    scratch: Vec<f32>,
+}
+
+struct EqPlaybackCtx {
+    ring: Arc<Ring>,
+}
+
+pub struct EqChainHandle {
+    _capture: pw::stream::StreamRc,
+    _capture_listener: pw::stream::StreamListener<EqCaptureCtx>,
+    playback: pw::stream::StreamRc,
+    _playback_listener: pw::stream::StreamListener<EqPlaybackCtx>,
+    pub params: Arc<EqParams>,
+}
+
+impl EqChainHandle {
+    /// Node id of the playback stream — the loop links its output ports to
+    /// the channel's targets. Only valid once the server has created the
+    /// stream's node (callers filter u32::MAX, like `mic_playback_node`).
+    pub fn playback_node_id(&self) -> u32 {
+        self.playback.node_id()
+    }
+}
+
+/// Stereo F32 format pod for stream negotiation.
+fn stereo_f32_format() -> Result<Vec<u8>, SinkError> {
+    let mut info = spa::param::audio::AudioInfoRaw::new();
+    info.set_format(spa::param::audio::AudioFormat::F32LE);
+    info.set_channels(2);
+    let object = spa::pod::Object {
+        type_: spa::sys::SPA_TYPE_OBJECT_Format,
+        id: spa::sys::SPA_PARAM_EnumFormat,
+        properties: info.into(),
+    };
+    spa::pod::serialize::PodSerializer::serialize(
+        std::io::Cursor::new(Vec::new()),
+        &spa::pod::Value::Object(object),
+    )
+    .map(|(c, _)| c.into_inner())
+    .map_err(|e| SinkError::Config(format!("eq format pod: {e:?}")))
+}
+
+impl EqChainHandle {
+    /// Build both streams against a live channel sink node.
+    pub fn new(
+        core: &pw::core::CoreRc,
+        sink_name: &str,
+        sink_id: u32,
+        config: &EqConfig,
+    ) -> Result<Self, SinkError> {
+        let err = |stage: &str, e: pw::Error| SinkError::Config(format!("eq {stage}: {e}"));
+        let params = Arc::new(EqParams::from_config(config));
+        // Interleaved stereo: 8192 samples = the same ~85 ms of headroom at
+        // 48 kHz as the mic's 4096 mono; real added latency is one quantum.
+        let ring = Arc::new(Ring::new(8192));
+
+        // ---- capture: channel monitor -> EQ -> ring ----
+        // Passive like the meters: the channel's own app streams drive the
+        // sink; the EQ tap must not keep an idle channel running.
+        let capture_name = format!("{EQ_CAPTURE_PREFIX}{sink_name}");
+        let capture = pw::stream::StreamRc::new(
+            core.clone(),
+            &capture_name,
+            pw::properties::properties! {
+                "media.type" => "Audio",
+                "media.category" => "Capture",
+                "node.name" => capture_name.as_str(),
+                "stream.capture.sink" => "true",
+                "node.passive" => "true",
+                "node.dont-reconnect" => "true",
+            },
+        )
+        .map_err(|e| err("capture stream", e))?;
+
+        let capture_listener = capture
+            .add_local_listener_with_user_data(EqCaptureCtx {
+                engine: EqEngine::new(48000.0),
+                params: params.clone(),
+                ring: ring.clone(),
+                scratch: Vec::with_capacity(8192),
+            })
+            .param_changed(|_, ctx, id, param| {
+                // Coefficients are rate-relative: redesign on renegotiation.
+                // Filter state resets — same tradeoff the mic chain accepts.
+                if id != spa::param::ParamType::Format.as_raw() {
+                    return;
+                }
+                let Some(param) = param else { return };
+                let mut info = spa::param::audio::AudioInfoRaw::new();
+                if info.parse(param).is_ok() && info.rate() > 0 {
+                    ctx.engine.set_sample_rate(info.rate() as f32);
+                }
+            })
+            .process(|stream, ctx| {
+                let Some(mut buffer) = stream.dequeue_buffer() else {
+                    return;
+                };
+                let datas = buffer.datas_mut();
+                let Some(data) = datas.first_mut() else { return };
+                let valid = data.chunk().size() as usize;
+                let Some(bytes) = data.data() else { return };
+
+                let n = (valid.min(bytes.len())) / 4;
+                ctx.scratch.clear();
+                ctx.scratch.extend(
+                    bytes[..n * 4]
+                        .chunks_exact(4)
+                        .map(|b| f32::from_ne_bytes([b[0], b[1], b[2], b[3]])),
+                );
+
+                ctx.engine.process_interleaved(&mut ctx.scratch, &ctx.params);
+                ctx.ring.push(&ctx.scratch);
+            })
+            .register()
+            .map_err(|e| err("capture listener", e))?;
+
+        let format = stereo_f32_format()?;
+        let mut capture_params = [Pod::from_bytes(&format)
+            .ok_or_else(|| SinkError::Config("eq capture format pod invalid".into()))?];
+        capture
+            .connect(
+                spa::utils::Direction::Input,
+                Some(sink_id),
+                pw::stream::StreamFlags::AUTOCONNECT
+                    | pw::stream::StreamFlags::MAP_BUFFERS
+                    | pw::stream::StreamFlags::RT_PROCESS,
+                &mut capture_params,
+            )
+            .map_err(|e| err("capture connect", e))?;
+
+        // ---- playback: ring -> device/buses ----
+        // node.autoconnect=false keeps WirePlumber's hands off this stream
+        // (it routes playback streams to the default sink — the link police
+        // in thread.rs destroys anything that slips through anyway); the
+        // loop links it to the channel's resolved targets itself.
+        let playback_name = format!("{EQ_PLAYBACK_PREFIX}{sink_name}");
+        let playback = pw::stream::StreamRc::new(
+            core.clone(),
+            &playback_name,
+            pw::properties::properties! {
+                "media.type" => "Audio",
+                "media.category" => "Playback",
+                "node.name" => playback_name.as_str(),
+                "node.autoconnect" => "false",
+                "node.dont-reconnect" => "true",
+            },
+        )
+        .map_err(|e| err("playback stream", e))?;
+
+        let playback_listener = playback
+            .add_local_listener_with_user_data(EqPlaybackCtx { ring })
+            .process(|stream, ctx| {
+                let Some(mut buffer) = stream.dequeue_buffer() else {
+                    return;
+                };
+                // Fill only what the graph asked for this cycle (frames);
+                // interleaved stereo = 2 samples, 8 bytes per frame.
+                let requested = buffer.requested() as usize;
+                let datas = buffer.datas_mut();
+                let Some(data) = datas.first_mut() else { return };
+                let max_bytes = data.data().map(|d| d.len()).unwrap_or(0);
+                let max_frames = max_bytes / 8;
+                let frames = if requested > 0 {
+                    requested.min(max_frames)
+                } else {
+                    max_frames.min(1024)
+                };
+                if frames == 0 {
+                    return;
+                }
+                if let Some(bytes) = data.data() {
+                    let mut chunk_samples = [0.0f32; 1024];
+                    let total_samples = frames * 2;
+                    let mut written = 0;
+                    while written < total_samples {
+                        let take = (total_samples - written).min(chunk_samples.len());
+                        ctx.ring.pop(&mut chunk_samples[..take]);
+                        for (i, s) in chunk_samples[..take].iter().enumerate() {
+                            let off = (written + i) * 4;
+                            bytes[off..off + 4].copy_from_slice(&s.to_ne_bytes());
+                        }
+                        written += take;
+                    }
+                }
+                let chunk = data.chunk_mut();
+                *chunk.offset_mut() = 0;
+                *chunk.stride_mut() = 8;
+                *chunk.size_mut() = (frames * 8) as u32;
+            })
+            .register()
+            .map_err(|e| err("playback listener", e))?;
+
+        let mut playback_params = [Pod::from_bytes(&format)
+            .ok_or_else(|| SinkError::Config("eq playback format pod invalid".into()))?];
+        playback
+            .connect(
+                spa::utils::Direction::Output,
+                None,
+                // No AUTOCONNECT: the loop creates the links itself.
+                pw::stream::StreamFlags::MAP_BUFFERS | pw::stream::StreamFlags::RT_PROCESS,
+                &mut playback_params,
+            )
+            .map_err(|e| err("playback connect", e))?;
+
+        Ok(Self {
+            _capture: capture,
+            _capture_listener: capture_listener,
+            playback,
+            _playback_listener: playback_listener,
+            params,
+        })
+    }
+}

--- a/src-tauri/src/audio/pw_native/mod.rs
+++ b/src-tauri/src/audio/pw_native/mod.rs
@@ -6,6 +6,8 @@
 //! Extras over the pactl backend: real per-sink level metering (`levels`).
 
 mod dsp;
+mod eq;
+mod eq_chain;
 pub mod levels;
 pub mod meter;
 mod mic;
@@ -185,6 +187,16 @@ impl AudioBackend for PipeWireBackend {
     fn set_mic_config(&self, config: &crate::audio::types::MicConfig) -> Result<(), SinkError> {
         let config = config.clone();
         self.request(|reply| Cmd::SetMicConfig { config, reply })
+    }
+
+    fn set_channel_eq(
+        &self,
+        sink_name: &str,
+        config: &crate::audio::types::EqConfig,
+    ) -> Result<(), SinkError> {
+        let sink_name = sink_name.to_string();
+        let config = config.clone();
+        self.request(|reply| Cmd::SetChannelEq { sink_name, config, reply })
     }
 
     fn get_default_devices(&self) -> Result<(Option<String>, Option<String>), SinkError> {

--- a/src-tauri/src/audio/pw_native/thread.rs
+++ b/src-tauri/src/audio/pw_native/thread.rs
@@ -16,11 +16,12 @@ use pw::registry::{GlobalObject, RegistryRc};
 use pw::spa::utils::dict::DictRef;
 use pw::types::ObjectType;
 
+use crate::audio::pw_native::eq_chain::EqChainHandle;
 use crate::audio::pw_native::levels::LevelStore;
 use crate::audio::pw_native::meter::MeterHandle;
 use crate::audio::pw_native::mic::{MicStreams, MIC_NODE};
 use crate::audio::pw_native::pods;
-use crate::audio::types::{is_virtual_sink, AppStream, MicConfig, OutputDevice};
+use crate::audio::types::{is_virtual_sink, AppStream, EqConfig, MicConfig, OutputDevice};
 use crate::error::SinkError;
 use crate::persistence::buses::is_bus_name;
 
@@ -61,6 +62,8 @@ pub enum Cmd {
     SetMonitor { name: String, enabled: bool, reply: Reply<()> },
     /// Apply mic chain configuration (create/destroy/re-tune as needed).
     SetMicConfig { config: MicConfig, reply: Reply<()> },
+    /// Apply a channel's parametric EQ (create/destroy/re-tune the insert).
+    SetChannelEq { sink_name: String, config: EqConfig, reply: Reply<()> },
     /// Hardware capture devices (microphones).
     ListInputs { reply: Reply<Vec<OutputDevice>> },
     /// Current system defaults: (output sink name, input source name).
@@ -150,6 +153,18 @@ struct State {
     monitor_links: HashMap<String, LinkSet>,
     /// Links from the mic playback stream into the virtual mic.
     mic_links: LinkSet,
+    /// Per-channel EQ configs (source of truth for chain (re)creation —
+    /// kept even while disabled so re-enabling restores the bands).
+    eq_configs: HashMap<String, EqConfig>,
+    /// Live EQ inserts by channel sink name. Presence here *is* "EQ is
+    /// enabled and live"; the channel's outgoing links re-source from the
+    /// insert's playback node.
+    eq_streams: HashMap<String, EqChainHandle>,
+    /// EQ playback node id -> node ids it is allowed to feed. Rebuilt
+    /// wholesale by every `ensure_all_links` pass; the link police destroys
+    /// anything else (WirePlumber routes playback streams to the default
+    /// sink — same leak the mic police exists for).
+    eq_desired_targets: HashMap<u32, std::collections::HashSet<u32>>,
 }
 
 impl State {
@@ -161,6 +176,21 @@ impl State {
             .map(|m| m.playback_node_id())
             .filter(|id| *id != u32::MAX)
     }
+
+    /// Live node id of a channel's EQ playback stream, if the insert is up.
+    fn eq_playback_node(&self, sink_name: &str) -> Option<u32> {
+        self.eq_streams
+            .get(sink_name)
+            .map(|h| h.playback_node_id())
+            .filter(|id| *id != u32::MAX)
+    }
+}
+
+/// The node whose ports feed a channel's downstream links: the EQ insert's
+/// playback stream when one is live, otherwise the channel sink itself.
+/// Pure so the routing decision is unit-testable (like `resolve_target`).
+fn resolve_source(eq_playback: Option<u32>, channel_id: u32) -> u32 {
+    eq_playback.unwrap_or(channel_id)
 }
 
 impl State {
@@ -360,18 +390,11 @@ fn on_global(
                 direction: props.get("port.direction").unwrap_or_default().to_string(),
                 channel: props.get("audio.channel").map(str::to_string),
             };
-            let relevant_links = {
-                let mut s = state.borrow_mut();
-                s.ports.insert(global.id, entry);
-                s.nodes
-                    .get(&node_id)
-                    .is_some_and(|n| n.media_class == SINK_CLASS)
-            };
-            if relevant_links {
-                ensure_all_links(state);
-            }
-            // Mic wiring depends on ports of untracked stream nodes, so
-            // reconcile on every port event (no-op until both ends exist).
+            state.borrow_mut().ports.insert(global.id, entry);
+            // Channel and mic wiring both depend on ports of untracked
+            // stream nodes (EQ/mic playback streams), so reconcile on every
+            // port event — both are idempotent no-ops until both ends exist.
+            ensure_all_links(state);
             ensure_mic_links(state);
         }
         ObjectType::Link => {
@@ -386,12 +409,26 @@ fn on_global(
                     // session-manager fallback) links it somewhere other
                     // than the virtual mic, destroy that link — mic audio
                     // must never leak into the speakers.
-                    match (s.mic_playback_node(), s.node_by_name(MIC_NODE)) {
+                    let mic_stray = match (s.mic_playback_node(), s.node_by_name(MIC_NODE)) {
                         (Some(playback), mic) if out == playback => {
                             mic.map(|n| n.id) != Some(inp)
                         }
                         _ => false,
-                    }
+                    };
+                    // Same policing for EQ playback streams: only the links
+                    // the loop planned (device/buses/monitor) may exist. An
+                    // EQ node with no plan yet (chain just built, first
+                    // reconcile pending) allows nothing — our own links are
+                    // always created after the plan is recorded.
+                    let eq_stray = s
+                        .eq_streams
+                        .values()
+                        .any(|h| h.playback_node_id() == out)
+                        && !s
+                            .eq_desired_targets
+                            .get(&out)
+                            .is_some_and(|allowed| allowed.contains(&inp));
+                    mic_stray || eq_stray
                 };
                 if police {
                     let _ = registry.destroy_global(global.id);
@@ -570,6 +607,20 @@ fn on_node(
                     s.meters.insert(node_name.clone(), meter);
                 }
                 Err(e) => eprintln!("sink: meter for {node_name} failed: {e}"),
+            }
+        }
+        // An enabled EQ config with no live insert: build it against the
+        // fresh sink id. Covers both startup (config loaded before the sink
+        // exists) and the heal path (sink recreated after an external
+        // destroy) with the same hook — like the meter above.
+        if !s.eq_streams.contains_key(&node_name) {
+            if let Some(config) = s.eq_configs.get(&node_name).filter(|c| c.enabled).cloned() {
+                match EqChainHandle::new(core, &node_name, global.id, &config) {
+                    Ok(handle) => {
+                        s.eq_streams.insert(node_name.clone(), handle);
+                    }
+                    Err(e) => eprintln!("sink: eq chain for {node_name} failed: {e}"),
+                }
             }
         }
         drop(s);
@@ -822,12 +873,21 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
     // Forget resolved targets for channels that no longer exist.
     s.channel_targets.retain(|name, _| channel_names.contains(name));
 
+    // The link plan for every live EQ insert, rebuilt from scratch each
+    // pass — the link police destroys anything an EQ playback node feeds
+    // that isn't in here.
+    let mut eq_targets: HashMap<u32, std::collections::HashSet<u32>> = HashMap::new();
+
     for sink_name in &channel_names {
         let sink_name = sink_name.as_str();
         let channel_id = match node_ids.get(sink_name) {
             Some(id) => *id,
             None => continue,
         };
+        // With a live EQ insert, every outgoing link (device, buses,
+        // monitor) re-sources from its playback node — one coherent source,
+        // so all listeners hear the same (EQ'd, equally delayed) audio.
+        let source_id = resolve_source(s.eq_playback_node(sink_name), channel_id);
 
         // ---- output device links ----
         let explicit = s.channel_outputs.get(sink_name).cloned().flatten();
@@ -850,8 +910,11 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
                 s.channel_targets.remove(sink_name);
             }
         }
+        if let (Some(t), true) = (target_id, source_id != channel_id) {
+            eq_targets.entry(source_id).or_default().insert(t);
+        }
         let pairs = target_id
-            .map(|t| desired_pairs(&s, channel_id, t))
+            .map(|t| desired_pairs(&s, source_id, t))
             .unwrap_or_default();
         let current: Vec<(u32, u32)> = s
             .channel_links
@@ -864,7 +927,7 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
                 .first()
                 .and_then(|(_, input)| s.ports.get(input).map(|p| p.node_id))
             {
-                let created = create_links(&core, sink_name, channel_id, in_node, &pairs);
+                let created = create_links(&core, sink_name, source_id, in_node, &pairs);
                 if !created.is_empty() {
                     s.channel_links.insert(sink_name.to_string(), created);
                 }
@@ -877,8 +940,11 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
                 .bus_members
                 .get(bus_name)
                 .is_some_and(|members| members.contains(sink_name));
+            if included && source_id != channel_id {
+                eq_targets.entry(source_id).or_default().insert(*bus_id);
+            }
             let pairs = if included {
-                desired_pairs(&s, channel_id, *bus_id)
+                desired_pairs(&s, source_id, *bus_id)
             } else {
                 Vec::new()
             };
@@ -891,7 +957,7 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
             if current != pairs {
                 s.bus_links.remove(&key);
                 if !pairs.is_empty() {
-                    let created = create_links(&core, sink_name, channel_id, *bus_id, &pairs);
+                    let created = create_links(&core, sink_name, source_id, *bus_id, &pairs);
                     if !created.is_empty() {
                         s.bus_links.insert(key, created);
                     }
@@ -908,7 +974,17 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
         .copied();
     let monitored: Vec<String> = s.monitored.iter().cloned().collect();
     for name in monitored {
-        let node_id = node_ids.get(&name).copied();
+        // Monitoring an EQ'd channel listens to the insert's output — the
+        // same audio its device/buses hear.
+        let node_id = node_ids
+            .get(&name)
+            .copied()
+            .map(|id| resolve_source(s.eq_playback_node(&name), id));
+        if let (Some(node), Some(default)) = (node_id, default_id) {
+            if node_ids.get(&name).copied() != Some(node) {
+                eq_targets.entry(node).or_default().insert(default);
+            }
+        }
         let mut pairs = match (node_id, default_id) {
             (Some(node), Some(default)) => desired_pairs(&s, node, default),
             _ => Vec::new(),
@@ -939,6 +1015,9 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
             }
         }
     }
+
+    // Publish the EQ link plan for the police (see on_global's Link arm).
+    s.eq_desired_targets = eq_targets;
 }
 
 /// The three virtual node shapes we own (kind 0=channel sink, 1=mix bus,
@@ -1012,6 +1091,10 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
             let mut s = state.borrow_mut();
             s.desired.remove(&name);
             s.meters.remove(&name);
+            // Drop the EQ insert before the sink proxy goes away so the
+            // capture stream's target doesn't vanish under it mid-teardown.
+            s.eq_streams.remove(&name);
+            s.eq_configs.remove(&name);
             s.channel_links.remove(&name);
             s.bus_links.retain(|(_, ch), _| ch != &name);
             s.channel_outputs.remove(&name);
@@ -1189,6 +1272,53 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
                     s.monitor_links.remove(&name);
                 }
             }
+            ensure_all_links(state);
+            let _ = reply.send(Ok(()));
+        }
+        Cmd::SetChannelEq { sink_name, config, reply } => {
+            if !is_virtual_sink(&sink_name) {
+                let _ = reply.send(Err(SinkError::UnknownSink(sink_name)));
+                return;
+            }
+            let (needs_create, needs_destroy) = {
+                let mut s = state.borrow_mut();
+                s.eq_configs.insert(sink_name.clone(), config.clone());
+                // Live re-tune: band edits reach the RT thread through the
+                // params atomics, no relink and no audible gap.
+                if let Some(handle) = s.eq_streams.get(&sink_name) {
+                    handle.params.apply(&config);
+                }
+                let live = s.eq_streams.contains_key(&sink_name);
+                (config.enabled && !live, !config.enabled && live)
+            };
+            if needs_destroy {
+                state.borrow_mut().eq_streams.remove(&sink_name);
+            } else if needs_create {
+                let sink_id = state
+                    .borrow()
+                    .node_by_name(&sink_name)
+                    .map(|n| n.id);
+                if let Some(sink_id) = sink_id {
+                    let Some(core) = CORE.with(|c| c.borrow().clone()) else {
+                        let _ = reply.send(Err(SinkError::Config(
+                            "eq chain requires a live core".into(),
+                        )));
+                        return;
+                    };
+                    match EqChainHandle::new(&core, &sink_name, sink_id, &config) {
+                        Ok(handle) => {
+                            state.borrow_mut().eq_streams.insert(sink_name.clone(), handle);
+                        }
+                        Err(e) => {
+                            let _ = reply.send(Err(e));
+                            return;
+                        }
+                    }
+                }
+                // Sink not live yet (e.g. mid-profile-load): the on_node
+                // hook builds the chain from eq_configs when it appears.
+            }
+            // Re-source the channel's links from/to the insert.
             ensure_all_links(state);
             let _ = reply.send(Ok(()));
         }
@@ -1471,6 +1601,16 @@ mod tests {
             direction: dir.to_string(),
             channel: channel.map(str::to_string),
         }
+    }
+
+    #[test]
+    fn resolve_source_prefers_live_eq_playback() {
+        assert_eq!(resolve_source(Some(77), 10), 77);
+    }
+
+    #[test]
+    fn resolve_source_falls_back_to_channel() {
+        assert_eq!(resolve_source(None, 10), 10);
     }
 
     #[test]

--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -392,3 +392,169 @@ mod mic_clamp_tests {
         assert_eq!(c, before);
     }
 }
+
+/// Hard cap on parametric EQ bands per channel. Ten matches the Sonar EQ
+/// users already know, keeps preset validation simple, and bounds the RT
+/// cost per channel.
+pub const MAX_EQ_BANDS: usize = 10;
+
+/// Parametric EQ band shapes (RBJ Audio EQ Cookbook designs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EqBandKind {
+    Peaking,
+    LowShelf,
+    HighShelf,
+    LowPass,
+    HighPass,
+}
+
+fn default_band_q() -> f32 {
+    1.0
+}
+
+/// One parametric EQ band.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct EqBand {
+    pub kind: EqBandKind,
+    pub freq_hz: f32,
+    /// Ignored by LowPass/HighPass (their shape has no gain parameter).
+    #[serde(default)]
+    pub gain_db: f32,
+    /// Peaking/LowPass/HighPass: filter Q. Shelves: RBJ shelf slope S —
+    /// one field, two meanings, so presets stay a flat 4-field record.
+    #[serde(default = "default_band_q")]
+    pub q: f32,
+}
+
+impl EqBand {
+    /// TD-050: clamp to DSP-safe ranges, replacing non-finite values, so a
+    /// hostile IPC payload or preset file can't blow up the filter design.
+    pub fn clamp_ranges(&mut self) {
+        fn finite(v: f32, fallback: f32, lo: f32, hi: f32) -> f32 {
+            if v.is_finite() {
+                v.clamp(lo, hi)
+            } else {
+                fallback
+            }
+        }
+        self.freq_hz = finite(self.freq_hz, 1000.0, 20.0, 20000.0);
+        self.gain_db = finite(self.gain_db, 0.0, -24.0, 24.0);
+        self.q = finite(self.q, default_band_q(), 0.1, 10.0);
+    }
+}
+
+/// The Sonar-style starting layout: shelves at the extremes, three mids,
+/// everything flat. Five bands; the UI can add up to MAX_EQ_BANDS.
+pub fn default_eq_bands() -> Vec<EqBand> {
+    [
+        (EqBandKind::LowShelf, 100.0, 0.71),
+        (EqBandKind::Peaking, 500.0, 1.0),
+        (EqBandKind::Peaking, 1500.0, 1.0),
+        (EqBandKind::Peaking, 5000.0, 1.0),
+        (EqBandKind::HighShelf, 10000.0, 0.71),
+    ]
+    .into_iter()
+    .map(|(kind, freq_hz, q)| EqBand {
+        kind,
+        freq_hz,
+        gain_db: 0.0,
+        q,
+    })
+    .collect()
+}
+
+/// A channel's parametric EQ (persisted per channel; applied live).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EqConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Headroom trim applied before the band cascade (dB). Boost-heavy
+    /// curves need this negative to avoid clipping.
+    #[serde(default)]
+    pub preamp_db: f32,
+    #[serde(default = "default_eq_bands")]
+    pub bands: Vec<EqBand>,
+}
+
+impl EqConfig {
+    /// TD-050-style sanitization for the whole config (see EqBand).
+    pub fn clamp_ranges(&mut self) {
+        if !self.preamp_db.is_finite() {
+            self.preamp_db = 0.0;
+        }
+        self.preamp_db = self.preamp_db.clamp(-24.0, 24.0);
+        self.bands.truncate(MAX_EQ_BANDS);
+        for band in &mut self.bands {
+            band.clamp_ranges();
+        }
+    }
+}
+
+impl Default for EqConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            preamp_db: 0.0,
+            bands: default_eq_bands(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod eq_clamp_tests {
+    use super::*;
+
+    #[test]
+    fn band_clamp_bounds_out_of_range_values() {
+        let mut b = EqBand {
+            kind: EqBandKind::Peaking,
+            freq_hz: 99999.0,
+            gain_db: -80.0,
+            q: 0.0,
+        };
+        b.clamp_ranges();
+        assert_eq!(b.freq_hz, 20000.0);
+        assert_eq!(b.gain_db, -24.0);
+        assert_eq!(b.q, 0.1);
+    }
+
+    #[test]
+    fn band_clamp_replaces_non_finite_with_defaults() {
+        let mut b = EqBand {
+            kind: EqBandKind::Peaking,
+            freq_hz: f32::NAN,
+            gain_db: f32::INFINITY,
+            q: f32::NEG_INFINITY,
+        };
+        b.clamp_ranges();
+        assert_eq!(b.freq_hz, 1000.0);
+        assert_eq!(b.gain_db, 0.0);
+        assert_eq!(b.q, default_band_q());
+    }
+
+    #[test]
+    fn config_clamp_truncates_to_max_bands() {
+        let mut c = EqConfig::default();
+        c.bands = vec![c.bands[0]; MAX_EQ_BANDS + 5];
+        c.preamp_db = f32::NAN;
+        c.clamp_ranges();
+        assert_eq!(c.bands.len(), MAX_EQ_BANDS);
+        assert_eq!(c.preamp_db, 0.0);
+    }
+
+    #[test]
+    fn config_without_fields_deserializes_with_defaults() {
+        // Old profile/eq JSON without these keys must keep loading.
+        let c: EqConfig = serde_json::from_str("{}").unwrap();
+        assert!(!c.enabled);
+        assert_eq!(c.preamp_db, 0.0);
+        assert_eq!(c.bands, default_eq_bands());
+    }
+
+    #[test]
+    fn band_kind_serializes_snake_case() {
+        let json = serde_json::to_string(&EqBandKind::LowShelf).unwrap();
+        assert_eq!(json, "\"low_shelf\"");
+    }
+}

--- a/src-tauri/src/commands/channels.rs
+++ b/src-tauri/src/commands/channels.rs
@@ -164,7 +164,7 @@ pub fn remove_channel(state: State<'_, AppState>, sink_name: String) -> Result<(
         .destroy_virtual_sink(&sink_name)
         .map_err(|e| e.to_string())?;
 
-    let (defs, assignments, outputs, buses, names) = {
+    let (defs, assignments, outputs, eq, buses, names) = {
         let mut mixer = state.lock_mixer()?;
         mixer.channels.retain(|c| c.name != sink_name);
         mixer
@@ -172,6 +172,9 @@ pub fn remove_channel(state: State<'_, AppState>, sink_name: String) -> Result<(
             .assignments
             .retain(|a| a.sink_name != sink_name);
         mixer.outputs.remove(&sink_name);
+        // The backend's DestroySink already tore down the live insert;
+        // this drops the persisted config with the channel.
+        mixer.eq.remove(&sink_name);
         // Drop the channel from every mix's membership too.
         mixer.buses.remove_channel(&sink_name);
         // Re-evaluate auto-routing with the channel gone.
@@ -181,6 +184,7 @@ pub fn remove_channel(state: State<'_, AppState>, sink_name: String) -> Result<(
             mixer.channel_defs.clone(),
             mixer.assignments.clone(),
             mixer.outputs.clone(),
+            mixer.eq.clone(),
             mixer.buses.clone(),
             crate::commands::buses::channel_names(&mixer),
         )
@@ -195,6 +199,7 @@ pub fn remove_channel(state: State<'_, AppState>, sink_name: String) -> Result<(
     defs.save().map_err(|e| e.to_string())?;
     assignments.save().map_err(|e| e.to_string())?;
     outputs.save().map_err(|e| e.to_string())?;
+    eq.save().map_err(|e| e.to_string())?;
     buses.save().map_err(|e| e.to_string())?;
     wireplumber::write(&assignments).map_err(|e| e.to_string())?;
     Ok(())

--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -231,6 +231,7 @@ pub fn init_virtual_devices(
             channels: mixer.channels.clone(),
             assignments: mixer.assignments.clone(),
             outputs: mixer.outputs.clone(),
+            eq: mixer.eq.clone(),
             trigger_device: None,
             buses: mixer.buses.clone(),
         };

--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -162,13 +162,18 @@ pub fn init_virtual_devices(
             .map_err(|e| e.to_string())?;
     }
 
-    let (outputs, mic, buses) = {
+    let (outputs, eq, mic, buses) = {
         let mut mixer = state.lock_mixer()?;
         mixer.init_defaults();
         // The master mix always carries the full channel set.
         let names: Vec<String> = defs.channels.iter().map(|c| c.name.clone()).collect();
         mixer.buses.sync_master(&names);
-        (mixer.outputs.clone(), mixer.mic.clone(), mixer.buses.clone())
+        (
+            mixer.outputs.clone(),
+            mixer.eq.clone(),
+            mixer.mic.clone(),
+            mixer.buses.clone(),
+        )
     };
     if let Err(e) = buses.save() {
         eprintln!("sink: saving mixes failed: {e}");
@@ -187,6 +192,13 @@ pub fn init_virtual_devices(
         if !outputs.failover(&def.name) {
             if let Err(e) = state.backend.set_channel_failover(&def.name, false) {
                 eprintln!("sink: failover setting for {} failed: {e}", def.name);
+            }
+        }
+        // Restore saved EQ (only channels that were ever configured; the
+        // loop builds the insert when the sink node appears).
+        if let Some(config) = eq.configs.get(&def.name) {
+            if let Err(e) = state.backend.set_channel_eq(&def.name, config) {
+                eprintln!("sink: eq restore for {} failed: {e}", def.name);
             }
         }
     }

--- a/src-tauri/src/commands/eq.rs
+++ b/src-tauri/src/commands/eq.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+
+use tauri::State;
+
+use crate::audio::types::EqConfig;
+use crate::state::AppState;
+
+/// All channels' EQ configs in one round-trip (channels without an entry
+/// have never been configured — the frontend treats them as default).
+#[tauri::command]
+pub fn get_channel_eq_configs(
+    state: State<'_, AppState>,
+) -> Result<HashMap<String, EqConfig>, String> {
+    Ok(state.lock_mixer()?.eq.configs.clone())
+}
+
+/// Apply and persist one channel's parametric EQ.
+#[tauri::command]
+pub fn set_channel_eq(
+    state: State<'_, AppState>,
+    sink_name: String,
+    mut config: EqConfig,
+) -> Result<(), String> {
+    config.clamp_ranges();
+    state
+        .backend
+        .set_channel_eq(&sink_name, &config)
+        .map_err(|e| e.to_string())?;
+    let eq = {
+        let mut mixer = state.lock_mixer()?;
+        mixer.eq.set(&sink_name, config);
+        crate::commands::profiles::autosave_active(&mixer);
+        mixer.eq.clone()
+    };
+    eq.save().map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/eq.rs
+++ b/src-tauri/src/commands/eq.rs
@@ -1,8 +1,12 @@
 use std::collections::HashMap;
 
+use serde::Serialize;
 use tauri::State;
 
+use crate::audio::eq_import::parse_autoeq;
+use crate::audio::presets::{bundled_presets, EqPreset, PRESET_SCHEMA};
 use crate::audio::types::EqConfig;
+use crate::persistence::eq_presets;
 use crate::state::AppState;
 
 /// All channels' EQ configs in one round-trip (channels without an entry
@@ -33,4 +37,117 @@ pub fn set_channel_eq(
         mixer.eq.clone()
     };
     eq.save().map_err(|e| e.to_string())
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EqPresetEntry {
+    /// "bundled" (ships in the binary) or "user" (local library).
+    pub source: String,
+    pub preset: EqPreset,
+}
+
+/// Bundled presets first, then the user's library, each sorted by name.
+#[tauri::command]
+pub fn list_eq_presets() -> Result<Vec<EqPresetEntry>, String> {
+    let mut entries: Vec<EqPresetEntry> = bundled_presets()
+        .into_iter()
+        .map(|preset| EqPresetEntry {
+            source: "bundled".into(),
+            preset,
+        })
+        .collect();
+    entries.extend(
+        eq_presets::list()
+            .map_err(|e| e.to_string())?
+            .into_iter()
+            .map(|preset| EqPresetEntry {
+                source: "user".into(),
+                preset,
+            }),
+    );
+    Ok(entries)
+}
+
+/// Save the given config into the user's local preset library.
+#[tauri::command]
+pub fn save_user_eq_preset(name: String, mut config: EqConfig) -> Result<(), String> {
+    config.clamp_ranges();
+    let preset = EqPreset {
+        schema: PRESET_SCHEMA,
+        name,
+        author: None,
+        description: None,
+        preamp_db: config.preamp_db,
+        bands: config.bands,
+    };
+    eq_presets::save(&preset).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn delete_user_eq_preset(name: String) -> Result<(), String> {
+    eq_presets::delete(&name).map_err(|e| e.to_string())
+}
+
+/// A channel's EQ as shareable preset JSON (pretty-printed, schema 1).
+#[tauri::command]
+pub fn export_channel_eq(state: State<'_, AppState>, sink_name: String) -> Result<String, String> {
+    let (config, label) = {
+        let mixer = state.lock_mixer()?;
+        let label = mixer
+            .channels
+            .iter()
+            .find(|c| c.name == sink_name)
+            .map(|c| c.label.clone())
+            .unwrap_or_else(|| sink_name.clone());
+        (mixer.eq.get(&sink_name), label)
+    };
+    let preset = EqPreset {
+        schema: PRESET_SCHEMA,
+        name: label,
+        author: None,
+        description: None,
+        preamp_db: config.preamp_db,
+        bands: config.bands,
+    };
+    serde_json::to_string_pretty(&preset).map_err(|e| e.to_string())
+}
+
+/// Write a channel's EQ preset JSON to `path` (picked via the native save
+/// dialog; the file I/O stays in Rust so no fs plugin scope is needed).
+#[tauri::command]
+pub fn export_channel_eq_to_file(
+    state: State<'_, AppState>,
+    sink_name: String,
+    path: String,
+) -> Result<(), String> {
+    let json = export_channel_eq(state, sink_name)?;
+    std::fs::write(&path, json).map_err(|e| format!("write {path}: {e}"))
+}
+
+/// Parse pasted preset text: our JSON schema or an AutoEq result block.
+/// Returns a disabled config for preview-then-apply in the modal.
+#[tauri::command]
+pub fn import_eq_config(text: String) -> Result<EqConfig, String> {
+    let trimmed = text.trim();
+    if trimmed.starts_with('{') {
+        let preset: EqPreset = serde_json::from_str(trimmed).map_err(|e| e.to_string())?;
+        if preset.schema != PRESET_SCHEMA {
+            return Err(format!("unsupported preset schema {}", preset.schema));
+        }
+        if preset.bands.is_empty() {
+            return Err("preset has no bands".into());
+        }
+        let mut config = preset.to_config();
+        config.enabled = false;
+        Ok(config)
+    } else {
+        parse_autoeq(trimmed).map_err(|e| e.to_string())
+    }
+}
+
+/// Read + parse a preset file picked via the native open dialog.
+#[tauri::command]
+pub fn import_eq_file(path: String) -> Result<EqConfig, String> {
+    let text = std::fs::read_to_string(&path).map_err(|e| format!("read {path}: {e}"))?;
+    import_eq_config(text)
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod apps;
 pub mod buses;
 pub mod channels;
 pub mod devices;
+pub mod eq;
 pub mod mic;
 pub mod profiles;
 pub mod routing;

--- a/src-tauri/src/commands/profiles.rs
+++ b/src-tauri/src/commands/profiles.rs
@@ -18,6 +18,7 @@ pub fn autosave_active(mixer: &crate::mixer::state::MixerState) {
         channels: mixer.channels.clone(),
         assignments: mixer.assignments.clone(),
         outputs: mixer.outputs.clone(),
+        eq: mixer.eq.clone(),
         // Preserved from the cache rather than re-read from disk each mutation.
         trigger_device: mixer.active_trigger.clone(),
         buses: mixer.buses.clone(),
@@ -139,6 +140,14 @@ pub fn load_profile(
         {
             eprintln!("sink: profile failover for {} failed: {e}", channel.name);
         }
+        // EQ: non-fatal like output/failover — one channel's insert failing
+        // must not abort the whole profile load.
+        if let Err(e) = state
+            .backend
+            .set_channel_eq(&channel.name, &profile.eq.get(&channel.name))
+        {
+            eprintln!("sink: profile eq for {} failed: {e}", channel.name);
+        }
     }
 
     // ---- mix bus reconciliation ----
@@ -171,7 +180,7 @@ pub fn load_profile(
         }
     }
 
-    let (defs, assignments, outputs) = {
+    let (defs, assignments, outputs, eq) = {
         let mut mixer = state.lock_mixer()?;
         mixer.buses = target_buses.clone();
         mixer.channel_defs = crate::persistence::channels::Channels {
@@ -189,17 +198,20 @@ pub fn load_profile(
         mixer.channels = profile.channels.clone();
         mixer.assignments = profile.assignments.clone();
         mixer.outputs = profile.outputs.clone();
+        mixer.eq = profile.eq.clone();
         mixer.auto_routed.clear();
         (
             mixer.channel_defs.clone(),
             mixer.assignments.clone(),
             mixer.outputs.clone(),
+            mixer.eq.clone(),
         )
     };
 
     defs.save().map_err(|e| e.to_string())?;
     assignments.save().map_err(|e| e.to_string())?;
     outputs.save().map_err(|e| e.to_string())?;
+    eq.save().map_err(|e| e.to_string())?;
     target_buses.save().map_err(|e| e.to_string())?;
     wireplumber::write(&assignments).map_err(|e| e.to_string())?;
     // The loaded profile becomes the live-bound (autosaving) one.
@@ -234,6 +246,7 @@ pub fn create_blank_profile(app: tauri::AppHandle, name: String) -> Result<(), S
         channels,
         assignments: Default::default(),
         outputs: Default::default(),
+        eq: Default::default(),
         trigger_device: None,
         buses: Default::default(),
     };

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use tauri::State;
 
+use crate::headset::HeadsetStatus;
 use crate::persistence::autostart;
 use crate::persistence::prefs::{DeviceLabelStyle, Prefs};
 use crate::state::AppState;
@@ -70,6 +71,34 @@ pub fn set_start_minimized(state: State<'_, AppState>, minimized: bool) -> Resul
         autostart::enable().map_err(|e| e.to_string())?;
     }
     Ok(())
+}
+
+/// Current SteelSeries headset-detection status for the settings UI (installed?
+/// supported device present? headset on/off?).
+#[tauri::command]
+pub fn get_headset_status(state: State<'_, AppState>) -> HeadsetStatus {
+    state.headset.status()
+}
+
+/// Turn opt-in SteelSeries headset-off detection on or off. Persists the
+/// preference and starts/stops the polling monitor.
+#[tauri::command]
+pub fn set_headset_detection(
+    state: State<'_, AppState>,
+    enabled: bool,
+) -> Result<HeadsetStatus, String> {
+    let prefs = {
+        let mut mixer = state.lock_mixer()?;
+        mixer.prefs.headset_detection = enabled;
+        mixer.prefs.clone()
+    };
+    prefs.save().map_err(|e| e.to_string())?;
+    if enabled {
+        state.headset.start(state.backend.clone());
+    } else {
+        state.headset.stop();
+    }
+    Ok(state.headset.status())
 }
 
 /// Show or hide the title-bar balance slider.

--- a/src-tauri/src/headset.rs
+++ b/src-tauri/src/headset.rs
@@ -1,0 +1,431 @@
+//! Opt-in SteelSeries (and other `headsetcontrol`-supported) wireless headset
+//! detection.
+//!
+//! Some wireless dongles keep their USB sink node alive when the headset
+//! powers off (the base station *is* the sound card), so nothing disappears
+//! from the audio graph and the normal follow-default failover has nothing to
+//! react to - audio keeps flowing into a headset that isn't there. We can't
+//! see that at the PipeWire layer, but `headsetcontrol` reads it over the
+//! vendor HID interface. When enabled, this module polls it and, on a
+//! confirmed power-off, moves the system default off the dead sink to the best
+//! available output (restoring it when the headset returns).
+//!
+//! Design note: detection is deliberately *conservative*. We only treat a
+//! headset as disconnected when `headsetcontrol` reports an explicit
+//! battery-unavailable status, so a JSON-schema mismatch or a transient error
+//! can never wrongly pull audio off a headset that is actually in use - it
+//! just means the feature does nothing, same as it being off.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use serde::Serialize;
+
+use crate::audio::backend::AudioBackend;
+use crate::audio::types::OutputDevice;
+
+/// How often to poll `headsetcontrol` while detection is enabled.
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+/// Consecutive identical reads required before acting - debounces a blip.
+const DEBOUNCE: u8 = 2;
+
+/// What `headsetcontrol -o json` tells us about a supported wireless headset.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HeadsetReading {
+    /// The `headsetcontrol` binary is not on `PATH`.
+    ToolMissing,
+    /// It ran but errored (couldn't execute, or unparsable output).
+    ToolError(String),
+    /// It ran fine but reported no *supported* device - either nothing is
+    /// plugged in, or (commonly) the installed `headsetcontrol` is too old for
+    /// this device. The UI turns this into an actionable hint.
+    NoSupportedDevice,
+    /// A supported headset's base/dongle is present. `connected` is whether
+    /// the wireless headset itself is powered on.
+    Present { model: String, connected: bool },
+}
+
+/// Parse `headsetcontrol -o json`. Pure, so the whole decision path is
+/// testable without the binary or the hardware.
+pub fn parse_reading(json: &str) -> HeadsetReading {
+    let value: serde_json::Value = match serde_json::from_str(json) {
+        Ok(v) => v,
+        Err(e) => return HeadsetReading::ToolError(format!("unparsable headsetcontrol json: {e}")),
+    };
+    let device = value
+        .get("devices")
+        .and_then(|d| d.as_array())
+        .and_then(|d| d.first());
+    let Some(device) = device else {
+        return HeadsetReading::NoSupportedDevice;
+    };
+    let model = device
+        .get("device")
+        .and_then(|d| d.as_str())
+        .or_else(|| device.get("product").and_then(|p| p.as_str()))
+        .unwrap_or("Headset")
+        .to_string();
+    // Only an explicit unavailable-family battery status counts as "off"; every
+    // other value (available, charging, or a key we didn't recognise) is read
+    // as "on" so we never yank audio off a working headset.
+    let battery_status = device
+        .get("battery")
+        .and_then(|b| b.get("status"))
+        .and_then(|s| s.as_str());
+    let connected = !matches!(
+        battery_status.map(str::to_ascii_uppercase).as_deref(),
+        Some("BATTERY_UNAVAILABLE") | Some("BATTERY_TIMEOUT") | Some("BATTERY_HIDERROR")
+    );
+    HeadsetReading::Present { model, connected }
+}
+
+/// Reads headset state. Abstracted so tests can inject readings and a native
+/// HID backend could replace the subprocess later.
+pub trait HeadsetDetector: Send + Sync {
+    fn read(&self) -> HeadsetReading;
+}
+
+/// The `headsetcontrol` CLI detector (Option A).
+pub struct HeadsetControl;
+
+impl HeadsetDetector for HeadsetControl {
+    fn read(&self) -> HeadsetReading {
+        match Command::new("headsetcontrol").args(["-o", "json"]).output() {
+            Ok(out) => parse_reading(&String::from_utf8_lossy(&out.stdout)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => HeadsetReading::ToolMissing,
+            Err(e) => HeadsetReading::ToolError(e.to_string()),
+        }
+    }
+}
+
+/// A SteelSeries/Arctis output device, matched by name so we know which sink
+/// goes dead when the headset powers off.
+fn is_headset_sink(device: &OutputDevice) -> bool {
+    let hay = format!("{} {}", device.name, device.description).to_ascii_lowercase();
+    hay.contains("steelseries") || hay.contains("arctis")
+}
+
+/// The best output to fall over to: the first real device that is neither the
+/// headset itself nor one of Sink's own virtual channel sinks.
+fn pick_fallback(devices: &[OutputDevice]) -> Option<String> {
+    devices
+        .iter()
+        .find(|d| !is_headset_sink(d) && !d.name.starts_with("sink_"))
+        .map(|d| d.name.clone())
+}
+
+/// What to do on a confirmed state change. Pure and idempotent: `has_saved`
+/// (whether we've already moved the default away) plus the confirmed
+/// connected state fully determine the action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Action {
+    None,
+    FailOver,
+    Restore,
+}
+
+fn decide(connected: bool, has_saved: bool) -> Action {
+    match (connected, has_saved) {
+        (false, false) => Action::FailOver, // headset off, not yet switched
+        (true, true) => Action::Restore,    // headset back, we had switched
+        _ => Action::None,
+    }
+}
+
+/// UI-facing snapshot of detection state.
+#[derive(Debug, Clone, Serialize)]
+pub struct HeadsetStatus {
+    /// The monitor is running (the setting is on).
+    pub enabled: bool,
+    /// `headsetcontrol` is installed.
+    pub tool_installed: bool,
+    /// A supported device is present (base/dongle recognised).
+    pub device_present: bool,
+    /// The wireless headset is powered on.
+    pub connected: bool,
+    pub model: Option<String>,
+    /// A one-line actionable note when something needs attention.
+    pub message: Option<String>,
+}
+
+impl HeadsetStatus {
+    fn from_reading(reading: &HeadsetReading, enabled: bool) -> Self {
+        let mut status = HeadsetStatus {
+            enabled,
+            tool_installed: !matches!(reading, HeadsetReading::ToolMissing),
+            device_present: matches!(reading, HeadsetReading::Present { .. }),
+            connected: matches!(reading, HeadsetReading::Present { connected: true, .. }),
+            model: None,
+            message: None,
+        };
+        match reading {
+            HeadsetReading::ToolMissing => {
+                status.message = Some("Install headsetcontrol to use this".into());
+            }
+            HeadsetReading::ToolError(e) => status.message = Some(e.clone()),
+            HeadsetReading::NoSupportedDevice => {
+                status.message =
+                    Some("No supported headset found (or headsetcontrol is too old for it)".into());
+            }
+            HeadsetReading::Present { model, connected } => {
+                status.model = Some(model.clone());
+                status.message = Some(if *connected {
+                    format!("{model} connected")
+                } else {
+                    format!("{model} is off - audio moved to your speakers")
+                });
+            }
+        }
+        status
+    }
+}
+
+/// Owns the polling thread. Started/stopped by the settings toggle.
+pub struct HeadsetMonitor {
+    running: Arc<AtomicBool>,
+    handle: Mutex<Option<JoinHandle<()>>>,
+    detector: Arc<dyn HeadsetDetector>,
+}
+
+impl HeadsetMonitor {
+    pub fn new() -> Self {
+        Self::with_detector(Arc::new(HeadsetControl))
+    }
+
+    pub fn with_detector(detector: Arc<dyn HeadsetDetector>) -> Self {
+        Self {
+            running: Arc::new(AtomicBool::new(false)),
+            handle: Mutex::new(None),
+            detector,
+        }
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.running.load(Ordering::Relaxed)
+    }
+
+    /// A one-shot read for the UI (independent of whether the monitor runs).
+    pub fn status(&self) -> HeadsetStatus {
+        HeadsetStatus::from_reading(&self.detector.read(), self.is_running())
+    }
+
+    /// Start polling. No-op if already running.
+    pub fn start(&self, backend: Arc<dyn AudioBackend>) {
+        if self.running.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let running = self.running.clone();
+        let detector = self.detector.clone();
+        let handle = std::thread::spawn(move || monitor_loop(&running, backend, detector.as_ref()));
+        if let Ok(mut slot) = self.handle.lock() {
+            *slot = Some(handle);
+        }
+    }
+
+    /// Stop polling and join the thread.
+    pub fn stop(&self) {
+        self.running.store(false, Ordering::SeqCst);
+        let handle = self.handle.lock().ok().and_then(|mut slot| slot.take());
+        if let Some(handle) = handle {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Default for HeadsetMonitor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn monitor_loop(
+    running: &AtomicBool,
+    backend: Arc<dyn AudioBackend>,
+    detector: &dyn HeadsetDetector,
+) {
+    let mut stable: Option<bool> = None; // last confirmed connected state
+    let mut candidate: Option<bool> = None; // debounce candidate
+    let mut count: u8 = 0;
+    // (device we switched away from, device we switched to) while headset is off.
+    let mut saved: Option<(String, String)> = None;
+
+    while running.load(Ordering::Relaxed) {
+        std::thread::sleep(POLL_INTERVAL);
+        if !running.load(Ordering::Relaxed) {
+            break;
+        }
+
+        let (connected, model) = match detector.read() {
+            HeadsetReading::Present { connected, model } => (connected, model),
+            // No supported device / tool issue: stop tracking, act on nothing.
+            _ => {
+                candidate = None;
+                count = 0;
+                continue;
+            }
+        };
+
+        // Debounce: require DEBOUNCE identical reads before trusting a change.
+        if candidate == Some(connected) {
+            count = count.saturating_add(1);
+        } else {
+            candidate = Some(connected);
+            count = 1;
+        }
+        if count < DEBOUNCE || stable == Some(connected) {
+            continue;
+        }
+        stable = Some(connected);
+
+        match decide(connected, saved.is_some()) {
+            Action::FailOver => {
+                if let Some(pair) = fail_over(backend.as_ref(), &model) {
+                    saved = Some(pair);
+                }
+            }
+            Action::Restore => {
+                if let Some((from, to)) = saved.take() {
+                    restore(backend.as_ref(), &from, &to);
+                }
+            }
+            Action::None => {}
+        }
+    }
+}
+
+/// Move the system default off the (dead) headset sink to the best fallback,
+/// but only if the headset sink is actually the current default. Returns the
+/// (from, to) pair so it can be restored.
+fn fail_over(backend: &dyn AudioBackend, _model: &str) -> Option<(String, String)> {
+    let (default_out, _) = backend.get_default_devices().ok()?;
+    let default_out = default_out?;
+    let devices = backend.list_output_devices().ok()?;
+
+    let headset_is_default = devices
+        .iter()
+        .any(|d| d.name == default_out && is_headset_sink(d));
+    if !headset_is_default {
+        return None; // user isn't listening on the headset - nothing to move
+    }
+
+    let fallback = pick_fallback(&devices)?;
+    match backend.set_default_output(&fallback) {
+        Ok(()) => Some((default_out, fallback)),
+        Err(e) => {
+            eprintln!("sink: headset failover could not switch default: {e}");
+            None
+        }
+    }
+}
+
+/// Restore the default to the headset - but only if nothing else has changed
+/// it since (never stomp a manual switch the user made in the meantime).
+fn restore(backend: &dyn AudioBackend, from: &str, to: &str) {
+    match backend.get_default_devices() {
+        Ok((Some(current), _)) if current == to => {
+            if let Err(e) = backend.set_default_output(from) {
+                eprintln!("sink: headset restore could not switch default back: {e}");
+            }
+        }
+        _ => {} // default moved elsewhere; leave the user's choice alone
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dev(name: &str, desc: &str) -> OutputDevice {
+        OutputDevice {
+            index: 0,
+            name: name.to_string(),
+            description: desc.to_string(),
+        }
+    }
+
+    #[test]
+    fn parses_no_device_when_list_empty() {
+        let json = r#"{ "device_count": 0, "devices": [] }"#;
+        assert_eq!(parse_reading(json), HeadsetReading::NoSupportedDevice);
+    }
+
+    #[test]
+    fn parses_connected_when_battery_available() {
+        let json = r#"{ "device_count": 1, "devices": [
+            { "device": "SteelSeries Arctis Nova 7", "battery": { "status": "BATTERY_AVAILABLE", "level": 80 } }
+        ] }"#;
+        assert_eq!(
+            parse_reading(json),
+            HeadsetReading::Present { model: "SteelSeries Arctis Nova 7".into(), connected: true }
+        );
+    }
+
+    #[test]
+    fn parses_charging_as_connected() {
+        let json = r#"{ "devices": [ { "device": "X", "battery": { "status": "BATTERY_CHARGING" } } ] }"#;
+        assert_eq!(
+            parse_reading(json),
+            HeadsetReading::Present { model: "X".into(), connected: true }
+        );
+    }
+
+    #[test]
+    fn parses_unavailable_battery_as_disconnected() {
+        let json = r#"{ "devices": [ { "device": "Nova 7", "battery": { "status": "BATTERY_UNAVAILABLE" } } ] }"#;
+        assert_eq!(
+            parse_reading(json),
+            HeadsetReading::Present { model: "Nova 7".into(), connected: false }
+        );
+    }
+
+    #[test]
+    fn unknown_battery_status_is_treated_as_connected_fail_safe() {
+        // A schema we didn't anticipate must never read as "off".
+        let json = r#"{ "devices": [ { "device": "Y", "battery": { "status": "SOMETHING_NEW" } } ] }"#;
+        assert_eq!(
+            parse_reading(json),
+            HeadsetReading::Present { model: "Y".into(), connected: true }
+        );
+        let no_battery = r#"{ "devices": [ { "device": "Z" } ] }"#;
+        assert_eq!(
+            parse_reading(no_battery),
+            HeadsetReading::Present { model: "Z".into(), connected: true }
+        );
+    }
+
+    #[test]
+    fn garbage_json_is_a_tool_error_not_a_disconnect() {
+        assert!(matches!(parse_reading("not json"), HeadsetReading::ToolError(_)));
+    }
+
+    #[test]
+    fn fallback_skips_the_headset_and_virtual_sinks() {
+        let devices = vec![
+            dev("sink_game", "Game"),
+            dev("alsa_output.usb-SteelSeries_Arctis_Nova_Pro-00.analog-stereo", "Arctis Nova Pro"),
+            dev("alsa_output.pci-0000_01_00.1.hdmi-stereo", "GB203 HDMI"),
+            dev("alsa_output.pci-0000_00_1f.3.analog-stereo", "Built-in Speakers"),
+        ];
+        assert_eq!(
+            pick_fallback(&devices).as_deref(),
+            Some("alsa_output.pci-0000_01_00.1.hdmi-stereo")
+        );
+    }
+
+    #[test]
+    fn fallback_is_none_when_only_headset_and_virtuals_exist() {
+        let devices = vec![dev("sink_chat", "Chat"), dev("x.arctis.y", "Arctis 7")];
+        assert_eq!(pick_fallback(&devices), None);
+    }
+
+    #[test]
+    fn decide_matrix() {
+        assert_eq!(decide(false, false), Action::FailOver); // off, not switched
+        assert_eq!(decide(false, true), Action::None); // off, already switched
+        assert_eq!(decide(true, true), Action::Restore); // back, restore
+        assert_eq!(decide(true, false), Action::None); // on, nothing to do
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod audio;
 mod commands;
 mod error;
+mod headset;
 mod mixer;
 mod persistence;
 mod state;
@@ -92,6 +93,8 @@ pub fn run() {
             commands::settings::set_balance_channels,
             commands::settings::set_balance_visible,
             commands::settings::set_start_minimized,
+            commands::settings::get_headset_status,
+            commands::settings::set_headset_detection,
             commands::settings::reset_app,
         ])
         .setup(move |app| {
@@ -106,6 +109,15 @@ pub fn run() {
             }
             if let Some(levels) = levels {
                 spawn_level_emitter(app.handle().clone(), levels);
+            }
+            // Resume opt-in headset detection if it was left enabled.
+            let state = app.state::<AppState>();
+            let headset_on = state
+                .lock_mixer()
+                .map(|m| m.prefs.headset_detection)
+                .unwrap_or(false);
+            if headset_on {
+                state.headset.start(state.backend.clone());
             }
             Ok(())
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -75,6 +75,8 @@ pub fn run() {
             commands::mic::get_mic_config,
             commands::mic::set_mic_config,
             commands::mic::get_input_devices,
+            commands::eq::get_channel_eq_configs,
+            commands::eq::set_channel_eq,
             commands::profiles::list_profiles,
             commands::profiles::load_profile,
             commands::profiles::delete_profile,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,7 @@ pub fn run() {
     let app_state = AppState::new(backend, backend_native);
 
     let result = tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
         .manage(app_state)
         .invoke_handler(tauri::generate_handler![
             commands::devices::get_virtual_devices,
@@ -77,6 +78,13 @@ pub fn run() {
             commands::mic::get_input_devices,
             commands::eq::get_channel_eq_configs,
             commands::eq::set_channel_eq,
+            commands::eq::list_eq_presets,
+            commands::eq::save_user_eq_preset,
+            commands::eq::delete_user_eq_preset,
+            commands::eq::export_channel_eq,
+            commands::eq::export_channel_eq_to_file,
+            commands::eq::import_eq_config,
+            commands::eq::import_eq_file,
             commands::profiles::list_profiles,
             commands::profiles::load_profile,
             commands::profiles::delete_profile,

--- a/src-tauri/src/mixer/state.rs
+++ b/src-tauri/src/mixer/state.rs
@@ -20,6 +20,8 @@ pub struct MixerState {
     pub aliases: Aliases,
     /// Per-channel output device choices (persisted to disk).
     pub outputs: crate::persistence::outputs::ChannelOutputs,
+    /// Per-channel parametric EQ configs (persisted to disk).
+    pub eq: crate::persistence::eq::ChannelEq,
     /// Mic chain configuration (persisted to disk).
     pub mic: crate::audio::types::MicConfig,
     /// Every app identity ever observed (history + ignore list).

--- a/src-tauri/src/persistence/eq.rs
+++ b/src-tauri/src/persistence/eq.rs
@@ -1,0 +1,110 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::audio::types::EqConfig;
+use crate::error::SinkError;
+
+/// Per-channel parametric EQ configs, stored as JSON at
+/// `$XDG_CONFIG_HOME/sink/eq.json`. A missing entry means "never touched" —
+/// the default (disabled, flat) config.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ChannelEq {
+    /// `serde(default)` keeps pre-EQ profile files loading cleanly.
+    #[serde(default)]
+    pub configs: HashMap<String, EqConfig>,
+}
+
+impl ChannelEq {
+    pub fn config_path() -> Result<PathBuf, SinkError> {
+        let dir = dirs::config_dir()
+            .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
+        Ok(dir.join("sink").join("eq.json"))
+    }
+
+    pub fn load() -> Self {
+        let Ok(path) = Self::config_path() else {
+            return Self::default();
+        };
+        match fs::read_to_string(&path) {
+            Ok(raw) => serde_json::from_str(&raw).unwrap_or_else(|e| {
+                eprintln!("sink: ignoring malformed {}: {e}", path.display());
+                Self::default()
+            }),
+            Err(_) => Self::default(),
+        }
+    }
+
+    pub fn save(&self) -> Result<(), SinkError> {
+        let path = Self::config_path()?;
+        if let Some(parent) = path.parent() {
+            crate::persistence::ensure_private_dir(parent)?;
+        }
+        let json = serde_json::to_string_pretty(self)
+            .map_err(|e| SinkError::Config(format!("serialize eq: {e}")))?;
+        super::write_atomic(&path, &json)?;
+        Ok(())
+    }
+
+    /// A channel's EQ, defaulting to disabled/flat when never configured.
+    pub fn get(&self, sink_name: &str) -> EqConfig {
+        self.configs.get(sink_name).cloned().unwrap_or_default()
+    }
+
+    pub fn set(&mut self, sink_name: &str, config: EqConfig) {
+        self.configs.insert(sink_name.to_string(), config);
+    }
+
+    /// Drop all state for a removed channel.
+    pub fn remove(&mut self, sink_name: &str) {
+        self.configs.remove(sink_name);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio::types::{default_eq_bands, EqBandKind};
+
+    #[test]
+    fn roundtrips_configured_channels() {
+        let mut eq = ChannelEq::default();
+        let mut config = EqConfig {
+            enabled: true,
+            preamp_db: -3.0,
+            ..EqConfig::default()
+        };
+        config.bands[0].gain_db = 4.5;
+        eq.set("sink_game", config.clone());
+        let json = serde_json::to_string(&eq).expect("serializes");
+        let back: ChannelEq = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(back, eq);
+        assert_eq!(back.get("sink_game"), config);
+    }
+
+    #[test]
+    fn unconfigured_channel_gets_default() {
+        let eq = ChannelEq::default();
+        let config = eq.get("sink_chat");
+        assert!(!config.enabled);
+        assert_eq!(config.bands, default_eq_bands());
+        assert_eq!(config.bands[0].kind, EqBandKind::LowShelf);
+    }
+
+    #[test]
+    fn legacy_file_without_configs_field_loads() {
+        // A pre-EQ profile (or an empty file body) has no `configs` key.
+        let eq: ChannelEq = serde_json::from_str("{}").expect("legacy loads");
+        assert_eq!(eq, ChannelEq::default());
+    }
+
+    #[test]
+    fn remove_drops_config() {
+        let mut eq = ChannelEq::default();
+        eq.set("sink_game", EqConfig::default());
+        eq.remove("sink_game");
+        assert!(eq.configs.is_empty());
+    }
+}

--- a/src-tauri/src/persistence/eq_presets.rs
+++ b/src-tauri/src/persistence/eq_presets.rs
@@ -1,0 +1,103 @@
+//! The user's local EQ preset library: named JSON files (the same schema
+//! as the bundled presets) under `$XDG_CONFIG_HOME/sink/eq_presets/`,
+//! modeled on the profiles store — including its name sanitization, so a
+//! preset name can never traverse out of the directory.
+
+use std::fs;
+use std::path::PathBuf;
+
+use crate::audio::presets::{EqPreset, PRESET_SCHEMA};
+use crate::error::SinkError;
+use crate::persistence::profiles::sanitize_name;
+
+fn presets_dir() -> Result<PathBuf, SinkError> {
+    let dir = dirs::config_dir()
+        .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
+    Ok(dir.join("sink").join("eq_presets"))
+}
+
+/// All user presets, sorted by name. Unreadable files are skipped (one
+/// corrupt preset must not hide the rest).
+pub fn list() -> Result<Vec<EqPreset>, SinkError> {
+    let dir = presets_dir()?;
+    let mut presets = Vec::new();
+    let entries = match fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(presets), // no library yet
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        match fs::read_to_string(&path)
+            .map_err(|e| e.to_string())
+            .and_then(|raw| serde_json::from_str::<EqPreset>(&raw).map_err(|e| e.to_string()))
+        {
+            Ok(preset) if preset.schema == PRESET_SCHEMA && !preset.bands.is_empty() => {
+                presets.push(preset);
+            }
+            Ok(_) => eprintln!("sink: skipping eq preset {}: bad schema", path.display()),
+            Err(e) => eprintln!("sink: skipping eq preset {}: {e}", path.display()),
+        }
+    }
+    presets.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(presets)
+}
+
+pub fn save(preset: &EqPreset) -> Result<(), SinkError> {
+    let name = sanitize_name(&preset.name)?;
+    if preset.bands.is_empty() {
+        return Err(SinkError::Config("a preset needs at least one band".into()));
+    }
+    let dir = presets_dir()?;
+    crate::persistence::ensure_private_dir(&dir)?;
+    let json = serde_json::to_string_pretty(preset)
+        .map_err(|e| SinkError::Config(format!("serialize eq preset: {e}")))?;
+    super::write_atomic(&dir.join(format!("{name}.json")), &json)?;
+    Ok(())
+}
+
+pub fn delete(name: &str) -> Result<(), SinkError> {
+    let name = sanitize_name(name)?;
+    let path = presets_dir()?.join(format!("{name}.json"));
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()), // idempotent
+        Err(e) => Err(SinkError::Io(e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn traversal_names_are_rejected() {
+        // sanitize_name (shared with profiles) is the barrier; pin that it
+        // holds for the preset entry points too.
+        assert!(delete("../etc/passwd").is_err());
+        let preset = EqPreset {
+            schema: PRESET_SCHEMA,
+            name: "../escape".into(),
+            author: None,
+            description: None,
+            preamp_db: 0.0,
+            bands: crate::audio::types::default_eq_bands(),
+        };
+        assert!(save(&preset).is_err());
+    }
+
+    #[test]
+    fn empty_band_presets_are_rejected() {
+        let preset = EqPreset {
+            schema: PRESET_SCHEMA,
+            name: "Empty".into(),
+            author: None,
+            description: None,
+            preamp_db: 0.0,
+            bands: Vec::new(),
+        };
+        assert!(save(&preset).is_err());
+    }
+}

--- a/src-tauri/src/persistence/mod.rs
+++ b/src-tauri/src/persistence/mod.rs
@@ -4,6 +4,7 @@ pub mod assignments;
 pub mod autostart;
 pub mod buses;
 pub mod channels;
+pub mod eq;
 pub mod mic;
 pub mod outputs;
 pub mod prefs;

--- a/src-tauri/src/persistence/mod.rs
+++ b/src-tauri/src/persistence/mod.rs
@@ -5,6 +5,7 @@ pub mod autostart;
 pub mod buses;
 pub mod channels;
 pub mod eq;
+pub mod eq_presets;
 pub mod mic;
 pub mod outputs;
 pub mod prefs;

--- a/src-tauri/src/persistence/prefs.rs
+++ b/src-tauri/src/persistence/prefs.rs
@@ -39,6 +39,10 @@ pub struct Prefs {
     /// showing the window (only meaningful with autostart enabled).
     #[serde(default)]
     pub start_minimized: bool,
+    /// Opt-in: poll `headsetcontrol` and move audio off a SteelSeries headset
+    /// to the speakers when it powers off (its dongle keeps the sink alive).
+    #[serde(default)]
+    pub headset_detection: bool,
 }
 
 fn default_true() -> bool {
@@ -54,6 +58,7 @@ impl Default for Prefs {
             balance_b: None,
             show_balance: true,
             start_minimized: false,
+            headset_detection: false,
         }
     }
 }

--- a/src-tauri/src/persistence/profiles.rs
+++ b/src-tauri/src/persistence/profiles.rs
@@ -18,6 +18,9 @@ pub struct Profile {
     /// Added in Phase 4; default keeps older profile files loadable.
     #[serde(default)]
     pub outputs: crate::persistence::outputs::ChannelOutputs,
+    /// Per-channel parametric EQ; default keeps older profile files loadable.
+    #[serde(default)]
+    pub eq: crate::persistence::eq::ChannelEq,
     /// Phase 5: output device (node.name) whose appearance auto-loads this
     /// profile — Sonar-style hardware profile switching.
     #[serde(default)]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use crate::audio::backend::AudioBackend;
+use crate::headset::HeadsetMonitor;
 use crate::mixer::state::MixerState;
 
 /// Application state managed by Tauri and shared across commands and the tray.
@@ -9,6 +10,8 @@ pub struct AppState {
     /// True when the native PipeWire backend is driving (vs pactl fallback).
     pub backend_native: bool,
     pub mixer: Mutex<MixerState>,
+    /// Opt-in SteelSeries headset-off detector (idle until the setting is on).
+    pub headset: HeadsetMonitor,
 }
 
 impl AppState {
@@ -49,6 +52,7 @@ impl AppState {
             backend,
             backend_native,
             mixer: Mutex::new(mixer),
+            headset: HeadsetMonitor::new(),
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -39,6 +39,7 @@ impl AppState {
             assignments: crate::persistence::assignments::Assignments::load(),
             aliases: crate::persistence::aliases::Aliases::load(),
             outputs: crate::persistence::outputs::ChannelOutputs::load(),
+            eq: crate::persistence::eq::ChannelEq::load(),
             mic: crate::persistence::mic::load(),
             channel_defs,
             buses,

--- a/src/components/Eq/EqBandRow.tsx
+++ b/src/components/Eq/EqBandRow.tsx
@@ -1,0 +1,95 @@
+import type { EqBand, EqBandKind } from "../../types";
+import { EQ_FREQ_MAX_HZ, EQ_FREQ_MIN_HZ, EQ_GAIN_RANGE_DB } from "../../types";
+import { Ms } from "../Icons";
+
+const KINDS: { value: EqBandKind; label: string }[] = [
+  { value: "peaking", label: "Peak" },
+  { value: "low_shelf", label: "Low shelf" },
+  { value: "high_shelf", label: "High shelf" },
+  { value: "low_pass", label: "Low pass" },
+  { value: "high_pass", label: "High pass" },
+];
+
+const isShelf = (kind: EqBandKind) => kind === "low_shelf" || kind === "high_shelf";
+const isPass = (kind: EqBandKind) => kind === "low_pass" || kind === "high_pass";
+
+interface EqBandRowProps {
+  band: EqBand;
+  selected: boolean;
+  onSelect: () => void;
+  onChange: (patch: Partial<EqBand>) => void;
+  onRemove: () => void;
+}
+
+/** Numeric editor for one band — the keyboard-accessible twin of the
+ *  curve dot (drag isn't reachable for everyone). */
+export function EqBandRow({ band, selected, onSelect, onChange, onRemove }: EqBandRowProps) {
+  const clampNum = (v: string, lo: number, hi: number, fallback: number) => {
+    const n = Number(v);
+    return Number.isFinite(n) ? Math.max(lo, Math.min(hi, n)) : fallback;
+  };
+
+  return (
+    <div className={"eqm-band" + (selected ? " sel" : "")} onPointerDown={onSelect}>
+      <select
+        className="eqm-kind"
+        value={band.kind}
+        aria-label="Band type"
+        onChange={(e) => onChange({ kind: e.target.value as EqBandKind })}
+      >
+        {KINDS.map((k) => (
+          <option key={k.value} value={k.value}>
+            {k.label}
+          </option>
+        ))}
+      </select>
+      <label className="eqm-field">
+        <span>Hz</span>
+        <input
+          type="number"
+          min={EQ_FREQ_MIN_HZ}
+          max={EQ_FREQ_MAX_HZ}
+          step={1}
+          value={Math.round(band.freq_hz)}
+          onChange={(e) =>
+            onChange({
+              freq_hz: clampNum(e.target.value, EQ_FREQ_MIN_HZ, EQ_FREQ_MAX_HZ, band.freq_hz),
+            })
+          }
+        />
+      </label>
+      <label className="eqm-field">
+        <span>dB</span>
+        <input
+          type="number"
+          min={-EQ_GAIN_RANGE_DB}
+          max={EQ_GAIN_RANGE_DB}
+          step={0.5}
+          value={band.gain_db}
+          disabled={isPass(band.kind)}
+          title={isPass(band.kind) ? "Pass filters have no gain" : undefined}
+          onChange={(e) =>
+            onChange({
+              gain_db: clampNum(e.target.value, -EQ_GAIN_RANGE_DB, EQ_GAIN_RANGE_DB, band.gain_db),
+            })
+          }
+        />
+      </label>
+      <label className="eqm-field">
+        {/* One schema field, two meanings (see EqBand.q). */}
+        <span>{isShelf(band.kind) ? "Slope" : "Q"}</span>
+        <input
+          type="number"
+          min={0.1}
+          max={10}
+          step={0.1}
+          value={band.q}
+          onChange={(e) => onChange({ q: clampNum(e.target.value, 0.1, 10, band.q) })}
+        />
+      </label>
+      <button className="eqm-remove" title="Remove band" aria-label="Remove band" onClick={onRemove}>
+        <Ms name="close" style={{ fontSize: 14 }} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/Eq/EqCurve.tsx
+++ b/src/components/Eq/EqCurve.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { EqBand, EqConfig } from "../../types";
+import { EQ_GAIN_RANGE_DB } from "../../types";
+import { curvePoints, freqToX, xToFreq } from "../../lib/eqMath";
+
+// SVG coordinate space; the element scales responsively.
+const W = 600;
+const H = 220;
+const PAD = 8;
+
+const dbToY = (db: number) =>
+  PAD + ((EQ_GAIN_RANGE_DB - db) / (2 * EQ_GAIN_RANGE_DB)) * (H - 2 * PAD);
+const yToDb = (y: number) =>
+  EQ_GAIN_RANGE_DB - ((y - PAD) / (H - 2 * PAD)) * 2 * EQ_GAIN_RANGE_DB;
+const fxToX = (fx: number) => PAD + fx * (W - 2 * PAD);
+const xToFx = (x: number) => (x - PAD) / (W - 2 * PAD);
+
+/** Frequencies that get a labeled grid line. */
+const GRID_FREQS = [50, 100, 500, 1000, 5000, 10000];
+const GRID_DBS = [-12, 0, 12];
+
+const fmtFreq = (hz: number) => (hz >= 1000 ? `${hz / 1000}k` : `${hz}`);
+
+/** Bands without a gain axis: their dot rides the 0 dB line. */
+const gainless = (band: EqBand) => band.kind === "low_pass" || band.kind === "high_pass";
+
+interface EqCurveProps {
+  config: EqConfig;
+  selected: number;
+  onSelect: (index: number) => void;
+  onBandChange: (index: number, patch: Partial<EqBand>) => void;
+}
+
+/** The interactive response curve: drag a dot to set freq/gain, scroll on
+ *  it to tighten/widen Q, double-click to zero the band. */
+export function EqCurve({ config, selected, onSelect, onBandChange }: EqCurveProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const dragIndex = useRef<number>(-1);
+
+  const dragTo = useCallback(
+    (clientX: number, clientY: number) => {
+      const svg = svgRef.current;
+      const index = dragIndex.current;
+      if (!svg || index < 0) return;
+      const band = config.bands[index];
+      if (!band) return;
+      const r = svg.getBoundingClientRect();
+      const x = ((clientX - r.left) / r.width) * W;
+      const y = ((clientY - r.top) / r.height) * H;
+      const freq_hz = Math.round(xToFreq(xToFx(x)));
+      const patch: Partial<EqBand> = { freq_hz };
+      if (!gainless(band)) {
+        const db = Math.max(-EQ_GAIN_RANGE_DB, Math.min(EQ_GAIN_RANGE_DB, yToDb(y)));
+        patch.gain_db = Math.round(db * 10) / 10;
+      }
+      onBandChange(index, patch);
+    },
+    [config.bands, onBandChange],
+  );
+
+  // Window-level listeners attached once; latest handler via ref (Fader idiom).
+  const dragToRef = useRef(dragTo);
+  dragToRef.current = dragTo;
+
+  useEffect(() => {
+    const move = (e: PointerEvent) => {
+      if (dragIndex.current >= 0) dragToRef.current(e.clientX, e.clientY);
+    };
+    const up = () => {
+      dragIndex.current = -1;
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+    return () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+  }, []);
+
+  const points = curvePoints(config);
+  const path = points
+    .map(
+      (p, i) =>
+        `${i === 0 ? "M" : "L"}${fxToX(freqToX(p.freq)).toFixed(1)},${dbToY(
+          Math.max(-EQ_GAIN_RANGE_DB, Math.min(EQ_GAIN_RANGE_DB, p.db)),
+        ).toFixed(1)}`,
+    )
+    .join(" ");
+  const zeroY = dbToY(0);
+  const fill = `${path} L${fxToX(1).toFixed(1)},${zeroY} L${fxToX(0).toFixed(1)},${zeroY} Z`;
+
+  return (
+    <svg
+      ref={svgRef}
+      className={"eqm-curve" + (config.enabled ? "" : " off")}
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label="EQ frequency response"
+    >
+      {GRID_FREQS.map((f) => (
+        <g key={f}>
+          <line
+            className="eqm-grid"
+            x1={fxToX(freqToX(f))}
+            x2={fxToX(freqToX(f))}
+            y1={PAD}
+            y2={H - PAD}
+          />
+          <text className="eqm-grid-label" x={fxToX(freqToX(f)) + 3} y={H - PAD - 4}>
+            {fmtFreq(f)}
+          </text>
+        </g>
+      ))}
+      {GRID_DBS.map((db) => (
+        <g key={db}>
+          <line
+            className={"eqm-grid" + (db === 0 ? " zero" : "")}
+            x1={PAD}
+            x2={W - PAD}
+            y1={dbToY(db)}
+            y2={dbToY(db)}
+          />
+          <text className="eqm-grid-label" x={PAD + 2} y={dbToY(db) - 3}>
+            {db > 0 ? `+${db}` : db}
+          </text>
+        </g>
+      ))}
+      <path className="eqm-fill" d={fill} />
+      <path className="eqm-line" d={path} />
+      {config.bands.map((band, i) => (
+        <circle
+          key={i}
+          className={"eqm-dot" + (i === selected ? " sel" : "")}
+          cx={fxToX(freqToX(band.freq_hz))}
+          cy={gainless(band) ? zeroY : dbToY(band.gain_db)}
+          r={i === selected ? 8 : 6}
+          onPointerDown={(e) => {
+            e.preventDefault();
+            onSelect(i);
+            dragIndex.current = i;
+          }}
+          onDoubleClick={() => onBandChange(i, { gain_db: 0 })}
+          onWheel={(e) => {
+            // Scroll tightens/widens the band (Q, or slope on shelves).
+            const dir = e.deltaY > 0 ? -1 : 1;
+            const q = Math.max(0.1, Math.min(10, band.q * (dir > 0 ? 1.12 : 1 / 1.12)));
+            onBandChange(i, { q: Math.round(q * 100) / 100 });
+          }}
+        >
+          <title>{`${Math.round(band.freq_hz)} Hz, ${band.gain_db.toFixed(1)} dB — drag to move, scroll for width, double-click to zero`}</title>
+        </circle>
+      ))}
+    </svg>
+  );
+}

--- a/src/components/Eq/EqModal.tsx
+++ b/src/components/Eq/EqModal.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { useMixerStore } from "../../store/mixer";
+import type { EqBand, EqConfig, VirtualSink } from "../../types";
+import { defaultEqConfig, MAX_EQ_BANDS } from "../../types";
+import { Modal } from "../Modal";
+import { Ms } from "../Icons";
+import { Toggle } from "../Toggle";
+import { DspSlider } from "../Mic/DspSlider";
+import { EqBandRow } from "./EqBandRow";
+import { EqCurve } from "./EqCurve";
+
+interface EqModalProps {
+  channel: VirtualSink;
+  open: boolean;
+  onClose: () => void;
+}
+
+/** Per-channel parametric EQ editor: response curve, band list, preamp. */
+export function EqModal({ channel, open, onClose }: EqModalProps) {
+  const config = useMixerStore(
+    (s) => s.eqConfigs[channel.name] ?? null,
+  ) ?? defaultEqConfig();
+  const setChannelEq = useMixerStore((s) => s.setChannelEq);
+  const backendNative = useMixerStore((s) => s.backendNative);
+  const [selected, setSelected] = useState(0);
+
+  const apply = (next: EqConfig) => void setChannelEq(channel.name, next);
+
+  const patchBand = (index: number, patch: Partial<EqBand>) => {
+    const bands = config.bands.map((b, i) => (i === index ? { ...b, ...patch } : b));
+    apply({ ...config, bands });
+  };
+
+  const addBand = () => {
+    if (config.bands.length >= MAX_EQ_BANDS) return;
+    const bands = [...config.bands, { kind: "peaking" as const, freq_hz: 1000, gain_db: 0, q: 1 }];
+    apply({ ...config, bands });
+    setSelected(bands.length - 1);
+  };
+
+  const removeBand = (index: number) => {
+    if (config.bands.length <= 1) return;
+    const bands = config.bands.filter((_, i) => i !== index);
+    apply({ ...config, bands });
+    setSelected(Math.min(selected, bands.length - 1));
+  };
+
+  const reset = () => {
+    // Back to the flat starting layout; the enable switch is left alone.
+    apply({ ...defaultEqConfig(), enabled: config.enabled });
+    setSelected(0);
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={`${channel.label} — Equalizer`}
+      className="eqm-modal"
+    >
+      {backendNative === false && (
+        <p className="modal-text">
+          Parametric EQ requires the native PipeWire engine, which isn't
+          running on this system.
+        </p>
+      )}
+      <div className="eqm-head">
+        <div className="eqm-enable">
+          <Toggle
+            on={config.enabled}
+            onClick={() => apply({ ...config, enabled: !config.enabled })}
+          />
+          <span>{config.enabled ? "On" : "Off"}</span>
+        </div>
+        <button className="select" onClick={reset} title="Back to the flat 5-band layout">
+          <Ms name="restart_alt" style={{ fontSize: 15 }} />
+          <span>Reset</span>
+        </button>
+      </div>
+
+      <EqCurve
+        config={config}
+        selected={selected}
+        onSelect={setSelected}
+        onBandChange={patchBand}
+      />
+
+      <DspSlider
+        label="Preamp"
+        min={-24}
+        max={24}
+        step={0.5}
+        unit=" dB"
+        value={config.preamp_db}
+        defaultValue={0}
+        onChange={(v) => apply({ ...config, preamp_db: v })}
+      />
+
+      <div className="eqm-bands">
+        {config.bands.map((band, i) => (
+          <EqBandRow
+            key={i}
+            band={band}
+            selected={i === selected}
+            onSelect={() => setSelected(i)}
+            onChange={(patch) => patchBand(i, patch)}
+            onRemove={() => removeBand(i)}
+          />
+        ))}
+        {config.bands.length < MAX_EQ_BANDS && (
+          <button className="eqm-add" onClick={addBand}>
+            <Ms name="add" style={{ fontSize: 15 }} />
+            Add band
+          </button>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/Eq/EqModal.tsx
+++ b/src/components/Eq/EqModal.tsx
@@ -8,6 +8,7 @@ import { Toggle } from "../Toggle";
 import { DspSlider } from "../Mic/DspSlider";
 import { EqBandRow } from "./EqBandRow";
 import { EqCurve } from "./EqCurve";
+import { EqPresetMenu } from "./EqPresetMenu";
 
 interface EqModalProps {
   channel: VirtualSink;
@@ -23,6 +24,9 @@ export function EqModal({ channel, open, onClose }: EqModalProps) {
   const setChannelEq = useMixerStore((s) => s.setChannelEq);
   const backendNative = useMixerStore((s) => s.backendNative);
   const [selected, setSelected] = useState(0);
+
+  // Surface preset/import failures on the app's global error banner.
+  const setError = (message: string) => useMixerStore.setState({ error: message });
 
   const apply = (next: EqConfig) => void setChannelEq(channel.name, next);
 
@@ -72,10 +76,18 @@ export function EqModal({ channel, open, onClose }: EqModalProps) {
           />
           <span>{config.enabled ? "On" : "Off"}</span>
         </div>
-        <button className="select" onClick={reset} title="Back to the flat 5-band layout">
-          <Ms name="restart_alt" style={{ fontSize: 15 }} />
-          <span>Reset</span>
-        </button>
+        <div className="eqm-head-actions">
+          <EqPresetMenu
+            sinkName={channel.name}
+            config={config}
+            onApply={apply}
+            onError={setError}
+          />
+          <button className="select" onClick={reset} title="Back to the flat 5-band layout">
+            <Ms name="restart_alt" style={{ fontSize: 15 }} />
+            <span>Reset</span>
+          </button>
+        </div>
       </div>
 
       <EqCurve

--- a/src/components/Eq/EqPresetMenu.tsx
+++ b/src/components/Eq/EqPresetMenu.tsx
@@ -137,24 +137,21 @@ export function EqPresetMenu({ sinkName, config, onApply, onError }: EqPresetMen
         style={{ minWidth: 260 }}
       >
         {presets.map((entry) => (
-          <div
-            key={`${entry.source}:${entry.preset.name}`}
-            className="menu-item"
-            title={entry.preset.description ?? undefined}
-            onClick={() => applyPreset(entry)}
-          >
-            <Ms name={entry.source === "bundled" ? "verified" : "person"} />
-            <span>{entry.preset.name}</span>
+          <div key={`${entry.source}:${entry.preset.name}`} className="eqm-preset-row">
+            <button
+              className="menu-item eqm-preset-apply"
+              title={entry.preset.description ?? undefined}
+              onClick={() => applyPreset(entry)}
+            >
+              <Ms name={entry.source === "bundled" ? "verified" : "person"} />
+              <span>{entry.preset.name}</span>
+            </button>
             {entry.source === "user" && (
               <button
                 className="eqm-remove"
-                style={{ marginLeft: "auto" }}
                 title="Delete preset"
                 aria-label={`Delete preset ${entry.preset.name}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  void deletePreset(entry.preset.name);
-                }}
+                onClick={() => void deletePreset(entry.preset.name)}
               >
                 <Ms name="close" style={{ fontSize: 13 }} />
               </button>
@@ -207,15 +204,15 @@ export function EqPresetMenu({ sinkName, config, onApply, onError }: EqPresetMen
             </div>
           </div>
         ) : (
-          <div className="menu-item" onClick={() => setImporting(true)}>
+          <button className="menu-item eqm-menu-btn" onClick={() => setImporting(true)}>
             <Ms name="content_paste" />
             <span>Import (paste / AutoEq / file)</span>
-          </div>
+          </button>
         )}
-        <div className="menu-item" onClick={() => void exportToFile()}>
+        <button className="menu-item eqm-menu-btn" onClick={() => void exportToFile()}>
           <Ms name="download" />
           <span>Export to file…</span>
-        </div>
+        </button>
       </Popover>
     </div>
   );

--- a/src/components/Eq/EqPresetMenu.tsx
+++ b/src/components/Eq/EqPresetMenu.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
+import type { EqConfig } from "../../types";
+import { Ms } from "../Icons";
+import { Popover } from "../Popover";
+
+interface EqPresetEntry {
+  source: "bundled" | "user";
+  preset: {
+    schema: number;
+    name: string;
+    author?: string | null;
+    description?: string | null;
+    preamp_db: number;
+    bands: EqConfig["bands"];
+  };
+}
+
+interface EqPresetMenuProps {
+  sinkName: string;
+  config: EqConfig;
+  onApply: (config: EqConfig) => void;
+  onError: (message: string) => void;
+}
+
+/** Preset picker + import/export. Bundled presets ship inside the binary
+ *  (repo presets/eq/); user presets live in ~/.config/sink/eq_presets. */
+export function EqPresetMenu({ sinkName, config, onApply, onError }: EqPresetMenuProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [presets, setPresets] = useState<EqPresetEntry[]>([]);
+  const [saveName, setSaveName] = useState("");
+  const [importing, setImporting] = useState(false);
+  const [importText, setImportText] = useState("");
+
+  const refresh = () => {
+    invoke<EqPresetEntry[]>("list_eq_presets")
+      .then(setPresets)
+      .catch((e) => onError(String(e)));
+  };
+
+  useEffect(() => {
+    if (menuOpen) refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [menuOpen]);
+
+  const applyPreset = (entry: EqPresetEntry) => {
+    setMenuOpen(false);
+    // A preset carries bands + preamp; applying always switches the EQ on.
+    onApply({
+      enabled: true,
+      preamp_db: entry.preset.preamp_db,
+      bands: entry.preset.bands.map((b) => ({ ...b })),
+    });
+  };
+
+  const saveCurrent = async () => {
+    const name = saveName.trim();
+    if (!name) return;
+    try {
+      await invoke("save_user_eq_preset", { name, config });
+      setSaveName("");
+      refresh();
+    } catch (e) {
+      onError(String(e));
+    }
+  };
+
+  const applyImported = (imported: EqConfig) => {
+    // Imports parse to a disabled config (preview semantics); keep the
+    // channel's current on/off state so importing never surprises.
+    onApply({ ...imported, enabled: config.enabled });
+    setImporting(false);
+    setImportText("");
+    setMenuOpen(false);
+  };
+
+  const importPasted = async () => {
+    try {
+      applyImported(await invoke<EqConfig>("import_eq_config", { text: importText }));
+    } catch (e) {
+      onError(String(e));
+    }
+  };
+
+  const importFromFile = async () => {
+    try {
+      const path = await openDialog({
+        multiple: false,
+        filters: [{ name: "EQ preset", extensions: ["json", "txt"] }],
+      });
+      if (typeof path !== "string") return;
+      applyImported(await invoke<EqConfig>("import_eq_file", { path }));
+    } catch (e) {
+      onError(String(e));
+    }
+  };
+
+  const exportToFile = async () => {
+    try {
+      const path = await saveDialog({
+        defaultPath: `${sinkName.replace(/^sink_/, "")}-eq.json`,
+        filters: [{ name: "EQ preset", extensions: ["json"] }],
+      });
+      if (typeof path !== "string") return;
+      await invoke("export_channel_eq_to_file", { sinkName, path });
+      setMenuOpen(false);
+    } catch (e) {
+      onError(String(e));
+    }
+  };
+
+  const deletePreset = async (name: string) => {
+    try {
+      await invoke("delete_user_eq_preset", { name });
+      refresh();
+    } catch (e) {
+      onError(String(e));
+    }
+  };
+
+  return (
+    <div style={{ position: "relative" }}>
+      <button className="select" onClick={() => setMenuOpen((o) => !o)}>
+        <Ms name="library_music" style={{ fontSize: 15 }} />
+        <span>Presets</span>
+        <Ms name="expand_more" />
+      </button>
+      <Popover
+        open={menuOpen}
+        onClose={() => {
+          setMenuOpen(false);
+          setImporting(false);
+        }}
+        side="bottom"
+        align="end"
+        style={{ minWidth: 260 }}
+      >
+        {presets.map((entry) => (
+          <div
+            key={`${entry.source}:${entry.preset.name}`}
+            className="menu-item"
+            title={entry.preset.description ?? undefined}
+            onClick={() => applyPreset(entry)}
+          >
+            <Ms name={entry.source === "bundled" ? "verified" : "person"} />
+            <span>{entry.preset.name}</span>
+            {entry.source === "user" && (
+              <button
+                className="eqm-remove"
+                style={{ marginLeft: "auto" }}
+                title="Delete preset"
+                aria-label={`Delete preset ${entry.preset.name}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void deletePreset(entry.preset.name);
+                }}
+              >
+                <Ms name="close" style={{ fontSize: 13 }} />
+              </button>
+            )}
+          </div>
+        ))}
+
+        <div className="menu-sep" />
+        <div className="eqm-save-row">
+          <input
+            className="menu-input"
+            placeholder="Save current as…"
+            value={saveName}
+            maxLength={64}
+            onChange={(e) => setSaveName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void saveCurrent();
+            }}
+          />
+          <button
+            className="select"
+            disabled={!saveName.trim()}
+            onClick={() => void saveCurrent()}
+          >
+            <Ms name="save" style={{ fontSize: 15 }} />
+          </button>
+        </div>
+
+        <div className="menu-sep" />
+        {importing ? (
+          <div className="eqm-import">
+            <textarea
+              className="eqm-import-text"
+              placeholder={"Paste preset JSON or an AutoEq block:\nPreamp: -6.0 dB\nFilter 1: ON PK Fc 105 Hz Gain -2.4 dB Q 0.70"}
+              value={importText}
+              autoFocus
+              onChange={(e) => setImportText(e.target.value)}
+            />
+            <div className="eqm-import-btns">
+              <button
+                className="select"
+                disabled={!importText.trim()}
+                onClick={() => void importPasted()}
+              >
+                Import
+              </button>
+              <button className="select" onClick={() => void importFromFile()}>
+                From file…
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="menu-item" onClick={() => setImporting(true)}>
+            <Ms name="content_paste" />
+            <span>Import (paste / AutoEq / file)</span>
+          </div>
+        )}
+        <div className="menu-item" onClick={() => void exportToFile()}>
+          <Ms name="download" />
+          <span>Export to file…</span>
+        </div>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/MixerBoard/ChannelStrip.tsx
+++ b/src/components/MixerBoard/ChannelStrip.tsx
@@ -6,6 +6,7 @@ import { channelIcon, Ms, ICON_CHOICES } from "../Icons";
 import { Modal } from "../Modal";
 import { Popover } from "../Popover";
 import { perceptual, volToDb } from "../../lib/audio";
+import { EqModal } from "../Eq/EqModal";
 import { ChannelApps } from "./ChannelApps";
 import { Fader } from "./Fader";
 import { OutputSelect } from "./OutputSelect";
@@ -44,11 +45,14 @@ export function ChannelStrip({
   const monitoring = useMixerStore((s) => s.monitors[channel.name] ?? false);
   const toggleMonitor = useMixerStore((s) => s.toggleMonitor);
 
+  const eqEnabled = useMixerStore((s) => s.eqConfigs[channel.name]?.enabled ?? false);
+
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [pickingIcon, setPickingIcon] = useState(false);
   const [managingApps, setManagingApps] = useState(false);
+  const [editingEq, setEditingEq] = useState(false);
 
   const commitRename = () => {
     setEditing(false);
@@ -196,7 +200,17 @@ export function ChannelStrip({
         >
           <Ms name="headphones" style={{ fontSize: 16 }} />
         </button>
+        <button
+          className={"sbtn" + (eqEnabled ? " on-eq" : "")}
+          onClick={() => setEditingEq(true)}
+          aria-pressed={eqEnabled}
+          title="Equalizer"
+        >
+          <Ms name="tune" style={{ fontSize: 16 }} />
+        </button>
       </div>
+
+      <EqModal channel={channel} open={editingEq} onClose={() => setEditingEq(false)} />
 
       <OutputSelect
         compact

--- a/src/components/MixerBoard/OutputSelect.tsx
+++ b/src/components/MixerBoard/OutputSelect.tsx
@@ -24,6 +24,8 @@ interface OutputSelectProps {
   /** Compact footer style (channel strip) vs pill style (mixer top bar). */
   compact?: boolean;
   popoverStyle?: CSSProperties;
+  /** Tooltip for the pill (mixer top bar); compact builds its own. */
+  title?: string;
 }
 
 function deviceIcon(description: string): string {
@@ -43,6 +45,7 @@ export function OutputSelect({
   onChange,
   compact,
   popoverStyle,
+  title,
 }: OutputSelectProps) {
   const [open, setOpen] = useState(false);
   const outputDevices = useMixerStore((s) => s.outputDevices);
@@ -140,7 +143,7 @@ export function OutputSelect({
 
   return (
     <div style={{ position: "relative" }}>
-      <button className="out-pill" onClick={() => setOpen((o) => !o)}>
+      <button className="out-pill" onClick={() => setOpen((o) => !o)} title={title ?? label}>
         <Ms name={shown ? deviceIcon(shown.description) : "speaker_group"} />
         <span>{label}</span>
         <Ms name="expand_more" className="chev" />

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -7,11 +7,14 @@ export function Modal({
   onClose,
   title,
   children,
+  className,
 }: {
   open: boolean;
   onClose: () => void;
   title: string;
   children: ReactNode;
+  /** Extra class on the dialog (e.g. a width variant). */
+  className?: string;
 }) {
   useEffect(() => {
     if (!open) return;
@@ -26,7 +29,7 @@ export function Modal({
   return (
     <div className="modal-scrim" onClick={onClose}>
       <div
-        className="modal"
+        className={"modal" + (className ? ` ${className}` : "")}
         role="dialog"
         aria-label={title}
         onClick={(e) => e.stopPropagation()}

--- a/src/components/Settings/SettingsScreen.tsx
+++ b/src/components/Settings/SettingsScreen.tsx
@@ -13,6 +13,15 @@ interface DefaultDevices {
   input: string | null;
 }
 
+interface HeadsetStatus {
+  enabled: boolean;
+  tool_installed: boolean;
+  device_present: boolean;
+  connected: boolean;
+  model: string | null;
+  message: string | null;
+}
+
 type LabelStyle = "plain" | "suffix" | "prefix";
 
 const LABEL_STYLES: { value: LabelStyle; label: string; example: string }[] = [
@@ -85,6 +94,7 @@ export function SettingsScreen() {
   const [labelStyle, setLabelStyle] = useState<LabelStyle>("plain");
   const [labelStyleOpen, setLabelStyleOpen] = useState(false);
   const [confirmingReset, setConfirmingReset] = useState(false);
+  const [headset, setHeadset] = useState<HeadsetStatus | null>(null);
   const [error, setError] = useState<string | null>(null);
   const outputDevices = useMixerStore((s) => s.outputDevices);
   const inputDevices = useMixerStore((s) => s.inputDevices);
@@ -102,8 +112,20 @@ export function SettingsScreen() {
         setStartMinimized(p.start_minimized);
       })
       .catch(() => {});
+    void invoke<HeadsetStatus>("get_headset_status").then(setHeadset).catch(() => {});
     void getVersion().then(setVersion);
   }, []);
+
+  const toggleHeadset = async () => {
+    const next = !(headset?.enabled ?? false);
+    try {
+      const status = await invoke<HeadsetStatus>("set_headset_detection", { enabled: next });
+      setHeadset(status);
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    }
+  };
 
   const pickDefault = async (kind: "output" | "input", name: string) => {
     try {
@@ -239,6 +261,20 @@ export function SettingsScreen() {
               />
             </div>
           )}
+          <div className="row">
+            <div className="ricon">
+              <Ms name="headset_mic" />
+            </div>
+            <div className="rmain">
+              <div className="rtitle">SteelSeries headset detection</div>
+              <div className="rsub">
+                {headset?.enabled && headset.message
+                  ? headset.message
+                  : "Move audio to your speakers when a SteelSeries headset powers off but its dongle keeps the sink alive (needs headsetcontrol)"}
+              </div>
+            </div>
+            <Toggle on={headset?.enabled ?? false} onClick={() => void toggleHeadset()} />
+          </div>
         </div>
 
         <div className="section-label">About</div>

--- a/src/components/TitleBar/MasterOutput.tsx
+++ b/src/components/TitleBar/MasterOutput.tsx
@@ -1,0 +1,29 @@
+import { useMixerStore } from "../../store/mixer";
+import { OutputSelect } from "../MixerBoard/OutputSelect";
+
+/**
+ * Master output: sends every channel to one device in a single action
+ * (Sonar/Voicemeeter-style). The fast fix when a headset dies but its
+ * dongle keeps the sink alive - one pick moves all audio to the speakers,
+ * with no per-channel fiddling and no headset-specific detection.
+ */
+export function MasterOutput() {
+  const channels = useMixerStore((s) => s.channels);
+  const channelOutputs = useMixerStore((s) => s.channelOutputs);
+  const setAllOutputs = useMixerStore((s) => s.setAllOutputs);
+
+  if (channels.length === 0) return null;
+
+  // The output shared by every channel, or "mixed" when they differ.
+  const first = channelOutputs[channels[0].name] ?? null;
+  const allSame = channels.every((c) => (channelOutputs[c.name] ?? null) === first);
+
+  return (
+    <OutputSelect
+      value={allSame ? first : null}
+      mixed={!allSame}
+      onChange={(name) => void setAllOutputs(name)}
+      title="Send every channel to one output device"
+    />
+  );
+}

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -2,6 +2,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useMixerStore } from "../../store/mixer";
 import { Ms, SinkMark } from "../Icons";
 import { BalanceBar } from "../MixerBoard/BalanceBar";
+import { MasterOutput } from "./MasterOutput";
 import { ProfileMenu } from "./ProfileMenu";
 
 /**
@@ -31,6 +32,7 @@ export function TitleBar({ screen }: { screen: string }) {
       </div>
       <div data-tauri-drag-region className="hb-spacer" />
       <BalanceBar />
+      {screen === "Mixer" && <MasterOutput />}
       <ProfileMenu />
       <div className={"hb-status" + (error ? " err" : "")}>
         <span className="dot" />

--- a/src/lib/eqMath.test.ts
+++ b/src/lib/eqMath.test.ts
@@ -1,0 +1,54 @@
+// Pins the TS side of the hand-synced RBJ math (the Rust twin lives in
+// src-tauri/src/audio/pw_native/eq.rs with the same assertions).
+
+import { describe, expect, it } from "vitest";
+import { curvePoints, freqToX, magnitudeDb, xToFreq } from "./eqMath";
+import type { EqBand } from "../types";
+import { defaultEqConfig } from "../types";
+
+const band = (kind: EqBand["kind"], freq_hz: number, gain_db: number, q: number): EqBand => ({
+  kind,
+  freq_hz,
+  gain_db,
+  q,
+});
+
+describe("eqMath", () => {
+  it("peaking band matches its gain at the center frequency", () => {
+    const db = magnitudeDb([band("peaking", 1000, 6, 1)], 0, 1000);
+    expect(db).toBeCloseTo(6, 1);
+  });
+
+  it("peaking band is flat far from the center", () => {
+    const db = magnitudeDb([band("peaking", 1000, 12, 2)], 0, 60);
+    expect(Math.abs(db)).toBeLessThan(0.5);
+  });
+
+  it("low pass rolls off above the cutoff", () => {
+    const bands = [band("low_pass", 1000, 0, 0.71)];
+    expect(Math.abs(magnitudeDb(bands, 0, 100))).toBeLessThan(0.5);
+    expect(magnitudeDb(bands, 0, 8000)).toBeLessThan(-30);
+  });
+
+  it("a flat config is 0 dB everywhere", () => {
+    const config = defaultEqConfig();
+    for (const { db } of curvePoints(config, 32)) {
+      expect(Math.abs(db)).toBeLessThan(0.01);
+    }
+  });
+
+  it("preamp shifts the whole curve uniformly", () => {
+    const config = { ...defaultEqConfig(), preamp_db: -6 };
+    for (const { db } of curvePoints(config, 16)) {
+      expect(db).toBeCloseTo(-6, 3);
+    }
+  });
+
+  it("freqToX and xToFreq are inverses on the log axis", () => {
+    for (const freq of [20, 100, 1000, 10000, 20000]) {
+      expect(xToFreq(freqToX(freq))).toBeCloseTo(freq, 0);
+    }
+    expect(freqToX(20)).toBe(0);
+    expect(freqToX(20000)).toBe(1);
+  });
+});

--- a/src/lib/eqMath.ts
+++ b/src/lib/eqMath.ts
@@ -1,0 +1,156 @@
+// Frequency-response math for the EQ curve — a hand-synced mirror of the
+// RBJ designs in src-tauri/src/audio/pw_native/eq.rs. If a formula changes
+// on either side, change both; the parallel test suites pin the contract.
+
+import type { EqBand, EqBandKind, EqConfig } from "../types";
+import { EQ_FREQ_MAX_HZ, EQ_FREQ_MIN_HZ } from "../types";
+
+export interface Biquad {
+  b0: number;
+  b1: number;
+  b2: number;
+  a1: number;
+  a2: number;
+}
+
+/** RBJ Audio EQ Cookbook design (see eq.rs for the shared conventions:
+ *  shelves use q as slope S, low/high pass ignore gain). */
+export function biquadCoeffs(
+  kind: EqBandKind,
+  freqHz: number,
+  gainDb: number,
+  q: number,
+  sampleRate = 48000,
+): Biquad {
+  const freq = Math.min(Math.max(freqHz, 1), sampleRate * 0.49);
+  const safeQ = Math.max(q, 0.01);
+  const w0 = (2 * Math.PI * freq) / sampleRate;
+  const sinW0 = Math.sin(w0);
+  const cosW0 = Math.cos(w0);
+  const a = Math.pow(10, gainDb / 40);
+
+  let b0: number, b1: number, b2: number, a0: number, a1: number, a2: number;
+  switch (kind) {
+    case "peaking": {
+      const alpha = sinW0 / (2 * safeQ);
+      b0 = 1 + alpha * a;
+      b1 = -2 * cosW0;
+      b2 = 1 - alpha * a;
+      a0 = 1 + alpha / a;
+      a1 = -2 * cosW0;
+      a2 = 1 - alpha / a;
+      break;
+    }
+    case "low_shelf":
+    case "high_shelf": {
+      const s = safeQ;
+      const alpha =
+        (sinW0 / 2) * Math.sqrt(Math.max((a + 1 / a) * (1 / s - 1) + 2, 0));
+      const twoSqrtAAlpha = 2 * Math.sqrt(a) * alpha;
+      const ap1 = a + 1;
+      const am1 = a - 1;
+      if (kind === "low_shelf") {
+        b0 = a * (ap1 - am1 * cosW0 + twoSqrtAAlpha);
+        b1 = 2 * a * (am1 - ap1 * cosW0);
+        b2 = a * (ap1 - am1 * cosW0 - twoSqrtAAlpha);
+        a0 = ap1 + am1 * cosW0 + twoSqrtAAlpha;
+        a1 = -2 * (am1 + ap1 * cosW0);
+        a2 = ap1 + am1 * cosW0 - twoSqrtAAlpha;
+      } else {
+        b0 = a * (ap1 + am1 * cosW0 + twoSqrtAAlpha);
+        b1 = -2 * a * (am1 + ap1 * cosW0);
+        b2 = a * (ap1 + am1 * cosW0 - twoSqrtAAlpha);
+        a0 = ap1 - am1 * cosW0 + twoSqrtAAlpha;
+        a1 = 2 * (am1 - ap1 * cosW0);
+        a2 = ap1 - am1 * cosW0 - twoSqrtAAlpha;
+      }
+      break;
+    }
+    case "low_pass": {
+      const alpha = sinW0 / (2 * safeQ);
+      const oneMinusCos = 1 - cosW0;
+      b0 = oneMinusCos / 2;
+      b1 = oneMinusCos;
+      b2 = oneMinusCos / 2;
+      a0 = 1 + alpha;
+      a1 = -2 * cosW0;
+      a2 = 1 - alpha;
+      break;
+    }
+    case "high_pass": {
+      const alpha = sinW0 / (2 * safeQ);
+      const onePlusCos = 1 + cosW0;
+      b0 = onePlusCos / 2;
+      b1 = -onePlusCos;
+      b2 = onePlusCos / 2;
+      a0 = 1 + alpha;
+      a1 = -2 * cosW0;
+      a2 = 1 - alpha;
+      break;
+    }
+  }
+  return { b0: b0 / a0, b1: b1 / a0, b2: b2 / a0, a1: a1 / a0, a2: a2 / a0 };
+}
+
+/** |H(e^jw)| of one biquad at `freqHz`, in dB. */
+function biquadMagnitudeDb(c: Biquad, freqHz: number, sampleRate: number): number {
+  const w = (2 * Math.PI * freqHz) / sampleRate;
+  const numRe = c.b0 + c.b1 * Math.cos(w) + c.b2 * Math.cos(2 * w);
+  const numIm = -(c.b1 * Math.sin(w) + c.b2 * Math.sin(2 * w));
+  const denRe = 1 + c.a1 * Math.cos(w) + c.a2 * Math.cos(2 * w);
+  const denIm = -(c.a1 * Math.sin(w) + c.a2 * Math.sin(2 * w));
+  const mag = Math.sqrt(
+    (numRe * numRe + numIm * numIm) / (denRe * denRe + denIm * denIm),
+  );
+  return 20 * Math.log10(mag);
+}
+
+/** Combined response of the whole config (preamp + band cascade) at `freqHz`. */
+export function magnitudeDb(
+  bands: EqBand[],
+  preampDb: number,
+  freqHz: number,
+  sampleRate = 48000,
+): number {
+  let db = preampDb;
+  for (const band of bands) {
+    const c = biquadCoeffs(band.kind, band.freq_hz, band.gain_db, band.q, sampleRate);
+    db += biquadMagnitudeDb(c, freqHz, sampleRate);
+  }
+  return db;
+}
+
+/** Log-spaced response samples across the audible range, for the SVG path. */
+export function curvePoints(
+  config: EqConfig,
+  steps = 128,
+  sampleRate = 48000,
+): { freq: number; db: number }[] {
+  const logMin = Math.log10(EQ_FREQ_MIN_HZ);
+  const logMax = Math.log10(EQ_FREQ_MAX_HZ);
+  const points: { freq: number; db: number }[] = [];
+  for (let i = 0; i <= steps; i++) {
+    const freq = Math.pow(10, logMin + ((logMax - logMin) * i) / steps);
+    points.push({
+      freq,
+      db: magnitudeDb(config.bands, config.preamp_db, freq, sampleRate),
+    });
+  }
+  return points;
+}
+
+/** X position of a frequency on the log axis, as 0..1. */
+export function freqToX(freqHz: number): number {
+  const logMin = Math.log10(EQ_FREQ_MIN_HZ);
+  const logMax = Math.log10(EQ_FREQ_MAX_HZ);
+  const clamped = Math.min(Math.max(freqHz, EQ_FREQ_MIN_HZ), EQ_FREQ_MAX_HZ);
+  return (Math.log10(clamped) - logMin) / (logMax - logMin);
+}
+
+/** Inverse of freqToX. */
+export function xToFreq(x: number): number {
+  const logMin = Math.log10(EQ_FREQ_MIN_HZ);
+  const logMax = Math.log10(EQ_FREQ_MAX_HZ);
+  const t = Math.min(Math.max(x, 0), 1);
+  return Math.pow(10, logMin + (logMax - logMin) * t);
+}

--- a/src/store/mixer.test.ts
+++ b/src/store/mixer.test.ts
@@ -8,6 +8,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 import { useMixerStore } from "./mixer";
 import type { VirtualSink } from "../types";
+import { defaultEqConfig } from "../types";
 
 const channel = (name: string, volume = 100): VirtualSink => ({
   name,
@@ -97,5 +98,37 @@ describe("setLevels", () => {
   it("stores per-sink peaks", () => {
     useMixerStore.getState().setLevels({ sink_game: [0.5, 0.4] });
     expect(useMixerStore.getState().levels["sink_game"]).toEqual([0.5, 0.4]);
+  });
+});
+
+describe("setChannelEq", () => {
+  it("applies optimistically and debounces per channel", async () => {
+    const store = useMixerStore.getState();
+    const config = {
+      ...defaultEqConfig(),
+      enabled: true,
+    };
+
+    await store.setChannelEq("sink_game", { ...config, preamp_db: -2 });
+    await store.setChannelEq("sink_game", { ...config, preamp_db: -5 });
+    await store.setChannelEq("sink_chat", config);
+
+    // Optimistic: both channels reflect their latest config immediately…
+    expect(useMixerStore.getState().eqConfigs["sink_game"].preamp_db).toBe(-5);
+    expect(useMixerStore.getState().eqConfigs["sink_chat"].enabled).toBe(true);
+    // …but nothing has hit the backend yet (drag in progress).
+    expect(invoke).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    // One call per channel: sink_game's two edits collapsed into the last.
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenCalledWith("set_channel_eq", {
+      sinkName: "sink_game",
+      config: { ...config, preamp_db: -5 },
+    });
+    expect(invoke).toHaveBeenCalledWith("set_channel_eq", {
+      sinkName: "sink_chat",
+      config,
+    });
   });
 });

--- a/src/store/mixer.ts
+++ b/src/store/mixer.ts
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type {
   AppStream,
   BusDef,
+  EqConfig,
   MicConfig,
   OutputDevice,
   ProfileInfo,
@@ -56,6 +57,10 @@ interface MixerStore {
   setChannelFailover: (sinkName: string, enabled: boolean) => Promise<void>;
   /** Sonar-style "same device on all channels". */
   setAllOutputs: (outputName: string | null) => Promise<void>;
+  /** Channel -> parametric EQ (absent = never configured, i.e. default). */
+  eqConfigs: Record<string, EqConfig>;
+  fetchEq: () => Promise<void>;
+  setChannelEq: (sinkName: string, config: EqConfig) => Promise<void>;
   /** Mic chain (Phase 3). Null until loaded. */
   micConfig: MicConfig | null;
   inputDevices: OutputDevice[];
@@ -246,6 +251,7 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
         get().fetchAppStreams(),
         get().fetchProfiles(),
         get().fetchOutputs(),
+        get().fetchEq(),
         get().fetchMic(),
         get().fetchBuses(),
       ]);
@@ -400,6 +406,27 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
     }
   },
 
+  eqConfigs: {},
+
+  fetchEq: async () => {
+    try {
+      const eqConfigs = await invoke<Record<string, EqConfig>>("get_channel_eq_configs");
+      if (!jsonEqual(get().eqConfigs, eqConfigs)) set({ eqConfigs });
+    } catch (e) {
+      set({ error: String(e) });
+    }
+  },
+
+  setChannelEq: async (sinkName, config) => {
+    set({ eqConfigs: { ...get().eqConfigs, [sinkName]: config } });
+    // Debounced per channel: a band drag settles into one apply, and two
+    // open EQ panels never clobber each other's pending call.
+    debouncedInvoke(`eq:${sinkName}`, "set_channel_eq", { sinkName, config }, (e) => {
+      set({ error: String(e) });
+      void get().fetchEq();
+    });
+  },
+
   fetchMic: async () => {
     try {
       const [micConfig, inputDevices] = await Promise.all([
@@ -448,6 +475,7 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
       get().fetchChannels(),
       get().fetchAppStreams(),
       get().fetchOutputs(),
+      get().fetchEq(),
       get().fetchSeenApps(),
       get().fetchProfiles(),
       get().fetchBuses(),
@@ -522,6 +550,7 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
         get().fetchChannels(),
         get().fetchAppStreams(),
         get().fetchOutputs(),
+        get().fetchEq(),
         get().fetchSeenApps(),
         get().fetchBuses(),
       ]);
@@ -704,6 +733,7 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
         get().fetchChannels(),
         get().fetchAppStreams(),
         get().fetchOutputs(),
+        get().fetchEq(), // the channel's EQ entry is gone too
         get().fetchBuses(), // memberships dropped the channel
       ]);
     } catch (e) {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1923,3 +1923,40 @@ body,
   color: var(--fg-primary);
   border-color: var(--fg-secondary);
 }
+.eqm-head-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+.eqm-save-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: 4px 6px;
+}
+.eqm-save-row .menu-input {
+  flex: 1;
+  min-width: 0;
+}
+.eqm-import {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  padding: 4px 6px;
+}
+.eqm-import-text {
+  width: 100%;
+  min-height: 84px;
+  resize: vertical;
+  padding: 6px;
+  border-radius: var(--r-sm);
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+  color: var(--fg-primary);
+  font-family: inherit;
+  font-size: 11px;
+}
+.eqm-import-btns {
+  display: flex;
+  gap: var(--sp-1);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1771,3 +1771,155 @@ body,
 .row.row-sub .ricon {
   opacity: 0.7;
 }
+
+/* ---- Parametric EQ modal (eqm-) ---- */
+.sbtn.on-eq {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--on-accent);
+}
+.modal.eqm-modal {
+  width: min(640px, calc(100vw - 48px));
+}
+.eqm-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
+.eqm-enable {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--fs-meta);
+  color: var(--fg-secondary);
+}
+.eqm-curve {
+  width: 100%;
+  height: auto;
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  touch-action: none;
+}
+.eqm-curve.off {
+  opacity: 0.45;
+}
+.eqm-grid {
+  stroke: var(--border);
+  stroke-width: 1;
+}
+.eqm-grid.zero {
+  stroke: var(--fg-secondary);
+  opacity: 0.5;
+}
+.eqm-grid-label {
+  fill: var(--fg-secondary);
+  font-size: 9px;
+  font-family: inherit;
+  user-select: none;
+}
+.eqm-line {
+  fill: none;
+  stroke: var(--accent-hover);
+  stroke-width: 2;
+}
+.eqm-fill {
+  fill: var(--accent-light);
+  stroke: none;
+}
+.eqm-dot {
+  fill: var(--bg-surface);
+  stroke: var(--accent-hover);
+  stroke-width: 2;
+  cursor: grab;
+}
+.eqm-dot.sel {
+  fill: var(--accent);
+  stroke: var(--accent-hover);
+}
+.eqm-bands {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  max-height: 220px;
+  overflow-y: auto;
+}
+.eqm-band {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: 4px var(--sp-2);
+  border-radius: var(--r-sm);
+  border: 1px solid transparent;
+}
+.eqm-band.sel {
+  border-color: var(--border);
+  background: var(--bg-surface-hover);
+}
+.eqm-kind {
+  flex: 1;
+  min-width: 0;
+  height: 26px;
+  padding: 0 var(--sp-2);
+  border-radius: var(--r-sm);
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+  color: var(--fg-primary);
+  font-family: inherit;
+  font-size: var(--fs-meta);
+}
+.eqm-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  color: var(--fg-secondary);
+}
+.eqm-field input {
+  width: 62px;
+  height: 26px;
+  padding: 0 6px;
+  border-radius: var(--r-sm);
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+  color: var(--fg-primary);
+  font-family: inherit;
+  font-size: var(--fs-meta);
+}
+.eqm-field input:disabled {
+  opacity: 0.4;
+}
+.eqm-remove {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-sm);
+  border: none;
+  background: transparent;
+  color: var(--fg-secondary);
+  cursor: pointer;
+}
+.eqm-remove:hover {
+  background: var(--bg-active);
+  color: var(--danger);
+}
+.eqm-add {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  align-self: flex-start;
+  padding: 5px var(--sp-3);
+  border-radius: var(--r-sm);
+  border: 1px dashed var(--border);
+  background: transparent;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--fs-meta);
+}
+.eqm-add:hover {
+  color: var(--fg-primary);
+  border-color: var(--fg-secondary);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1960,3 +1960,25 @@ body,
   display: flex;
   gap: var(--sp-1);
 }
+/* menu-item as a real button (a11y): strip UA button chrome, keep the
+   menu look; the row wrapper hosts the apply button + a delete sibling
+   so no button ever nests inside another. */
+.eqm-preset-row {
+  display: flex;
+  align-items: center;
+}
+.eqm-preset-row .eqm-remove {
+  margin-left: auto;
+  margin-right: 4px;
+}
+button.menu-item {
+  width: 100%;
+  background: none;
+  border: none;
+  font-family: inherit;
+  text-align: left;
+}
+.eqm-preset-apply {
+  flex: 1;
+  min-width: 0;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,6 +68,55 @@ export const MIC_DSP_DEFAULTS = {
   limiter_ceiling_db: -1,
 } as const;
 
+/** Parametric EQ band shapes (mirrors Rust EqBandKind). */
+export type EqBandKind =
+  | "peaking"
+  | "low_shelf"
+  | "high_shelf"
+  | "low_pass"
+  | "high_pass";
+
+/** One parametric EQ band (mirrors Rust EqBand). */
+export interface EqBand {
+  kind: EqBandKind;
+  freq_hz: number;
+  /** Ignored by low_pass/high_pass. */
+  gain_db: number;
+  /** Peaking/LP/HP: filter Q. Shelves: RBJ shelf slope. */
+  q: number;
+}
+
+/** A channel's parametric EQ (mirrors Rust EqConfig). */
+export interface EqConfig {
+  enabled: boolean;
+  /** Headroom trim applied before the band cascade (dB). */
+  preamp_db: number;
+  bands: EqBand[];
+}
+
+export const MAX_EQ_BANDS = 10;
+export const EQ_GAIN_RANGE_DB = 24;
+export const EQ_FREQ_MIN_HZ = 20;
+export const EQ_FREQ_MAX_HZ = 20000;
+
+/** The Sonar-style starting layout (mirrors Rust default_eq_bands). */
+export const DEFAULT_EQ_BANDS: EqBand[] = [
+  { kind: "low_shelf", freq_hz: 100, gain_db: 0, q: 0.71 },
+  { kind: "peaking", freq_hz: 500, gain_db: 0, q: 1 },
+  { kind: "peaking", freq_hz: 1500, gain_db: 0, q: 1 },
+  { kind: "peaking", freq_hz: 5000, gain_db: 0, q: 1 },
+  { kind: "high_shelf", freq_hz: 10000, gain_db: 0, q: 0.71 },
+];
+
+/** A channel's EQ when it has never been configured. */
+export function defaultEqConfig(): EqConfig {
+  return {
+    enabled: false,
+    preamp_db: 0,
+    bands: DEFAULT_EQ_BANDS.map((b) => ({ ...b })),
+  };
+}
+
 /** App history entry (mirrors Rust SeenApp). */
 export interface SeenApp {
   match_prop: string;


### PR DESCRIPTION
handles the headset-powered-off-but-dongle-still-present case (the kneggon report).

- master output control in the mixer header, moves every channel to one device in one pick. works for any headset, no dependencies
- opt-in steelseries detection in settings: polls headsetcontrol and fails audio over to the speakers when the headset powers off but the dongle keeps the sink alive. off by default, conservative parsing so a weird status never yanks audio off a working headset

note: the eq feature was split out to #18 so it can land first; this one sits on dev-pipeline until the steelseries path gets real hardware testing. once #18 merges, the diff here shrinks to just the headset work.