### PR TITLE
install docs: lead with the aur + copr repos, trim the arch readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,24 @@ processed virtual microphone for voice chat.
 
 ## Install
 
-Grab the latest from [Releases](https://github.com/NC1107/sink/releases).
+**Arch / Manjaro / EndeavourOS** - from the [AUR](https://aur.archlinux.org/packages/sink-bin):
+
+```bash
+yay -S sink-bin      # or: paru -S sink-bin
+```
+
+**Fedora** - from [COPR](https://copr.fedorainfracloud.org/coprs/nc1107/sink/):
+
+```bash
+sudo dnf copr enable nc1107/sink
+sudo dnf install sink
+```
+
+Both track new releases, so you update through your package manager like any
+other package.
+
+Otherwise, grab the latest from [Releases](https://github.com/NC1107/sink/releases)
+and install the file directly:
 
 **Fedora / openSUSE**
 
@@ -59,10 +76,10 @@ sudo apt install ./sink_*_amd64.deb
 sudo pacman -U ./sink-bin-*-x86_64.pkg.tar.zst
 ```
 
-All three install the app properly — launcher entry, icon, uninstall
+These install the app properly - launcher entry, icon, uninstall
 through your package manager.
 
-**Any other distro — AppImage (portable, no root)**
+**Any other distro - AppImage (portable, no root)**
 
 ```bash
 chmod +x sink_*_amd64.AppImage

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -1,42 +1,11 @@
 # Arch packaging
 
-`sink-bin` is the Arch package for Sink.
-It repackages the official release `.deb` rather than building from source.
+`PKGBUILD` is the Arch package for Sink, `sink-bin`.
+It repackages the release `.deb` (no source build), so it installs with system PipeWire and webkit2gtk and no toolchain.
 
-The `.deb` already lays files out under `/usr` and links against system PipeWire and webkit2gtk, so Arch users get a normally integrated install (launcher entry, icon, `pacman` uninstall) with no build toolchain and no bundled libraries.
+The `archpkg` job in `.github/workflows/release.yml` stamps it with each release's version and `.deb` checksum, builds it with `makepkg`, and attaches the `.pkg.tar.zst` to the release.
+It is also on the [AUR](https://aur.archlinux.org/packages/sink-bin) (account `nc1107`).
 
-## How the pipeline works
+Install: `yay -S sink-bin` (or `paru -S sink-bin`), or `sudo pacman -U` the `.pkg.tar.zst` from a release.
 
-The `archpkg` job in `.github/workflows/release.yml` runs after every release:
-
-1. Builds the package in an `archlinux:latest` container with `makepkg`.
-2. Stamps the version and the real `sha256` of the released `.deb` into `PKGBUILD`.
-3. Attaches the resulting `sink-bin-<version>-x86_64.pkg.tar.zst` to the GitHub release.
-
-No AUR account is required: the prebuilt package is installed directly with `pacman -U`.
-
-## Installing (for users)
-
-Download `sink-bin-*-x86_64.pkg.tar.zst` from the release and install it:
-
-```bash
-sudo pacman -U ./sink-bin-*-x86_64.pkg.tar.zst
-```
-
-Uninstall with `sudo pacman -R sink-bin`.
-
-## Building it yourself
-
-On any Arch machine, with the `PKGBUILD` and a real release version:
-
-```bash
-sed -i 's/^pkgver=.*/pkgver=0.1.15/' PKGBUILD   # an existing release
-updpkgsums
-makepkg -si
-```
-
-## Publishing to the AUR later
-
-The same `PKGBUILD` is AUR-ready.
-AUR account registration was disabled when this was set up, so the package is shipped on the release instead.
-When registration reopens, create the `sink-bin` AUR package and push this `PKGBUILD` (plus a generated `.SRCINFO`); the build job can then publish on each release too.
+New AUR version: push an updated `PKGBUILD` + regenerated `.SRCINFO` (`makepkg --printsrcinfo`) to `ssh://aur@aur.archlinux.org/sink-bin.git`.


### PR DESCRIPTION
now that sink is on both the aur (sink-bin) and fedora copr (nc1107/sink), this updates the docs so people actually find them.

- root README install section now leads with the two repo installs, since they auto-update through the package manager:
  - arch: yay -S sink-bin
  - fedora: dnf copr enable nc1107/sink && dnf install sink
  the direct .rpm/.deb/.pkg downloads stay below as the no-repo option, appimage after that
- trims the packaging/arch/README down (it was way too long and still said aur registration was disabled)
- fixed a couple stray em dashes in the install section while i was in there

docs only, based off main so it stays out of the dev branch.