### PR TITLE
per-channel parametric eq with shareable presets

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,9 +16,9 @@ jobs:
   check:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -28,7 +28,7 @@ jobs:
           toolchain: stable
           components: clippy
 
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           workspaces: .
 
@@ -53,9 +53,9 @@ jobs:
   bundles:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -64,7 +64,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           workspaces: .
 
@@ -88,7 +88,7 @@ jobs:
       - run: npm ci
       - run: npm run tauri build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: bundles
           path: |
@@ -102,9 +102,9 @@ jobs:
     steps:
       - run: pacman -Syu --noconfirm --needed base-devel
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: bundles
           path: bundles
@@ -145,7 +145,7 @@ jobs:
           echo "sink launched and stayed alive under xvfb"
           cp "$pkg" "$GITHUB_WORKSPACE/"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: sink-bin
           path: sink-bin-*-x86_64.pkg.tar.zst

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,11 @@ jobs:
       tag: ${{ steps.ver.outputs.tag }}
       prerelease: ${{ steps.ver.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -42,7 +42,7 @@ jobs:
           toolchain: stable
           components: clippy
 
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           workspaces: .
 
@@ -185,7 +185,7 @@ jobs:
       - name: Install build tooling
         run: pacman -Syu --noconfirm --needed base-devel git github-cli
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Build and attach sink-bin
         env:
@@ -289,7 +289,7 @@ jobs:
       - name: Install tooling
         run: dnf -y install git copr-cli rpm-build rpmdevtools binutils tar gzip >/dev/null
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Publish sink to COPR
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,6 +2172,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.12.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2679,6 +2680,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2991,6 +3016,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "thiserror 2.0.18",
 ]
 
@@ -3360,6 +3386,64 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e126abc9e84e35cdfd01596140a73a1850cdb0df0a23acf0185776c30b469a6e"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -4417,6 +4501,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4448,11 +4541,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4486,6 +4596,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4496,6 +4612,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4510,10 +4632,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4528,6 +4662,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4538,6 +4678,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4552,6 +4698,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4562,6 +4714,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -59,9 +59,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "atk"
@@ -117,7 +117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "annotate-snippets",
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -126,7 +126,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -152,9 +152,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.1"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -215,9 +215,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 
 [[package]]
 name = "byteorder"
@@ -233,9 +233,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -246,7 +246,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
 ]
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "shlex 2.0.1",
@@ -370,16 +370,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -406,15 +400,6 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -455,7 +440,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -468,7 +453,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "libc",
 ]
@@ -493,18 +478,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -536,7 +521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -575,7 +560,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -586,14 +571,14 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "dbus"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
 dependencies = [
  "libc",
  "libdbus-sys",
@@ -606,7 +591,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -628,7 +612,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -668,7 +652,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -682,7 +666,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -705,7 +689,7 @@ checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -716,7 +700,7 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",
- "foldhash 0.2.0",
+ "foldhash",
  "html5ever",
  "precomputed-hash",
  "selectors",
@@ -782,14 +766,14 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embed-resource"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31a88c8d26de40ed18fe748c547845aa39de1db3afd958f8cb91579f3644bcb"
+checksum = "fbfdaacccebec3b28e4866b8973543c7647797db5ada1bdab552e48fe665fbbd"
 dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "vswhom",
  "winreg",
 ]
@@ -815,6 +799,16 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -866,12 +860,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -894,7 +882,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -952,7 +940,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1117,15 +1105,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1166,7 +1152,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1194,7 +1180,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1273,7 +1259,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1281,15 +1267,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1327,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1337,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1347,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1530,12 +1507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,9 +1586,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1692,18 +1663,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1735,16 +1705,10 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "serde",
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libappindicator"
@@ -1807,38 +1771,43 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libspa"
-version = "0.9.2"
-source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs?rev=v0.9.2#03301bc734c9f1d3fb7a064c072458ad00245133"
+version = "0.10.0"
+source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs?rev=v0.10.0#5dd5dfad56bb0987e4d63af3d6f397e4a132dd9d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "cc",
- "convert_case",
  "cookie-factory",
  "libc",
  "libspa-sys",
- "nix",
  "nom 8.0.0",
+ "rustix",
  "system-deps 7.0.8",
 ]
 
 [[package]]
 name = "libspa-sys"
-version = "0.9.2"
-source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs?rev=v0.9.2#03301bc734c9f1d3fb7a064c072458ad00245133"
+version = "0.10.0"
+source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs?rev=v0.10.0#5dd5dfad56bb0987e4d63af3d6f397e4a132dd9d"
 dependencies = [
  "bindgen",
  "cc",
  "system-deps 7.0.8",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1857,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "markup5ever"
@@ -1874,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -1911,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1932,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c"
+checksum = "1dd04e60bc0b07438a6771710ee1698f98f6ebbc7f89b61264af1563b8aeb878"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -1957,7 +1926,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -1980,18 +1949,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.12.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
 
 [[package]]
 name = "nom"
@@ -2046,7 +2003,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2065,7 +2022,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-core-foundation",
@@ -2078,7 +2035,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2099,7 +2056,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -2110,7 +2067,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2143,7 +2100,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2170,7 +2127,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -2183,7 +2140,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2194,7 +2151,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2206,7 +2163,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -2237,7 +2194,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -2352,7 +2309,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2372,24 +2329,21 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pipewire"
-version = "0.9.2"
-source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs?rev=v0.9.2#03301bc734c9f1d3fb7a064c072458ad00245133"
+version = "0.10.0"
+source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs?rev=v0.10.0#5dd5dfad56bb0987e4d63af3d6f397e4a132dd9d"
 dependencies = [
- "anyhow",
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "libc",
  "libspa",
  "libspa-sys",
- "nix",
- "once_cell",
  "pipewire-sys",
- "thiserror 2.0.18",
+ "rustix",
 ]
 
 [[package]]
 name = "pipewire-sys"
-version = "0.9.2"
-source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs?rev=v0.9.2#03301bc734c9f1d3fb7a064c072458ad00245133"
+version = "0.10.0"
+source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs?rev=v0.10.0#5dd5dfad56bb0987e4d63af3d6f397e4a132dd9d"
 dependencies = [
  "bindgen",
  "libspa-sys",
@@ -2404,9 +2358,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
@@ -2434,7 +2388,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2463,16 +2417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2498,7 +2442,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -2536,24 +2480,24 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2582,7 +2526,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2613,14 +2557,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2630,9 +2574,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2641,9 +2585,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -2705,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2719,10 +2663,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.22"
+name = "rustix"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -2781,7 +2738,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2796,7 +2753,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "cssparser",
  "derive_more",
  "log",
@@ -2858,7 +2815,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2869,7 +2826,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2893,7 +2850,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2916,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -2936,14 +2893,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2965,7 +2922,7 @@ checksum = "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3002,9 +2959,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "sink"
@@ -3034,15 +2991,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3155,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3181,7 +3138,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3206,7 +3163,7 @@ dependencies = [
  "cfg-expr 0.20.8",
  "heck 0.5.0",
  "pkg-config",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "version-compare",
 ]
 
@@ -3216,7 +3173,7 @@ version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "block2",
  "core-foundation",
  "core-graphics",
@@ -3258,7 +3215,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3275,9 +3232,9 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tauri"
-version = "2.11.2"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28"
+checksum = "667b20e2726d572dea2de7370da16e188eb06008faf9a92fab7cdc46791190b5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3328,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
+checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3349,9 +3306,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9"
+checksum = "08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -3365,7 +3322,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tauri-utils",
  "thiserror 2.0.18",
  "time",
@@ -3376,23 +3333,23 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924"
+checksum = "e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tauri-codegen",
  "tauri-utils",
 ]
 
 [[package]]
 name = "tauri-plugin"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e126abc9e84e35cdfd01596140a73a1850cdb0df0a23acf0185776c30b469a6e"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
 dependencies = [
  "anyhow",
  "glob",
@@ -3442,15 +3399,15 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "url",
 ]
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.2"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef"
+checksum = "b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8"
 dependencies = [
  "cookie",
  "dpi",
@@ -3473,9 +3430,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.2"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
+checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
@@ -3499,9 +3456,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
+checksum = "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887"
 dependencies = [
  "anyhow",
  "brotli",
@@ -3528,7 +3485,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -3543,17 +3500,16 @@ checksum = "cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6"
 dependencies = [
  "dunce",
  "embed-resource",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
 ]
 
 [[package]]
 name = "tendril"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
  "new_debug_unreachable",
- "utf-8",
 ]
 
 [[package]]
@@ -3582,7 +3538,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3593,17 +3549,16 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3613,15 +3568,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3639,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3654,9 +3609,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
 dependencies = [
  "bytes",
  "libc",
@@ -3708,9 +3663,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -3718,7 +3673,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3774,14 +3729,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3790,14 +3745,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3820,7 +3775,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -3865,9 +3820,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.23.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
+checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
 dependencies = [
  "crossbeam-channel",
  "dirs",
@@ -3963,12 +3918,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3994,12 +3943,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4007,11 +3950,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4076,27 +4019,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4107,9 +4041,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4117,9 +4051,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4127,46 +4061,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -4183,22 +4095,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.12.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4206,9 +4106,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -4282,7 +4182,7 @@ checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4409,7 +4309,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4420,7 +4320,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4738,9 +4638,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -4757,97 +4657,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.12.1",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -4922,9 +4734,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4939,7 +4751,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -4960,7 +4772,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -4994,11 +4806,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ processed virtual microphone for voice chat.
 - **Mixes** — recordable sources for OBS. Master Mix carries everything;
   custom mixes can carry "everything except music" and stay current as
   channels change. In OBS, add a mix as an audio input — not Desktop Audio.
+- **Equalizer** — per-channel parametric EQ (up to 10 bands) with a
+  draggable response curve, bundled community presets, and import/export
+  including AutoEq text blocks
 - **Microphone** — noise gate, compressor and limiter into a virtual mic
   you select in Discord or OBS. Pairs well with
   [NoiseTorch](https://github.com/noisetorch/NoiseTorch) on the input for

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "material-symbols": "^0.44.11",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1885,6 +1886,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,11 @@
         "@tauri-apps/cli": "^2",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
-        "@vitejs/plugin-react": "^4.3.4",
+        "@vitejs/plugin-react": "^6.0.3",
         "jsdom": "^29.1.1",
         "tailwindcss": "^4",
-        "typescript": "^5.6.3",
-        "vite": "^6",
+        "typescript": "^6.0.3",
+        "vite": "^8.1.5",
         "vitest": "^4.1.10"
       }
     },
@@ -79,288 +79,6 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
-      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
-      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.7"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
-      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
-      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -515,446 +233,38 @@
         "node": ">=20.19.0"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@exodus/bytes": {
@@ -1025,31 +335,39 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.0.tgz",
-      "integrity": "sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ]
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
     },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.0.tgz",
-      "integrity": "sha512-Bp3JpGP00Vu3f238ivRrjf7z3xSzVPXqCmaJYA9t2c+c8vKYvOzmXF7LkkeUalTEGd6cZcSWe+PFIP3Vy48fRg==",
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -1058,12 +376,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.0.tgz",
-      "integrity": "sha512-zaYIpr670mUmmZ1tVzUFplbQbG7h3Gugx3L5FoqhsC2m/YnLlR1a7zVLmXNPy+iY1tFPEbNG+HHBXZGyId0G5w==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -1072,12 +393,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.0.tgz",
-      "integrity": "sha512-+P49fvkv2dSoeevUW+lgZ/I2JHSsJCK1Lyjj7Cu6E4UHG4tS9XIefzIjo5qhgELjAclnen1rLzK2PMKJdo+Dyg==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -1086,26 +410,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.0.tgz",
-      "integrity": "sha512-l3FAAOyKJXH2ea6KNFN+MMgC/rnE94YGLXs2ehYqDcCoHt1DpvgWX75BhUJxN38XojP7Ul+4H8PRn7EdyqSDrw==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.0.tgz",
-      "integrity": "sha512-VokPN3TSctKj65cyCNPaUh4vMFA8awxOot/0sp+4J7ZlNRKQEhXhawqPwajoi8H5ZFt61i0ugZJuTKXBjGJ17Q==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -1114,12 +427,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.0.tgz",
-      "integrity": "sha512-DxH0P3wxm+Yzs/p3zrk9dw1rURu8p0Nv5+MRK/L7OtnLNg5rLZraSBFZ8iUXOd9f2BlhJyEpIZUH/emjq4UJ4g==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -1128,26 +444,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.0.tgz",
-      "integrity": "sha512-T6ZvMNe84kAz6TBWHC7hGAoEtzP1LWYw/AqayGWEF6uISt3Abk/st06LqRD9THd7Xz3NxzurUpzAuEAUbZf+nw==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.0.tgz",
-      "integrity": "sha512-q/4hzvQkDs8b4jIBab1pnLiiM0ayTZsN2amBFPDzuyZxjEd4wDwx0UJFYM3cOZzSf5Kw8fnWSprJzIBMkcR44Q==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1156,12 +461,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.0.tgz",
-      "integrity": "sha512-vvYWX3akdEAY6km+9wAqFDnk6pQsbJKVnj7xawcvs/+fdlYBGp+U+Qq/lLfpIxYIZvZLHMAKD9HLdacSx/r3dw==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
@@ -1170,40 +478,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.0.tgz",
-      "integrity": "sha512-DePa5cqOxDP/Zp0VOXpeWaGew5iIv5DXp9NYbzkX5PFQyWVX9184WCTh3hvr/7lhXo8ZVlbFLkz8+o/q1dU6gA==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.0.tgz",
-      "integrity": "sha512-LV8aWMB8UChglMCEzs7RkN0GsH29RJaLLqwm9fCIjlqwxQTiWAqNcc7wjBkH31hV0PU/yVxGYvrYsgfea2qw6g==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.0.tgz",
-      "integrity": "sha512-QoNSnwQtaeNu5grdBbsL0tt1uyl5EnS8DA8Mr3nluMXbhdQNyhN+G4tBax7VCdxLKj8YJ0/4OO9Ho84jMnJtKA==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
@@ -1212,54 +495,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.0.tgz",
-      "integrity": "sha512-/zZp5MKapIIApE8trN8qLGNSiRN9TUoaUZ1cmVu4XnVdd5LQLOXTtyi+vtfUbNnT3iyjzpPqYeKXmvJ+gJGYWw==",
-      "cpu": [
-        "ppc64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.0.tgz",
-      "integrity": "sha512-RbrzcD3aJ1k3UbtMRRBNwojdVVyXjuVAFTfn/xPa6EEl6GE9Sm/akPgFTb9aAC9pMKGJ6CtWxaGrqWcabH+ySg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.0.tgz",
-      "integrity": "sha512-ZF+onDsBso8PJf1XaG9lB+O9RnBpKGnY6OrzC4CSHrtC1jb6jWLTKK4bRqdoCXHd22gyr2hiYmEAm8Wns/BOCw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.0.tgz",
-      "integrity": "sha512-Atk0aSIk5Zx2Wuh9dgRQgLP0Koc8hOeYpbWryMXyk8G8/HmPkwPPkMqIIDhrXHHYqfUzSJA/I7IWSBv8xSmRBA==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
@@ -1268,12 +512,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.0.tgz",
-      "integrity": "sha512-0uMOcf3eZ5K+K4cYHkdxShFMPlPXCOdfDFEFn9dNYAEEd2cVvmOfH7zFgRVoDgmtQ1m9k5q7qfrHzyMAubKYUA==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
@@ -1282,12 +529,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.0.tgz",
-      "integrity": "sha512-mvFtE4A/t/7hRJ7X8Ozmu8FsIkAUat2nzl12pgU337BRmq87AQUJztwHz2Zv5/tjo9/C95E66CK03SI/ToEDJw==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
@@ -1296,26 +546,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.0.tgz",
-      "integrity": "sha512-z9b9+aTxvt8n2rNltMPvyaUfB8NJ+CVyOrGK/MdIKHx7B+lXmZpm/XbRsU7Rpf3fRqJ2uS6mBJiJveCtq8LHDg==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.0.tgz",
-      "integrity": "sha512-jXaXFqKMehsOc+g8R6oo33RRC6w07G9jDBxAE5eAKX7mOcCbZloYIPNhfG9Wl+P9O9IWHFO4OJgPi1Ml2qkt7w==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
@@ -1324,12 +563,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.0.tgz",
-      "integrity": "sha512-OXNWVFocS2IA4+QplhTZZ2a+8hPZR7T8KuozsNmJKK8y7cp83StHvGksfHzPG3wczWTczyWHVQuqeiTUbjiyBg==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -1338,26 +599,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.0.tgz",
-      "integrity": "sha512-AlAbNtBO637LxSldqV43z0FfXoGfl2TW1DgAg/bs7aQswFbDewz2SJm3BUhiGfbOVtW571xbc9p+REdxhyN/Eg==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.0.tgz",
-      "integrity": "sha512-QRSrQXyJ1M4tjNXdR0/G/IgV6lzfQQJYBjlWIEYkY2Xs86DRl/iEpQ4blMDjJxSl7n19eDKKXMg0AmuBVYy8pQ==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -1366,21 +616,17 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.0.tgz",
-      "integrity": "sha512-tkuFxhvKO/HlGd0VsINF6vHSYH8AF8W0TcNxKDK6JZmrehngFj78pToc8iemtnvwilDjs2G/qSzYFhe9U8q+fw==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -1897,49 +1143,15 @@
         "@tauri-apps/api": "^2.11.0"
       }
     },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/chai": {
@@ -1996,24 +1208,29 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/expect": {
@@ -2139,19 +1356,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.10.33",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
-      "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -2161,61 +1365,6 @@
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
-    },
-    "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -2269,24 +1418,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -2303,13 +1434,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.366",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.366.tgz",
-      "integrity": "sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.2",
@@ -2344,58 +1468,6 @@
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -2448,16 +1520,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/graceful-fs": {
@@ -2552,32 +1614,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/lightningcss": {
@@ -2853,16 +1889,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2886,17 +1912,10 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2910,16 +1929,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/obug": {
@@ -2964,9 +1973,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2977,9 +1986,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -3040,16 +2049,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3060,49 +2059,38 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.0.tgz",
-      "integrity": "sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g==",
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.9"
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.61.0",
-        "@rollup/rollup-android-arm64": "4.61.0",
-        "@rollup/rollup-darwin-arm64": "4.61.0",
-        "@rollup/rollup-darwin-x64": "4.61.0",
-        "@rollup/rollup-freebsd-arm64": "4.61.0",
-        "@rollup/rollup-freebsd-x64": "4.61.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.61.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.61.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.61.0",
-        "@rollup/rollup-linux-arm64-musl": "4.61.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.61.0",
-        "@rollup/rollup-linux-loong64-musl": "4.61.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.61.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.61.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.61.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.61.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.61.0",
-        "@rollup/rollup-linux-x64-gnu": "4.61.0",
-        "@rollup/rollup-linux-x64-musl": "4.61.0",
-        "@rollup/rollup-openbsd-x64": "4.61.0",
-        "@rollup/rollup-openharmony-arm64": "4.61.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.61.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.61.0",
-        "@rollup/rollup-win32-x64-gnu": "4.61.0",
-        "@rollup/rollup-win32-x64-msvc": "4.61.0",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/saxes": {
@@ -3125,16 +2113,6 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/siginfo": {
@@ -3286,10 +2264,18 @@
         "node": ">=20"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3310,56 +2296,24 @@
         "node": ">=20.18.1"
       }
     },
-    "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
-      }
-    },
     "node_modules/vite": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
-      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -3368,14 +2322,15 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -3384,13 +2339,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -3587,13 +2545,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/zustand": {
       "version": "5.0.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",
-        "material-symbols": "^0.44.11",
+        "material-symbols": "^0.45.8",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "zustand": "^5"
@@ -26,7 +26,7 @@
         "tailwindcss": "^4",
         "typescript": "^5.6.3",
         "vite": "^6",
-        "vitest": "^4.1.8"
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1390,49 +1390,49 @@
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
-      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.21.0",
-        "jiti": "^2.6.1",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.0"
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
-      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.0",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
-        "@tailwindcss/oxide-darwin-x64": "4.3.0",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
-      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
       "cpu": [
         "arm64"
       ],
@@ -1447,9 +1447,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
-      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
       "cpu": [
         "arm64"
       ],
@@ -1464,9 +1464,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
-      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
       "cpu": [
         "x64"
       ],
@@ -1481,9 +1481,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
-      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
       "cpu": [
         "x64"
       ],
@@ -1498,9 +1498,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
-      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
       "cpu": [
         "arm"
       ],
@@ -1515,9 +1515,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
-      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
       "cpu": [
         "arm64"
       ],
@@ -1532,9 +1532,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
-      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
       ],
@@ -1549,9 +1549,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
-      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
       "cpu": [
         "x64"
       ],
@@ -1566,9 +1566,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
-      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
       ],
@@ -1583,9 +1583,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
-      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -1601,11 +1601,11 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.10.0",
-        "@emnapi/runtime": "^1.10.0",
-        "@emnapi/wasi-threads": "^1.2.1",
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
         "@napi-rs/wasm-runtime": "^1.1.4",
-        "@tybys/wasm-util": "^0.10.1",
+        "@tybys/wasm-util": "^0.10.2",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1613,9 +1613,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
-      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -1630,9 +1630,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
-      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
       "cpu": [
         "x64"
       ],
@@ -1647,24 +1647,24 @@
       }
     },
     "node_modules/@tailwindcss/vite": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
-      "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/node": "4.3.0",
-        "@tailwindcss/oxide": "4.3.0",
-        "tailwindcss": "4.3.0"
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
-      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
+      "integrity": "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1672,9 +1672,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.2.tgz",
-      "integrity": "sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.4.tgz",
+      "integrity": "sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "bin": {
@@ -1688,23 +1688,23 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.11.2",
-        "@tauri-apps/cli-darwin-x64": "2.11.2",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.2",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.11.2",
-        "@tauri-apps/cli-linux-arm64-musl": "2.11.2",
-        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.2",
-        "@tauri-apps/cli-linux-x64-gnu": "2.11.2",
-        "@tauri-apps/cli-linux-x64-musl": "2.11.2",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.11.2",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.11.2",
-        "@tauri-apps/cli-win32-x64-msvc": "2.11.2"
+        "@tauri-apps/cli-darwin-arm64": "2.11.4",
+        "@tauri-apps/cli-darwin-x64": "2.11.4",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.4",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.4",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.4",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.4",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.4",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.4"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.2.tgz",
-      "integrity": "sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.4.tgz",
+      "integrity": "sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==",
       "cpu": [
         "arm64"
       ],
@@ -1719,9 +1719,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.2.tgz",
-      "integrity": "sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.4.tgz",
+      "integrity": "sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A==",
       "cpu": [
         "x64"
       ],
@@ -1736,9 +1736,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.2.tgz",
-      "integrity": "sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.4.tgz",
+      "integrity": "sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ==",
       "cpu": [
         "arm"
       ],
@@ -1753,9 +1753,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.2.tgz",
-      "integrity": "sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.4.tgz",
+      "integrity": "sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA==",
       "cpu": [
         "arm64"
       ],
@@ -1770,9 +1770,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.2.tgz",
-      "integrity": "sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.4.tgz",
+      "integrity": "sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==",
       "cpu": [
         "arm64"
       ],
@@ -1787,9 +1787,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.2.tgz",
-      "integrity": "sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.4.tgz",
+      "integrity": "sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1804,9 +1804,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.2.tgz",
-      "integrity": "sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.4.tgz",
+      "integrity": "sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==",
       "cpu": [
         "x64"
       ],
@@ -1821,9 +1821,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.2.tgz",
-      "integrity": "sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.4.tgz",
+      "integrity": "sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==",
       "cpu": [
         "x64"
       ],
@@ -1838,9 +1838,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.2.tgz",
-      "integrity": "sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.4.tgz",
+      "integrity": "sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==",
       "cpu": [
         "arm64"
       ],
@@ -1855,9 +1855,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.2.tgz",
-      "integrity": "sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.4.tgz",
+      "integrity": "sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA==",
       "cpu": [
         "ia32"
       ],
@@ -1872,9 +1872,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.2.tgz",
-      "integrity": "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.4.tgz",
+      "integrity": "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw==",
       "cpu": [
         "x64"
       ],
@@ -2017,16 +2017,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2035,13 +2035,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2062,9 +2062,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2075,13 +2075,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2089,14 +2089,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2105,9 +2105,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2115,13 +2115,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.10",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2312,9 +2312,9 @@
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.22.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.2.tgz",
-      "integrity": "sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==",
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2874,9 +2874,9 @@
       }
     },
     "node_modules/material-symbols": {
-      "version": "0.44.11",
-      "resolved": "https://registry.npmjs.org/material-symbols/-/material-symbols-0.44.11.tgz",
-      "integrity": "sha512-xYOSzQkoM54dANcCWaAHVayHTDGnhS7JjpE+UuI+xGzE9OLZd8VLuYp2nbVCvSj8gPDTscUHGBqvZoBAYMzYvw==",
+      "version": "0.45.8",
+      "resolved": "https://registry.npmjs.org/material-symbols/-/material-symbols-0.45.8.tgz",
+      "integrity": "sha512-1kpL3jl+/f6W34fmENPYMyftCmBNXUannoZ8XzlMsuEEFlIxesX+Z6ZCj2qSJGxzqwJ5yE/3x1XzVPsycieG2g==",
       "license": "Apache-2.0"
     },
     "node_modules/mdn-data": {
@@ -3176,9 +3176,9 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
-      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3417,19 +3417,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -3457,12 +3457,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "material-symbols": "^0.44.11",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "@tauri-apps/cli": "^2",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4",
-    "typescript": "^5.6.3",
-    "vite": "^6",
+    "typescript": "^6.0.3",
+    "vite": "^8.1.5",
     "vitest": "^4.1.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
-    "material-symbols": "^0.44.11",
+    "material-symbols": "^0.45.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "zustand": "^5"
@@ -29,6 +29,6 @@
     "tailwindcss": "^4",
     "typescript": "^5.6.3",
     "vite": "^6",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.10"
   }
 }

--- a/presets/eq/bass-boost.json
+++ b/presets/eq/bass-boost.json
@@ -1,0 +1,13 @@
+{
+  "schema": 1,
+  "name": "Bass Boost",
+  "author": "Sink",
+  "description": "Warm low-end lift for music, with headroom trimmed to match.",
+  "preamp_db": -4,
+  "bands": [
+    { "kind": "low_shelf", "freq_hz": 110, "gain_db": 6, "q": 0.71 },
+    { "kind": "peaking", "freq_hz": 250, "gain_db": 1.5, "q": 1.0 },
+    { "kind": "peaking", "freq_hz": 800, "gain_db": -1, "q": 1.2 },
+    { "kind": "high_shelf", "freq_hz": 9000, "gain_db": 1, "q": 0.71 }
+  ]
+}

--- a/presets/eq/flat.json
+++ b/presets/eq/flat.json
@@ -1,0 +1,14 @@
+{
+  "schema": 1,
+  "name": "Flat",
+  "author": "Sink",
+  "description": "The neutral 5-band starting point. Apply to undo any preset.",
+  "preamp_db": 0,
+  "bands": [
+    { "kind": "low_shelf", "freq_hz": 100, "gain_db": 0, "q": 0.71 },
+    { "kind": "peaking", "freq_hz": 500, "gain_db": 0, "q": 1.0 },
+    { "kind": "peaking", "freq_hz": 1500, "gain_db": 0, "q": 1.0 },
+    { "kind": "peaking", "freq_hz": 5000, "gain_db": 0, "q": 1.0 },
+    { "kind": "high_shelf", "freq_hz": 10000, "gain_db": 0, "q": 0.71 }
+  ]
+}

--- a/presets/eq/fps-footsteps.json
+++ b/presets/eq/fps-footsteps.json
@@ -1,0 +1,13 @@
+{
+  "schema": 1,
+  "name": "FPS Footsteps",
+  "author": "Sink",
+  "description": "Boosts the footstep band and tames explosions and rumble.",
+  "preamp_db": -3,
+  "bands": [
+    { "kind": "low_shelf", "freq_hz": 120, "gain_db": -4, "q": 0.71 },
+    { "kind": "peaking", "freq_hz": 2000, "gain_db": 2.5, "q": 1.0 },
+    { "kind": "peaking", "freq_hz": 4000, "gain_db": 4, "q": 1.4 },
+    { "kind": "high_shelf", "freq_hz": 8000, "gain_db": 1.5, "q": 0.71 }
+  ]
+}

--- a/presets/eq/vocal-clarity.json
+++ b/presets/eq/vocal-clarity.json
@@ -1,0 +1,13 @@
+{
+  "schema": 1,
+  "name": "Vocal Clarity",
+  "author": "Sink",
+  "description": "Presence lift for chat and podcasts; rumble rolled off.",
+  "preamp_db": -2,
+  "bands": [
+    { "kind": "high_pass", "freq_hz": 90, "gain_db": 0, "q": 0.71 },
+    { "kind": "peaking", "freq_hz": 2500, "gain_db": 3, "q": 1.0 },
+    { "kind": "peaking", "freq_hz": 5000, "gain_db": 2, "q": 1.4 },
+    { "kind": "high_shelf", "freq_hz": 10000, "gain_db": 1, "q": 0.71 }
+  ]
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,4 +24,4 @@ thiserror = "2"
 dirs = "6"
 # 0.8.0 on crates.io predates PipeWire 1.6 headers (libspa bindgen breaks);
 # git main carries the header fixes. v0_3_49 gates Buffer::requested().
-pipewire = { git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs", rev = "v0.9.2", features = ["v0_3_49"] }
+pipewire = { git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs", rev = "v0.10.0", features = ["v0_3_49"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,9 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png", "protocol-asset"] }
+# Native open/save pickers for EQ preset import/export; the file I/O itself
+# stays in our own commands (no fs plugin / scope surface needed).
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,49 @@
+use std::fmt::Write as _;
+use std::path::Path;
+
+/// Embed the community EQ presets (../presets/eq/*.json) into the binary:
+/// generate `OUT_DIR/eq_presets_generated.rs` with one include_str! per
+/// file. Compile-time embedding means zero packaging changes (the deb/rpm/
+/// AUR/COPR payloads stay identical) and presets can never be missing at
+/// runtime. Dropping a .json into presets/eq/ is picked up automatically.
+fn embed_eq_presets() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("cargo sets CARGO_MANIFEST_DIR");
+    let out_dir = std::env::var("OUT_DIR").expect("cargo sets OUT_DIR");
+    let presets_dir = Path::new(&manifest_dir).join("../presets/eq");
+    println!("cargo:rerun-if-changed={}", presets_dir.display());
+
+    let mut entries: Vec<(String, String)> = Vec::new();
+    if let Ok(dir) = std::fs::read_dir(&presets_dir) {
+        for entry in dir.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            println!("cargo:rerun-if-changed={}", path.display());
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default()
+                .to_string();
+            entries.push((stem, path.display().to_string()));
+        }
+    }
+    entries.sort();
+
+    let mut code = String::from(
+        "/// (file stem, raw JSON) of every bundled community EQ preset.\n\
+         pub static BUNDLED_EQ_PRESET_SOURCES: &[(&str, &str)] = &[\n",
+    );
+    for (stem, path) in &entries {
+        let _ = writeln!(code, "    ({stem:?}, include_str!({path:?})),");
+    }
+    code.push_str("];\n");
+
+    std::fs::write(Path::new(&out_dir).join("eq_presets_generated.rs"), code)
+        .expect("write eq presets codegen");
+}
+
 fn main() {
+    embed_eq_presets();
     tauri_build::build()
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,8 @@
     "core:window:allow-show",
     "core:window:allow-close",
     "core:window:allow-set-focus",
-    "core:window:allow-toggle-maximize"
+    "core:window:allow-toggle-maximize",
+    "dialog:allow-open",
+    "dialog:allow-save"
   ]
 }

--- a/src-tauri/src/audio/backend.rs
+++ b/src-tauri/src/audio/backend.rs
@@ -1,4 +1,4 @@
-use crate::audio::types::{AppStream, MicConfig, OutputDevice};
+use crate::audio::types::{AppStream, EqConfig, MicConfig, OutputDevice};
 use crate::error::SinkError;
 
 /// Abstraction over the underlying audio system.
@@ -41,6 +41,11 @@ pub trait AudioBackend: Send + Sync {
     fn set_channel_failover(&self, _sink_name: &str, _enabled: bool) -> Result<(), SinkError> {
         Ok(())
     }
+
+    /// Apply a channel's parametric EQ (insert/re-tune/remove the biquad
+    /// chain in the channel's output path). Native-only: the pactl fallback
+    /// has no in-graph insert point, mirroring `set_mic_config`.
+    fn set_channel_eq(&self, sink_name: &str, config: &EqConfig) -> Result<(), SinkError>;
 
     /// Per-channel resolved output: the `node.name` of the device each channel
     /// is actually routed to right now, after explicit/default/fallback

--- a/src-tauri/src/audio/eq_import.rs
+++ b/src-tauri/src/audio/eq_import.rs
@@ -1,0 +1,187 @@
+//! AutoEq text-format import. AutoEq (the community headphone-correction
+//! project) publishes parametric EQs as plain text:
+//!
+//! ```text
+//! Preamp: -6.0 dB
+//! Filter 1: ON PK Fc 105 Hz Gain -2.4 dB Q 0.70
+//! ```
+//!
+//! Tolerant token parsing, no regex: disabled and unrecognized filter
+//! lines are skipped (a partial import beats a hard failure over one
+//! exotic filter type); it errors only when nothing usable remains.
+
+use crate::audio::types::{EqBand, EqBandKind, EqConfig, MAX_EQ_BANDS};
+use crate::error::SinkError;
+
+fn kind_from_token(token: &str) -> Option<EqBandKind> {
+    match token {
+        "PK" | "PEQ" | "Modal" => Some(EqBandKind::Peaking),
+        "LS" | "LSC" => Some(EqBandKind::LowShelf),
+        "HS" | "HSC" => Some(EqBandKind::HighShelf),
+        "LP" | "LPQ" => Some(EqBandKind::LowPass),
+        "HP" | "HPQ" => Some(EqBandKind::HighPass),
+        _ => None,
+    }
+}
+
+/// Value following a `label` token (e.g. "Fc" -> 105.0 from "Fc 105 Hz").
+fn value_after(tokens: &[&str], label: &str) -> Option<f32> {
+    tokens
+        .iter()
+        .position(|t| t.eq_ignore_ascii_case(label))
+        .and_then(|i| tokens.get(i + 1))
+        .and_then(|v| v.parse().ok())
+}
+
+fn parse_filter_line(line: &str) -> Option<EqBand> {
+    // "Filter N: ON PK Fc 105 Hz Gain -2.4 dB Q 0.70"
+    let rest = line.split(':').nth(1)?.trim();
+    let tokens: Vec<&str> = rest.split_whitespace().collect();
+    if tokens.first().map(|t| t.eq_ignore_ascii_case("ON")) != Some(true) {
+        return None; // disabled ("OFF") or malformed
+    }
+    let kind = kind_from_token(tokens.get(1)?)?;
+    let freq_hz = value_after(&tokens, "Fc")?;
+    let gain_db = value_after(&tokens, "Gain").unwrap_or(0.0);
+    // Shelf lines in AutoEq's fixed-band output often omit Q.
+    let q = value_after(&tokens, "Q").unwrap_or(match kind {
+        EqBandKind::LowShelf | EqBandKind::HighShelf => 0.71,
+        _ => 1.0,
+    });
+    let mut band = EqBand {
+        kind,
+        freq_hz,
+        gain_db,
+        q,
+    };
+    band.clamp_ranges();
+    Some(band)
+}
+
+/// Parse an AutoEq result block into a (disabled, preview-ready) EqConfig.
+/// Keeps the first MAX_EQ_BANDS filters in file order — AutoEq emits them
+/// in descending importance already.
+pub fn parse_autoeq(text: &str) -> Result<EqConfig, SinkError> {
+    let mut preamp_db = 0.0f32;
+    let mut bands: Vec<EqBand> = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.to_ascii_lowercase().starts_with("preamp") {
+            if let Some(v) = line
+                .split(':')
+                .nth(1)
+                .and_then(|rest| rest.split_whitespace().next())
+                .and_then(|v| v.parse::<f32>().ok())
+            {
+                preamp_db = v;
+            }
+        } else if line.to_ascii_lowercase().starts_with("filter") && bands.len() < MAX_EQ_BANDS {
+            if let Some(band) = parse_filter_line(line) {
+                bands.push(band);
+            }
+        }
+    }
+    if bands.is_empty() {
+        return Err(SinkError::Parse(
+            "no usable filters found (expected AutoEq lines like \
+             'Filter 1: ON PK Fc 105 Hz Gain -2.4 dB Q 0.70')"
+                .into(),
+        ));
+    }
+    let mut config = EqConfig {
+        enabled: false,
+        preamp_db,
+        bands,
+    };
+    config.clamp_ranges();
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_preamp_and_peaking_filter() {
+        let config = parse_autoeq(
+            "Preamp: -6.0 dB\nFilter 1: ON PK Fc 105 Hz Gain -2.4 dB Q 0.70\n",
+        )
+        .expect("parses");
+        assert_eq!(config.preamp_db, -6.0);
+        assert_eq!(config.bands.len(), 1);
+        let b = &config.bands[0];
+        assert_eq!(b.kind, EqBandKind::Peaking);
+        assert_eq!(b.freq_hz, 105.0);
+        assert_eq!(b.gain_db, -2.4);
+        assert_eq!(b.q, 0.7);
+        assert!(!config.enabled, "imports preview disabled");
+    }
+
+    #[test]
+    fn skips_disabled_filters() {
+        let config = parse_autoeq(
+            "Filter 1: OFF PK Fc 100 Hz Gain 3.0 dB Q 1.0\n\
+             Filter 2: ON PK Fc 200 Hz Gain 1.0 dB Q 1.0\n",
+        )
+        .expect("parses");
+        assert_eq!(config.bands.len(), 1);
+        assert_eq!(config.bands[0].freq_hz, 200.0);
+    }
+
+    #[test]
+    fn maps_shelf_and_pass_abbreviations() {
+        let config = parse_autoeq(
+            "Filter 1: ON LSC Fc 105 Hz Gain 2.0 dB\n\
+             Filter 2: ON HSC Fc 10000 Hz Gain -1.0 dB Q 0.71\n\
+             Filter 3: ON HP Fc 80 Hz\n",
+        )
+        .expect("parses");
+        assert_eq!(config.bands[0].kind, EqBandKind::LowShelf);
+        assert_eq!(config.bands[0].q, 0.71, "shelf without Q gets the slope default");
+        assert_eq!(config.bands[1].kind, EqBandKind::HighShelf);
+        assert_eq!(config.bands[2].kind, EqBandKind::HighPass);
+    }
+
+    #[test]
+    fn skips_unknown_filter_kinds() {
+        let config = parse_autoeq(
+            "Filter 1: ON XYZ Fc 100 Hz Gain 3.0 dB Q 1.0\n\
+             Filter 2: ON PK Fc 200 Hz Gain 1.0 dB Q 1.0\n",
+        )
+        .expect("parses");
+        assert_eq!(config.bands.len(), 1);
+    }
+
+    #[test]
+    fn caps_at_max_bands_keeping_file_order() {
+        let mut text = String::from("Preamp: -1.0 dB\n");
+        for i in 1..=14 {
+            text.push_str(&format!(
+                "Filter {i}: ON PK Fc {} Hz Gain 1.0 dB Q 1.0\n",
+                i * 100
+            ));
+        }
+        let config = parse_autoeq(&text).expect("parses");
+        assert_eq!(config.bands.len(), MAX_EQ_BANDS);
+        assert_eq!(config.bands[0].freq_hz, 100.0, "first filters win");
+        assert_eq!(config.bands[9].freq_hz, 1000.0);
+    }
+
+    #[test]
+    fn errors_on_text_with_no_usable_filters() {
+        assert!(parse_autoeq("hello world").is_err());
+        assert!(parse_autoeq("Preamp: -3.0 dB\n").is_err());
+    }
+
+    #[test]
+    fn out_of_range_values_are_clamped() {
+        let config = parse_autoeq(
+            "Preamp: -80.0 dB\nFilter 1: ON PK Fc 99999 Hz Gain 80 dB Q 900\n",
+        )
+        .expect("parses");
+        assert_eq!(config.preamp_db, -24.0);
+        assert_eq!(config.bands[0].freq_hz, 20000.0);
+        assert_eq!(config.bands[0].gain_db, 24.0);
+        assert_eq!(config.bands[0].q, 10.0);
+    }
+}

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,5 +1,7 @@
 pub mod backend;
+pub mod eq_import;
 pub mod icons;
 pub mod pactl;
+pub mod presets;
 pub mod pw_native;
 pub mod types;

--- a/src-tauri/src/audio/pactl.rs
+++ b/src-tauri/src/audio/pactl.rs
@@ -331,6 +331,16 @@ impl AudioBackend for PactlBackend {
         ))
     }
 
+    fn set_channel_eq(
+        &self,
+        _sink_name: &str,
+        _config: &crate::audio::types::EqConfig,
+    ) -> Result<(), SinkError> {
+        Err(SinkError::Config(
+            "parametric EQ requires the native PipeWire backend".into(),
+        ))
+    }
+
     fn create_bus(&self, _name: &str, _label: &str) -> Result<(), SinkError> {
         Err(SinkError::Config(
             "mix buses require the native PipeWire backend".into(),

--- a/src-tauri/src/audio/presets.rs
+++ b/src-tauri/src/audio/presets.rs
@@ -1,0 +1,135 @@
+//! Community EQ presets: a versioned JSON schema, with the "community
+//! approved" set living in the repo's `presets/eq/` directory and embedded
+//! into the binary at build time (see build.rs).
+
+use serde::{Deserialize, Serialize};
+
+use crate::audio::types::{EqBand, EqConfig};
+
+/// The shareable preset file format (schema 1). Deliberately has no
+/// `enabled` flag: applying a preset sets bands + preamp and enables.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EqPreset {
+    pub schema: u32,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub preamp_db: f32,
+    pub bands: Vec<EqBand>,
+}
+
+pub const PRESET_SCHEMA: u32 = 1;
+
+impl EqPreset {
+    /// The channel config this preset applies (enabled, clamped).
+    pub fn to_config(&self) -> EqConfig {
+        let mut config = EqConfig {
+            enabled: true,
+            preamp_db: self.preamp_db,
+            bands: self.bands.clone(),
+        };
+        config.clamp_ranges();
+        config
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/eq_presets_generated.rs"));
+
+/// Parse one bundled source, or explain why it's unusable.
+fn parse_bundled(stem: &str, raw: &str) -> Result<EqPreset, String> {
+    let preset: EqPreset =
+        serde_json::from_str(raw).map_err(|e| format!("preset {stem}: {e}"))?;
+    if preset.schema != PRESET_SCHEMA {
+        return Err(format!(
+            "preset {stem}: unsupported schema {}",
+            preset.schema
+        ));
+    }
+    if preset.bands.is_empty() {
+        return Err(format!("preset {stem}: no bands"));
+    }
+    Ok(preset)
+}
+
+/// All bundled presets, sorted by name. Malformed entries are logged and
+/// skipped — defense in depth even though these ship inside the binary
+/// (a bad community PR must degrade one preset, not the whole menu).
+pub fn bundled_presets() -> Vec<EqPreset> {
+    let mut presets: Vec<EqPreset> = BUNDLED_EQ_PRESET_SOURCES
+        .iter()
+        .filter_map(|(stem, raw)| match parse_bundled(stem, raw) {
+            Ok(preset) => Some(preset),
+            Err(e) => {
+                eprintln!("sink: skipping bundled eq {e}");
+                None
+            }
+        })
+        .collect();
+    presets.sort_by(|a, b| a.name.cmp(&b.name));
+    presets
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio::types::EqBandKind;
+
+    #[test]
+    fn bundled_presets_parse_and_sort_by_name() {
+        let presets = bundled_presets();
+        assert!(
+            presets.iter().any(|p| p.name == "Flat"),
+            "the Flat reference preset must ship"
+        );
+        let names: Vec<&str> = presets.iter().map(|p| p.name.as_str()).collect();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+        for p in &presets {
+            assert_eq!(p.schema, PRESET_SCHEMA);
+            assert!(!p.bands.is_empty());
+        }
+    }
+
+    #[test]
+    fn flat_preset_is_numerically_flat() {
+        let presets = bundled_presets();
+        let flat = presets.iter().find(|p| p.name == "Flat").expect("shipped");
+        assert_eq!(flat.preamp_db, 0.0);
+        assert!(flat.bands.iter().all(|b| b.gain_db == 0.0));
+    }
+
+    #[test]
+    fn malformed_bundled_entry_is_skipped_not_panicked() {
+        assert!(parse_bundled("bad", "{not json").is_err());
+        assert!(parse_bundled("bad", r#"{"schema":2,"name":"x","bands":[]}"#).is_err());
+        assert!(
+            parse_bundled("bad", r#"{"schema":1,"name":"x","bands":[]}"#).is_err(),
+            "zero bands is rejected"
+        );
+    }
+
+    #[test]
+    fn to_config_enables_and_clamps() {
+        let preset = EqPreset {
+            schema: 1,
+            name: "Hot".into(),
+            author: None,
+            description: None,
+            preamp_db: -99.0,
+            bands: vec![EqBand {
+                kind: EqBandKind::Peaking,
+                freq_hz: 90000.0,
+                gain_db: 4.0,
+                q: 1.0,
+            }],
+        };
+        let config = preset.to_config();
+        assert!(config.enabled);
+        assert_eq!(config.preamp_db, -24.0);
+        assert_eq!(config.bands[0].freq_hz, 20000.0);
+    }
+}

--- a/src-tauri/src/audio/pw_native/eq.rs
+++ b/src-tauri/src/audio/pw_native/eq.rs
@@ -1,0 +1,530 @@
+//! Per-channel parametric EQ core: RBJ Audio EQ Cookbook biquads in a
+//! cascade of up to MAX_EQ_BANDS, preceded by a preamp trim.
+//!
+//! Pure Rust, no external DSP crates (same stance as the mic chain in
+//! `dsp.rs`). The frequency-response math is hand-mirrored in
+//! `src/lib/eqMath.ts` for the UI curve — keep both in sync.
+//!
+//! Threading model: the command thread writes band parameters into
+//! `EqParams` (plain atomics) and bumps a generation counter with Release
+//! ordering; the RT capture callback owns an `EqEngine` and redesigns its
+//! coefficients only when an Acquire load of the generation sees a change.
+//! Coefficient design (a few sin/cos) off the hot path per *change*, not
+//! per buffer, and never a lock on the RT thread.
+
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering};
+
+use crate::audio::types::{EqBand, EqBandKind, EqConfig, MAX_EQ_BANDS};
+
+/// Biquad transfer-function coefficients, normalized so a0 == 1.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BiquadCoeffs {
+    pub b0: f32,
+    pub b1: f32,
+    pub b2: f32,
+    pub a1: f32,
+    pub a2: f32,
+}
+
+impl BiquadCoeffs {
+    /// Pass-through (unity) filter.
+    pub fn identity() -> Self {
+        Self {
+            b0: 1.0,
+            b1: 0.0,
+            b2: 0.0,
+            a1: 0.0,
+            a2: 0.0,
+        }
+    }
+
+    /// RBJ Audio EQ Cookbook design. For shelves, `q` is the shelf slope S
+    /// (not a resonance Q) — the schema shares one field for both, see
+    /// `EqBand::q`. LowPass/HighPass ignore `gain_db`.
+    pub fn design(kind: EqBandKind, freq_hz: f32, gain_db: f32, q: f32, sample_rate: f32) -> Self {
+        // Guard the math: freq must sit below Nyquist and q must be
+        // positive. Config-level clamps enforce this for real input; this
+        // is the last line of defense against a divide-by-zero.
+        let freq = freq_hz.clamp(1.0, sample_rate * 0.49);
+        let q = q.max(0.01);
+        let w0 = 2.0 * std::f32::consts::PI * freq / sample_rate;
+        let (sin_w0, cos_w0) = w0.sin_cos();
+        let a = 10.0f32.powf(gain_db / 40.0);
+
+        let (b0, b1, b2, a0, a1, a2) = match kind {
+            EqBandKind::Peaking => {
+                let alpha = sin_w0 / (2.0 * q);
+                (
+                    1.0 + alpha * a,
+                    -2.0 * cos_w0,
+                    1.0 - alpha * a,
+                    1.0 + alpha / a,
+                    -2.0 * cos_w0,
+                    1.0 - alpha / a,
+                )
+            }
+            EqBandKind::LowShelf | EqBandKind::HighShelf => {
+                // Shelf slope form: alpha from S, the cookbook's
+                // "shelf slope" parameterization.
+                let s = q;
+                let alpha =
+                    sin_w0 / 2.0 * ((a + 1.0 / a) * (1.0 / s - 1.0) + 2.0).max(0.0).sqrt();
+                let two_sqrt_a_alpha = 2.0 * a.sqrt() * alpha;
+                let (ap1, am1) = (a + 1.0, a - 1.0);
+                if kind == EqBandKind::LowShelf {
+                    (
+                        a * (ap1 - am1 * cos_w0 + two_sqrt_a_alpha),
+                        2.0 * a * (am1 - ap1 * cos_w0),
+                        a * (ap1 - am1 * cos_w0 - two_sqrt_a_alpha),
+                        ap1 + am1 * cos_w0 + two_sqrt_a_alpha,
+                        -2.0 * (am1 + ap1 * cos_w0),
+                        ap1 + am1 * cos_w0 - two_sqrt_a_alpha,
+                    )
+                } else {
+                    (
+                        a * (ap1 + am1 * cos_w0 + two_sqrt_a_alpha),
+                        -2.0 * a * (am1 + ap1 * cos_w0),
+                        a * (ap1 + am1 * cos_w0 - two_sqrt_a_alpha),
+                        ap1 - am1 * cos_w0 + two_sqrt_a_alpha,
+                        2.0 * (am1 - ap1 * cos_w0),
+                        ap1 - am1 * cos_w0 - two_sqrt_a_alpha,
+                    )
+                }
+            }
+            EqBandKind::LowPass => {
+                let alpha = sin_w0 / (2.0 * q);
+                let b1 = 1.0 - cos_w0;
+                (
+                    b1 / 2.0,
+                    b1,
+                    b1 / 2.0,
+                    1.0 + alpha,
+                    -2.0 * cos_w0,
+                    1.0 - alpha,
+                )
+            }
+            EqBandKind::HighPass => {
+                let alpha = sin_w0 / (2.0 * q);
+                let b1 = 1.0 + cos_w0;
+                (
+                    b1 / 2.0,
+                    -b1,
+                    b1 / 2.0,
+                    1.0 + alpha,
+                    -2.0 * cos_w0,
+                    1.0 - alpha,
+                )
+            }
+        };
+
+        Self {
+            b0: b0 / a0,
+            b1: b1 / a0,
+            b2: b2 / a0,
+            a1: a1 / a0,
+            a2: a2 / a0,
+        }
+    }
+}
+
+/// Per-channel filter memory (transposed direct form II: two states, good
+/// numerical behavior at f32).
+#[derive(Debug, Default, Clone, Copy)]
+struct BiquadState {
+    z1: f32,
+    z2: f32,
+}
+
+impl BiquadState {
+    #[inline]
+    fn process(&mut self, x: f32, c: &BiquadCoeffs) -> f32 {
+        let y = c.b0 * x + self.z1;
+        self.z1 = c.b1 * x - c.a1 * y + self.z2;
+        self.z2 = c.b2 * x - c.a2 * y;
+        y
+    }
+}
+
+const KIND_PEAKING: u8 = 0;
+const KIND_LOW_SHELF: u8 = 1;
+const KIND_HIGH_SHELF: u8 = 2;
+const KIND_LOW_PASS: u8 = 3;
+const KIND_HIGH_PASS: u8 = 4;
+
+fn kind_to_u8(kind: EqBandKind) -> u8 {
+    match kind {
+        EqBandKind::Peaking => KIND_PEAKING,
+        EqBandKind::LowShelf => KIND_LOW_SHELF,
+        EqBandKind::HighShelf => KIND_HIGH_SHELF,
+        EqBandKind::LowPass => KIND_LOW_PASS,
+        EqBandKind::HighPass => KIND_HIGH_PASS,
+    }
+}
+
+fn kind_from_u8(v: u8) -> EqBandKind {
+    match v {
+        KIND_LOW_SHELF => EqBandKind::LowShelf,
+        KIND_HIGH_SHELF => EqBandKind::HighShelf,
+        KIND_LOW_PASS => EqBandKind::LowPass,
+        KIND_HIGH_PASS => EqBandKind::HighPass,
+        _ => EqBandKind::Peaking,
+    }
+}
+
+struct AtomicBand {
+    kind: AtomicU8,
+    freq_bits: AtomicU32,
+    gain_bits: AtomicU32,
+    q_bits: AtomicU32,
+}
+
+impl AtomicBand {
+    fn flat() -> Self {
+        Self {
+            kind: AtomicU8::new(KIND_PEAKING),
+            freq_bits: AtomicU32::new(1000.0f32.to_bits()),
+            gain_bits: AtomicU32::new(0.0f32.to_bits()),
+            q_bits: AtomicU32::new(1.0f32.to_bits()),
+        }
+    }
+
+    fn store(&self, band: &EqBand) {
+        self.kind.store(kind_to_u8(band.kind), Ordering::Relaxed);
+        self.freq_bits
+            .store(band.freq_hz.to_bits(), Ordering::Relaxed);
+        self.gain_bits
+            .store(band.gain_db.to_bits(), Ordering::Relaxed);
+        self.q_bits.store(band.q.to_bits(), Ordering::Relaxed);
+    }
+
+    fn load(&self) -> EqBand {
+        EqBand {
+            kind: kind_from_u8(self.kind.load(Ordering::Relaxed)),
+            freq_hz: f32::from_bits(self.freq_bits.load(Ordering::Relaxed)),
+            gain_db: f32::from_bits(self.gain_bits.load(Ordering::Relaxed)),
+            q: f32::from_bits(self.q_bits.load(Ordering::Relaxed)),
+        }
+    }
+}
+
+/// Live-tunable EQ parameters shared with the RT capture callback.
+///
+/// Single writer (the loop thread handling commands), single reader (the RT
+/// callback). Field writes are Relaxed; the trailing Release bump of
+/// `generation` publishes them all to the reader's Acquire load — no locks,
+/// no retries, and torn *intermediate* states are impossible because the
+/// reader only redesigns after seeing a new generation.
+pub struct EqParams {
+    enabled: AtomicBool,
+    preamp_bits: AtomicU32,
+    band_count: AtomicUsize,
+    bands: [AtomicBand; MAX_EQ_BANDS],
+    generation: AtomicU64,
+}
+
+impl EqParams {
+    pub fn from_config(config: &EqConfig) -> Self {
+        let p = Self {
+            enabled: AtomicBool::new(false),
+            preamp_bits: AtomicU32::new(0.0f32.to_bits()),
+            band_count: AtomicUsize::new(0),
+            bands: std::array::from_fn(|_| AtomicBand::flat()),
+            generation: AtomicU64::new(0),
+        };
+        p.apply(config);
+        p
+    }
+
+    /// Publish a new config to the RT reader (command thread only).
+    pub fn apply(&self, config: &EqConfig) {
+        let count = config.bands.len().min(MAX_EQ_BANDS);
+        for (slot, band) in self.bands.iter().zip(config.bands.iter()) {
+            slot.store(band);
+        }
+        self.band_count.store(count, Ordering::Relaxed);
+        self.enabled.store(config.enabled, Ordering::Relaxed);
+        self.preamp_bits
+            .store(config.preamp_db.to_bits(), Ordering::Relaxed);
+        self.generation.fetch_add(1, Ordering::Release);
+    }
+
+    fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+}
+
+/// The RT-side processor: owns coefficient + filter state, refreshed from
+/// `EqParams` when the generation changes or the sample rate renegotiates.
+pub struct EqEngine {
+    sample_rate: f32,
+    /// u64::MAX = "must refresh" sentinel (set on rate change / creation).
+    seen_generation: u64,
+    enabled: bool,
+    preamp_linear: f32,
+    coeffs: [BiquadCoeffs; MAX_EQ_BANDS],
+    count: usize,
+    /// Per band, per stereo channel. A rate change resets filter memory —
+    /// accepted, same as the mic chain rebuilding DspChain on rate change.
+    state: [[BiquadState; 2]; MAX_EQ_BANDS],
+}
+
+impl EqEngine {
+    pub fn new(sample_rate: f32) -> Self {
+        Self {
+            sample_rate: sample_rate.max(1.0),
+            seen_generation: u64::MAX,
+            enabled: false,
+            preamp_linear: 1.0,
+            coeffs: [BiquadCoeffs::identity(); MAX_EQ_BANDS],
+            count: 0,
+            state: [[BiquadState::default(); 2]; MAX_EQ_BANDS],
+        }
+    }
+
+    /// Coefficients are frequency-relative, so a renegotiated rate forces a
+    /// redesign on the next process() even if the params are unchanged.
+    pub fn set_sample_rate(&mut self, sample_rate: f32) {
+        if sample_rate > 0.0 && sample_rate != self.sample_rate {
+            self.sample_rate = sample_rate;
+            self.seen_generation = u64::MAX;
+            self.state = [[BiquadState::default(); 2]; MAX_EQ_BANDS];
+        }
+    }
+
+    fn refresh(&mut self, params: &EqParams) {
+        let generation = params.generation();
+        if generation == self.seen_generation {
+            return;
+        }
+        self.seen_generation = generation;
+        self.enabled = params.enabled.load(Ordering::Relaxed);
+        let preamp_db = f32::from_bits(params.preamp_bits.load(Ordering::Relaxed));
+        self.preamp_linear = 10.0f32.powf(preamp_db / 20.0);
+        self.count = params.band_count.load(Ordering::Relaxed).min(MAX_EQ_BANDS);
+        for i in 0..self.count {
+            let band = params.bands[i].load();
+            self.coeffs[i] =
+                BiquadCoeffs::design(band.kind, band.freq_hz, band.gain_db, band.q, self.sample_rate);
+        }
+    }
+
+    /// Process an interleaved stereo buffer in place. Pass-through when the
+    /// config is disabled (the chain is normally torn down on disable; this
+    /// covers the window between a disable apply() and the relink).
+    pub fn process_interleaved(&mut self, buf: &mut [f32], params: &EqParams) {
+        self.refresh(params);
+        if !self.enabled {
+            return;
+        }
+        for frame in buf.chunks_exact_mut(2) {
+            for (ch, sample) in frame.iter_mut().enumerate() {
+                let mut x = *sample * self.preamp_linear;
+                for i in 0..self.count {
+                    x = self.state[i][ch].process(x, &self.coeffs[i]);
+                }
+                *sample = x;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Analytic magnitude response |H(e^jw)| in dB — exact, no time-domain
+    /// sampling artifacts. This is the same formula the UI curve uses
+    /// (src/lib/eqMath.ts), so these tests also pin the shared math.
+    fn measured_gain_db(c: &BiquadCoeffs, freq: f32, sample_rate: f32) -> f32 {
+        let w = 2.0 * std::f64::consts::PI * f64::from(freq) / f64::from(sample_rate);
+        let (b0, b1, b2) = (f64::from(c.b0), f64::from(c.b1), f64::from(c.b2));
+        let (a1, a2) = (f64::from(c.a1), f64::from(c.a2));
+        let num_re = b0 + b1 * w.cos() + b2 * (2.0 * w).cos();
+        let num_im = -(b1 * w.sin() + b2 * (2.0 * w).sin());
+        let den_re = 1.0 + a1 * w.cos() + a2 * (2.0 * w).cos();
+        let den_im = -(a1 * w.sin() + a2 * (2.0 * w).sin());
+        let mag = ((num_re * num_re + num_im * num_im) / (den_re * den_re + den_im * den_im))
+            .sqrt();
+        (20.0 * mag.log10()) as f32
+    }
+
+    fn config(bands: Vec<EqBand>, preamp_db: f32) -> EqConfig {
+        EqConfig {
+            enabled: true,
+            preamp_db,
+            bands,
+        }
+    }
+
+    fn band(kind: EqBandKind, freq_hz: f32, gain_db: f32, q: f32) -> EqBand {
+        EqBand {
+            kind,
+            freq_hz,
+            gain_db,
+            q,
+        }
+    }
+
+    const SR: f32 = 48000.0;
+
+    #[test]
+    fn identity_passes_signal_unchanged() {
+        let c = BiquadCoeffs::identity();
+        let mut state = BiquadState::default();
+        for x in [0.0f32, 1.0, -0.5, 0.25] {
+            assert_eq!(state.process(x, &c), x);
+        }
+    }
+
+    #[test]
+    fn peaking_matches_gain_at_center_freq() {
+        let c = BiquadCoeffs::design(EqBandKind::Peaking, 1000.0, 6.0, 1.0, SR);
+        let g = measured_gain_db(&c, 1000.0, SR);
+        assert!((g - 6.0).abs() < 0.3, "expected ~+6 dB at center, got {g}");
+    }
+
+    #[test]
+    fn peaking_is_flat_far_from_center() {
+        let c = BiquadCoeffs::design(EqBandKind::Peaking, 1000.0, 12.0, 2.0, SR);
+        let g = measured_gain_db(&c, 60.0, SR);
+        assert!(g.abs() < 0.5, "expected ~0 dB two+ octaves away, got {g}");
+    }
+
+    #[test]
+    fn low_shelf_boosts_below_corner_flat_above() {
+        let c = BiquadCoeffs::design(EqBandKind::LowShelf, 200.0, 6.0, 0.71, SR);
+        let low = measured_gain_db(&c, 40.0, SR);
+        let high = measured_gain_db(&c, 4000.0, SR);
+        assert!((low - 6.0).abs() < 0.5, "low end should be ~+6 dB, got {low}");
+        assert!(high.abs() < 0.5, "high end should be flat, got {high}");
+    }
+
+    #[test]
+    fn high_shelf_boosts_above_corner_flat_below() {
+        let c = BiquadCoeffs::design(EqBandKind::HighShelf, 5000.0, -6.0, 0.71, SR);
+        let low = measured_gain_db(&c, 200.0, SR);
+        let high = measured_gain_db(&c, 15000.0, SR);
+        assert!(low.abs() < 0.5, "low end should be flat, got {low}");
+        assert!((high + 6.0).abs() < 0.6, "high end should be ~-6 dB, got {high}");
+    }
+
+    #[test]
+    fn low_pass_attenuates_above_cutoff() {
+        let c = BiquadCoeffs::design(EqBandKind::LowPass, 1000.0, 0.0, 0.71, SR);
+        let pass = measured_gain_db(&c, 100.0, SR);
+        let stop = measured_gain_db(&c, 8000.0, SR);
+        assert!(pass.abs() < 0.5, "passband should be flat, got {pass}");
+        assert!(stop < -30.0, "stopband should be strongly attenuated, got {stop}");
+    }
+
+    #[test]
+    fn high_pass_attenuates_below_cutoff() {
+        let c = BiquadCoeffs::design(EqBandKind::HighPass, 1000.0, 0.0, 0.71, SR);
+        let stop = measured_gain_db(&c, 100.0, SR);
+        let pass = measured_gain_db(&c, 8000.0, SR);
+        assert!(stop < -30.0, "stopband should be strongly attenuated, got {stop}");
+        assert!(pass.abs() < 0.5, "passband should be flat, got {pass}");
+    }
+
+    #[test]
+    fn params_apply_then_engine_refresh_picks_up_bands() {
+        let params = EqParams::from_config(&config(
+            vec![band(EqBandKind::Peaking, 2000.0, 4.0, 1.5)],
+            -3.0,
+        ));
+        let mut engine = EqEngine::new(SR);
+        engine.refresh(&params);
+        assert!(engine.enabled);
+        assert_eq!(engine.count, 1);
+        assert!((engine.preamp_linear - 10.0f32.powf(-3.0 / 20.0)).abs() < 1e-6);
+        let expected = BiquadCoeffs::design(EqBandKind::Peaking, 2000.0, 4.0, 1.5, SR);
+        assert_eq!(engine.coeffs[0], expected);
+
+        // A second apply with different bands is picked up on next refresh.
+        params.apply(&config(vec![band(EqBandKind::HighPass, 80.0, 0.0, 0.71)], 0.0));
+        engine.refresh(&params);
+        assert_eq!(engine.count, 1);
+        let expected = BiquadCoeffs::design(EqBandKind::HighPass, 80.0, 0.0, 0.71, SR);
+        assert_eq!(engine.coeffs[0], expected);
+    }
+
+    #[test]
+    fn set_sample_rate_forces_recompute_at_new_rate() {
+        let params = EqParams::from_config(&config(
+            vec![band(EqBandKind::Peaking, 2000.0, 4.0, 1.5)],
+            0.0,
+        ));
+        let mut engine = EqEngine::new(48000.0);
+        engine.refresh(&params);
+        let at_48k = engine.coeffs[0];
+        engine.set_sample_rate(96000.0);
+        engine.refresh(&params);
+        assert_ne!(engine.coeffs[0], at_48k);
+        assert_eq!(
+            engine.coeffs[0],
+            BiquadCoeffs::design(EqBandKind::Peaking, 2000.0, 4.0, 1.5, 96000.0)
+        );
+    }
+
+    #[test]
+    fn preamp_is_linear_multiply_before_cascade() {
+        let params = EqParams::from_config(&config(vec![], 6.0));
+        let mut engine = EqEngine::new(SR);
+        let mut buf = vec![0.5f32, -0.5, 0.25, -0.25];
+        engine.process_interleaved(&mut buf, &params);
+        let expected = 10.0f32.powf(6.0 / 20.0);
+        assert!((buf[0] - 0.5 * expected).abs() < 1e-6);
+        assert!((buf[1] + 0.5 * expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn disabled_config_passes_through_untouched() {
+        let mut cfg = config(vec![band(EqBandKind::Peaking, 1000.0, 12.0, 1.0)], 12.0);
+        cfg.enabled = false;
+        let params = EqParams::from_config(&cfg);
+        let mut engine = EqEngine::new(SR);
+        let original = vec![0.5f32, -0.5, 0.25, -0.25];
+        let mut buf = original.clone();
+        engine.process_interleaved(&mut buf, &params);
+        assert_eq!(buf, original);
+    }
+
+    #[test]
+    fn cascade_of_ten_flat_bands_is_still_flat() {
+        let bands: Vec<EqBand> = (0..MAX_EQ_BANDS)
+            .map(|i| band(EqBandKind::Peaking, 100.0 * (i as f32 + 1.0) * 2.0, 0.0, 1.0))
+            .collect();
+        let params = EqParams::from_config(&config(bands, 0.0));
+        let mut engine = EqEngine::new(SR);
+        // A 1 kHz sine through ten 0 dB bands should come out at unity.
+        let mut buf: Vec<f32> = (0..2000)
+            .flat_map(|n| {
+                let s = (2.0 * std::f32::consts::PI * 1000.0 * n as f32 / SR).sin() * 0.5;
+                [s, s]
+            })
+            .collect();
+        let peak_in = 0.5f32;
+        engine.process_interleaved(&mut buf, &params);
+        let peak_out = buf[2000..].iter().fold(0.0f32, |m, s| m.max(s.abs()));
+        assert!(
+            (peak_out - peak_in).abs() < 0.01,
+            "flat cascade drifted: in {peak_in}, out {peak_out}"
+        );
+    }
+
+    #[test]
+    fn stereo_channels_are_processed_independently() {
+        // A DC-blocking high-pass fed L=DC, R=silence must not bleed.
+        let params = EqParams::from_config(&config(
+            vec![band(EqBandKind::HighPass, 500.0, 0.0, 0.71)],
+            0.0,
+        ));
+        let mut engine = EqEngine::new(SR);
+        let mut buf: Vec<f32> = (0..2000).flat_map(|_| [1.0f32, 0.0]).collect();
+        engine.process_interleaved(&mut buf, &params);
+        let right_energy: f32 = buf.iter().skip(1).step_by(2).map(|s| s.abs()).sum();
+        assert_eq!(right_energy, 0.0, "silent right channel picked up energy");
+        let left_tail = buf[3000..].iter().step_by(2).fold(0.0f32, |m, s| m.max(s.abs()));
+        assert!(left_tail < 0.01, "DC should be blocked on the left, got {left_tail}");
+    }
+}

--- a/src-tauri/src/audio/pw_native/eq_chain.rs
+++ b/src-tauri/src/audio/pw_native/eq_chain.rs
@@ -1,0 +1,244 @@
+//! Per-channel EQ insert: captures a channel sink's monitor (post-fader,
+//! the same tap point as the meters), runs the biquad cascade, and plays
+//! the processed signal back out through a stream whose ports the loop
+//! links to the channel's real targets (device, buses) instead of the raw
+//! monitor.
+//!
+//! Topology:  channel sink ──monitor──▶ capture ──EQ──▶ ring ──▶ playback ──▶ device/buses
+//!
+//! Same construction as the mic chain (`mic.rs`), minus metering: EQ taps
+//! add no LevelStore slots, so the MAX_METERS budget is untouched.
+
+use std::sync::Arc;
+
+use pipewire as pw;
+use pw::spa;
+use spa::pod::Pod;
+
+use crate::audio::pw_native::eq::{EqEngine, EqParams};
+use crate::audio::pw_native::ring::Ring;
+use crate::audio::types::EqConfig;
+use crate::error::SinkError;
+
+/// node.name prefixes of the EQ helper streams (under INTERNAL_PREFIX, so
+/// they never show up in app/stream listings).
+pub const EQ_CAPTURE_PREFIX: &str = "sink-internal-eq-capture-";
+pub const EQ_PLAYBACK_PREFIX: &str = "sink-internal-eq-playback-";
+
+struct EqCaptureCtx {
+    engine: EqEngine,
+    params: Arc<EqParams>,
+    ring: Arc<Ring>,
+    scratch: Vec<f32>,
+}
+
+struct EqPlaybackCtx {
+    ring: Arc<Ring>,
+}
+
+pub struct EqChainHandle {
+    _capture: pw::stream::StreamRc,
+    _capture_listener: pw::stream::StreamListener<EqCaptureCtx>,
+    playback: pw::stream::StreamRc,
+    _playback_listener: pw::stream::StreamListener<EqPlaybackCtx>,
+    pub params: Arc<EqParams>,
+}
+
+impl EqChainHandle {
+    /// Node id of the playback stream — the loop links its output ports to
+    /// the channel's targets. Only valid once the server has created the
+    /// stream's node (callers filter u32::MAX, like `mic_playback_node`).
+    pub fn playback_node_id(&self) -> u32 {
+        self.playback.node_id()
+    }
+}
+
+/// Stereo F32 format pod for stream negotiation.
+fn stereo_f32_format() -> Result<Vec<u8>, SinkError> {
+    let mut info = spa::param::audio::AudioInfoRaw::new();
+    info.set_format(spa::param::audio::AudioFormat::F32LE);
+    info.set_channels(2);
+    let object = spa::pod::Object {
+        type_: spa::sys::SPA_TYPE_OBJECT_Format,
+        id: spa::sys::SPA_PARAM_EnumFormat,
+        properties: info.into(),
+    };
+    spa::pod::serialize::PodSerializer::serialize(
+        std::io::Cursor::new(Vec::new()),
+        &spa::pod::Value::Object(object),
+    )
+    .map(|(c, _)| c.into_inner())
+    .map_err(|e| SinkError::Config(format!("eq format pod: {e:?}")))
+}
+
+impl EqChainHandle {
+    /// Build both streams against a live channel sink node.
+    pub fn new(
+        core: &pw::core::CoreRc,
+        sink_name: &str,
+        sink_id: u32,
+        config: &EqConfig,
+    ) -> Result<Self, SinkError> {
+        let err = |stage: &str, e: pw::Error| SinkError::Config(format!("eq {stage}: {e}"));
+        let params = Arc::new(EqParams::from_config(config));
+        // Interleaved stereo: 8192 samples = the same ~85 ms of headroom at
+        // 48 kHz as the mic's 4096 mono; real added latency is one quantum.
+        let ring = Arc::new(Ring::new(8192));
+
+        // ---- capture: channel monitor -> EQ -> ring ----
+        // Passive like the meters: the channel's own app streams drive the
+        // sink; the EQ tap must not keep an idle channel running.
+        let capture_name = format!("{EQ_CAPTURE_PREFIX}{sink_name}");
+        let capture = pw::stream::StreamRc::new(
+            core.clone(),
+            &capture_name,
+            pw::properties::properties! {
+                "media.type" => "Audio",
+                "media.category" => "Capture",
+                "node.name" => capture_name.as_str(),
+                "stream.capture.sink" => "true",
+                "node.passive" => "true",
+                "node.dont-reconnect" => "true",
+            },
+        )
+        .map_err(|e| err("capture stream", e))?;
+
+        let capture_listener = capture
+            .add_local_listener_with_user_data(EqCaptureCtx {
+                engine: EqEngine::new(48000.0),
+                params: params.clone(),
+                ring: ring.clone(),
+                scratch: Vec::with_capacity(8192),
+            })
+            .param_changed(|_, ctx, id, param| {
+                // Coefficients are rate-relative: redesign on renegotiation.
+                // Filter state resets — same tradeoff the mic chain accepts.
+                if id != spa::param::ParamType::Format.as_raw() {
+                    return;
+                }
+                let Some(param) = param else { return };
+                let mut info = spa::param::audio::AudioInfoRaw::new();
+                if info.parse(param).is_ok() && info.rate() > 0 {
+                    ctx.engine.set_sample_rate(info.rate() as f32);
+                }
+            })
+            .process(|stream, ctx| {
+                let Some(mut buffer) = stream.dequeue_buffer() else {
+                    return;
+                };
+                let datas = buffer.datas_mut();
+                let Some(data) = datas.first_mut() else { return };
+                let valid = data.chunk().size() as usize;
+                let Some(bytes) = data.data() else { return };
+
+                let n = (valid.min(bytes.len())) / 4;
+                ctx.scratch.clear();
+                ctx.scratch.extend(
+                    bytes[..n * 4]
+                        .chunks_exact(4)
+                        .map(|b| f32::from_ne_bytes([b[0], b[1], b[2], b[3]])),
+                );
+
+                ctx.engine.process_interleaved(&mut ctx.scratch, &ctx.params);
+                ctx.ring.push(&ctx.scratch);
+            })
+            .register()
+            .map_err(|e| err("capture listener", e))?;
+
+        let format = stereo_f32_format()?;
+        let mut capture_params = [Pod::from_bytes(&format)
+            .ok_or_else(|| SinkError::Config("eq capture format pod invalid".into()))?];
+        capture
+            .connect(
+                spa::utils::Direction::Input,
+                Some(sink_id),
+                pw::stream::StreamFlags::AUTOCONNECT
+                    | pw::stream::StreamFlags::MAP_BUFFERS
+                    | pw::stream::StreamFlags::RT_PROCESS,
+                &mut capture_params,
+            )
+            .map_err(|e| err("capture connect", e))?;
+
+        // ---- playback: ring -> device/buses ----
+        // node.autoconnect=false keeps WirePlumber's hands off this stream
+        // (it routes playback streams to the default sink — the link police
+        // in thread.rs destroys anything that slips through anyway); the
+        // loop links it to the channel's resolved targets itself.
+        let playback_name = format!("{EQ_PLAYBACK_PREFIX}{sink_name}");
+        let playback = pw::stream::StreamRc::new(
+            core.clone(),
+            &playback_name,
+            pw::properties::properties! {
+                "media.type" => "Audio",
+                "media.category" => "Playback",
+                "node.name" => playback_name.as_str(),
+                "node.autoconnect" => "false",
+                "node.dont-reconnect" => "true",
+            },
+        )
+        .map_err(|e| err("playback stream", e))?;
+
+        let playback_listener = playback
+            .add_local_listener_with_user_data(EqPlaybackCtx { ring })
+            .process(|stream, ctx| {
+                let Some(mut buffer) = stream.dequeue_buffer() else {
+                    return;
+                };
+                // Fill only what the graph asked for this cycle (frames);
+                // interleaved stereo = 2 samples, 8 bytes per frame.
+                let requested = buffer.requested() as usize;
+                let datas = buffer.datas_mut();
+                let Some(data) = datas.first_mut() else { return };
+                let max_bytes = data.data().map(|d| d.len()).unwrap_or(0);
+                let max_frames = max_bytes / 8;
+                let frames = if requested > 0 {
+                    requested.min(max_frames)
+                } else {
+                    max_frames.min(1024)
+                };
+                if frames == 0 {
+                    return;
+                }
+                if let Some(bytes) = data.data() {
+                    let mut chunk_samples = [0.0f32; 1024];
+                    let total_samples = frames * 2;
+                    let mut written = 0;
+                    while written < total_samples {
+                        let take = (total_samples - written).min(chunk_samples.len());
+                        ctx.ring.pop(&mut chunk_samples[..take]);
+                        for (i, s) in chunk_samples[..take].iter().enumerate() {
+                            let off = (written + i) * 4;
+                            bytes[off..off + 4].copy_from_slice(&s.to_ne_bytes());
+                        }
+                        written += take;
+                    }
+                }
+                let chunk = data.chunk_mut();
+                *chunk.offset_mut() = 0;
+                *chunk.stride_mut() = 8;
+                *chunk.size_mut() = (frames * 8) as u32;
+            })
+            .register()
+            .map_err(|e| err("playback listener", e))?;
+
+        let mut playback_params = [Pod::from_bytes(&format)
+            .ok_or_else(|| SinkError::Config("eq playback format pod invalid".into()))?];
+        playback
+            .connect(
+                spa::utils::Direction::Output,
+                None,
+                // No AUTOCONNECT: the loop creates the links itself.
+                pw::stream::StreamFlags::MAP_BUFFERS | pw::stream::StreamFlags::RT_PROCESS,
+                &mut playback_params,
+            )
+            .map_err(|e| err("playback connect", e))?;
+
+        Ok(Self {
+            _capture: capture,
+            _capture_listener: capture_listener,
+            playback,
+            _playback_listener: playback_listener,
+            params,
+        })
+    }
+}

--- a/src-tauri/src/audio/pw_native/mod.rs
+++ b/src-tauri/src/audio/pw_native/mod.rs
@@ -6,6 +6,8 @@
 //! Extras over the pactl backend: real per-sink level metering (`levels`).
 
 mod dsp;
+mod eq;
+mod eq_chain;
 pub mod levels;
 pub mod meter;
 mod mic;
@@ -185,6 +187,16 @@ impl AudioBackend for PipeWireBackend {
     fn set_mic_config(&self, config: &crate::audio::types::MicConfig) -> Result<(), SinkError> {
         let config = config.clone();
         self.request(|reply| Cmd::SetMicConfig { config, reply })
+    }
+
+    fn set_channel_eq(
+        &self,
+        sink_name: &str,
+        config: &crate::audio::types::EqConfig,
+    ) -> Result<(), SinkError> {
+        let sink_name = sink_name.to_string();
+        let config = config.clone();
+        self.request(|reply| Cmd::SetChannelEq { sink_name, config, reply })
     }
 
     fn get_default_devices(&self) -> Result<(Option<String>, Option<String>), SinkError> {

--- a/src-tauri/src/audio/pw_native/thread.rs
+++ b/src-tauri/src/audio/pw_native/thread.rs
@@ -16,11 +16,12 @@ use pw::registry::{GlobalObject, RegistryRc};
 use pw::spa::utils::dict::DictRef;
 use pw::types::ObjectType;
 
+use crate::audio::pw_native::eq_chain::EqChainHandle;
 use crate::audio::pw_native::levels::LevelStore;
 use crate::audio::pw_native::meter::MeterHandle;
 use crate::audio::pw_native::mic::{MicStreams, MIC_NODE};
 use crate::audio::pw_native::pods;
-use crate::audio::types::{is_virtual_sink, AppStream, MicConfig, OutputDevice};
+use crate::audio::types::{is_virtual_sink, AppStream, EqConfig, MicConfig, OutputDevice};
 use crate::error::SinkError;
 use crate::persistence::buses::is_bus_name;
 
@@ -61,6 +62,8 @@ pub enum Cmd {
     SetMonitor { name: String, enabled: bool, reply: Reply<()> },
     /// Apply mic chain configuration (create/destroy/re-tune as needed).
     SetMicConfig { config: MicConfig, reply: Reply<()> },
+    /// Apply a channel's parametric EQ (create/destroy/re-tune the insert).
+    SetChannelEq { sink_name: String, config: EqConfig, reply: Reply<()> },
     /// Hardware capture devices (microphones).
     ListInputs { reply: Reply<Vec<OutputDevice>> },
     /// Current system defaults: (output sink name, input source name).
@@ -150,6 +153,18 @@ struct State {
     monitor_links: HashMap<String, LinkSet>,
     /// Links from the mic playback stream into the virtual mic.
     mic_links: LinkSet,
+    /// Per-channel EQ configs (source of truth for chain (re)creation —
+    /// kept even while disabled so re-enabling restores the bands).
+    eq_configs: HashMap<String, EqConfig>,
+    /// Live EQ inserts by channel sink name. Presence here *is* "EQ is
+    /// enabled and live"; the channel's outgoing links re-source from the
+    /// insert's playback node.
+    eq_streams: HashMap<String, EqChainHandle>,
+    /// EQ playback node id -> node ids it is allowed to feed. Rebuilt
+    /// wholesale by every `ensure_all_links` pass; the link police destroys
+    /// anything else (WirePlumber routes playback streams to the default
+    /// sink — same leak the mic police exists for).
+    eq_desired_targets: HashMap<u32, std::collections::HashSet<u32>>,
 }
 
 impl State {
@@ -161,6 +176,21 @@ impl State {
             .map(|m| m.playback_node_id())
             .filter(|id| *id != u32::MAX)
     }
+
+    /// Live node id of a channel's EQ playback stream, if the insert is up.
+    fn eq_playback_node(&self, sink_name: &str) -> Option<u32> {
+        self.eq_streams
+            .get(sink_name)
+            .map(|h| h.playback_node_id())
+            .filter(|id| *id != u32::MAX)
+    }
+}
+
+/// The node whose ports feed a channel's downstream links: the EQ insert's
+/// playback stream when one is live, otherwise the channel sink itself.
+/// Pure so the routing decision is unit-testable (like `resolve_target`).
+fn resolve_source(eq_playback: Option<u32>, channel_id: u32) -> u32 {
+    eq_playback.unwrap_or(channel_id)
 }
 
 impl State {
@@ -360,18 +390,11 @@ fn on_global(
                 direction: props.get("port.direction").unwrap_or_default().to_string(),
                 channel: props.get("audio.channel").map(str::to_string),
             };
-            let relevant_links = {
-                let mut s = state.borrow_mut();
-                s.ports.insert(global.id, entry);
-                s.nodes
-                    .get(&node_id)
-                    .is_some_and(|n| n.media_class == SINK_CLASS)
-            };
-            if relevant_links {
-                ensure_all_links(state);
-            }
-            // Mic wiring depends on ports of untracked stream nodes, so
-            // reconcile on every port event (no-op until both ends exist).
+            state.borrow_mut().ports.insert(global.id, entry);
+            // Channel and mic wiring both depend on ports of untracked
+            // stream nodes (EQ/mic playback streams), so reconcile on every
+            // port event — both are idempotent no-ops until both ends exist.
+            ensure_all_links(state);
             ensure_mic_links(state);
         }
         ObjectType::Link => {
@@ -386,12 +409,26 @@ fn on_global(
                     // session-manager fallback) links it somewhere other
                     // than the virtual mic, destroy that link — mic audio
                     // must never leak into the speakers.
-                    match (s.mic_playback_node(), s.node_by_name(MIC_NODE)) {
+                    let mic_stray = match (s.mic_playback_node(), s.node_by_name(MIC_NODE)) {
                         (Some(playback), mic) if out == playback => {
                             mic.map(|n| n.id) != Some(inp)
                         }
                         _ => false,
-                    }
+                    };
+                    // Same policing for EQ playback streams: only the links
+                    // the loop planned (device/buses/monitor) may exist. An
+                    // EQ node with no plan yet (chain just built, first
+                    // reconcile pending) allows nothing — our own links are
+                    // always created after the plan is recorded.
+                    let eq_stray = s
+                        .eq_streams
+                        .values()
+                        .any(|h| h.playback_node_id() == out)
+                        && !s
+                            .eq_desired_targets
+                            .get(&out)
+                            .is_some_and(|allowed| allowed.contains(&inp));
+                    mic_stray || eq_stray
                 };
                 if police {
                     let _ = registry.destroy_global(global.id);
@@ -570,6 +607,20 @@ fn on_node(
                     s.meters.insert(node_name.clone(), meter);
                 }
                 Err(e) => eprintln!("sink: meter for {node_name} failed: {e}"),
+            }
+        }
+        // An enabled EQ config with no live insert: build it against the
+        // fresh sink id. Covers both startup (config loaded before the sink
+        // exists) and the heal path (sink recreated after an external
+        // destroy) with the same hook — like the meter above.
+        if !s.eq_streams.contains_key(&node_name) {
+            if let Some(config) = s.eq_configs.get(&node_name).filter(|c| c.enabled).cloned() {
+                match EqChainHandle::new(core, &node_name, global.id, &config) {
+                    Ok(handle) => {
+                        s.eq_streams.insert(node_name.clone(), handle);
+                    }
+                    Err(e) => eprintln!("sink: eq chain for {node_name} failed: {e}"),
+                }
             }
         }
         drop(s);
@@ -822,12 +873,21 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
     // Forget resolved targets for channels that no longer exist.
     s.channel_targets.retain(|name, _| channel_names.contains(name));
 
+    // The link plan for every live EQ insert, rebuilt from scratch each
+    // pass — the link police destroys anything an EQ playback node feeds
+    // that isn't in here.
+    let mut eq_targets: HashMap<u32, std::collections::HashSet<u32>> = HashMap::new();
+
     for sink_name in &channel_names {
         let sink_name = sink_name.as_str();
         let channel_id = match node_ids.get(sink_name) {
             Some(id) => *id,
             None => continue,
         };
+        // With a live EQ insert, every outgoing link (device, buses,
+        // monitor) re-sources from its playback node — one coherent source,
+        // so all listeners hear the same (EQ'd, equally delayed) audio.
+        let source_id = resolve_source(s.eq_playback_node(sink_name), channel_id);
 
         // ---- output device links ----
         let explicit = s.channel_outputs.get(sink_name).cloned().flatten();
@@ -850,8 +910,11 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
                 s.channel_targets.remove(sink_name);
             }
         }
+        if let (Some(t), true) = (target_id, source_id != channel_id) {
+            eq_targets.entry(source_id).or_default().insert(t);
+        }
         let pairs = target_id
-            .map(|t| desired_pairs(&s, channel_id, t))
+            .map(|t| desired_pairs(&s, source_id, t))
             .unwrap_or_default();
         let current: Vec<(u32, u32)> = s
             .channel_links
@@ -864,7 +927,7 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
                 .first()
                 .and_then(|(_, input)| s.ports.get(input).map(|p| p.node_id))
             {
-                let created = create_links(&core, sink_name, channel_id, in_node, &pairs);
+                let created = create_links(&core, sink_name, source_id, in_node, &pairs);
                 if !created.is_empty() {
                     s.channel_links.insert(sink_name.to_string(), created);
                 }
@@ -877,8 +940,11 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
                 .bus_members
                 .get(bus_name)
                 .is_some_and(|members| members.contains(sink_name));
+            if included && source_id != channel_id {
+                eq_targets.entry(source_id).or_default().insert(*bus_id);
+            }
             let pairs = if included {
-                desired_pairs(&s, channel_id, *bus_id)
+                desired_pairs(&s, source_id, *bus_id)
             } else {
                 Vec::new()
             };
@@ -891,7 +957,7 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
             if current != pairs {
                 s.bus_links.remove(&key);
                 if !pairs.is_empty() {
-                    let created = create_links(&core, sink_name, channel_id, *bus_id, &pairs);
+                    let created = create_links(&core, sink_name, source_id, *bus_id, &pairs);
                     if !created.is_empty() {
                         s.bus_links.insert(key, created);
                     }
@@ -908,7 +974,17 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
         .copied();
     let monitored: Vec<String> = s.monitored.iter().cloned().collect();
     for name in monitored {
-        let node_id = node_ids.get(&name).copied();
+        // Monitoring an EQ'd channel listens to the insert's output — the
+        // same audio its device/buses hear.
+        let node_id = node_ids
+            .get(&name)
+            .copied()
+            .map(|id| resolve_source(s.eq_playback_node(&name), id));
+        if let (Some(node), Some(default)) = (node_id, default_id) {
+            if node_ids.get(&name).copied() != Some(node) {
+                eq_targets.entry(node).or_default().insert(default);
+            }
+        }
         let mut pairs = match (node_id, default_id) {
             (Some(node), Some(default)) => desired_pairs(&s, node, default),
             _ => Vec::new(),
@@ -939,6 +1015,9 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
             }
         }
     }
+
+    // Publish the EQ link plan for the police (see on_global's Link arm).
+    s.eq_desired_targets = eq_targets;
 }
 
 /// The three virtual node shapes we own (kind 0=channel sink, 1=mix bus,
@@ -1012,6 +1091,10 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
             let mut s = state.borrow_mut();
             s.desired.remove(&name);
             s.meters.remove(&name);
+            // Drop the EQ insert before the sink proxy goes away so the
+            // capture stream's target doesn't vanish under it mid-teardown.
+            s.eq_streams.remove(&name);
+            s.eq_configs.remove(&name);
             s.channel_links.remove(&name);
             s.bus_links.retain(|(_, ch), _| ch != &name);
             s.channel_outputs.remove(&name);
@@ -1189,6 +1272,53 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
                     s.monitor_links.remove(&name);
                 }
             }
+            ensure_all_links(state);
+            let _ = reply.send(Ok(()));
+        }
+        Cmd::SetChannelEq { sink_name, config, reply } => {
+            if !is_virtual_sink(&sink_name) {
+                let _ = reply.send(Err(SinkError::UnknownSink(sink_name)));
+                return;
+            }
+            let (needs_create, needs_destroy) = {
+                let mut s = state.borrow_mut();
+                s.eq_configs.insert(sink_name.clone(), config.clone());
+                // Live re-tune: band edits reach the RT thread through the
+                // params atomics, no relink and no audible gap.
+                if let Some(handle) = s.eq_streams.get(&sink_name) {
+                    handle.params.apply(&config);
+                }
+                let live = s.eq_streams.contains_key(&sink_name);
+                (config.enabled && !live, !config.enabled && live)
+            };
+            if needs_destroy {
+                state.borrow_mut().eq_streams.remove(&sink_name);
+            } else if needs_create {
+                let sink_id = state
+                    .borrow()
+                    .node_by_name(&sink_name)
+                    .map(|n| n.id);
+                if let Some(sink_id) = sink_id {
+                    let Some(core) = CORE.with(|c| c.borrow().clone()) else {
+                        let _ = reply.send(Err(SinkError::Config(
+                            "eq chain requires a live core".into(),
+                        )));
+                        return;
+                    };
+                    match EqChainHandle::new(&core, &sink_name, sink_id, &config) {
+                        Ok(handle) => {
+                            state.borrow_mut().eq_streams.insert(sink_name.clone(), handle);
+                        }
+                        Err(e) => {
+                            let _ = reply.send(Err(e));
+                            return;
+                        }
+                    }
+                }
+                // Sink not live yet (e.g. mid-profile-load): the on_node
+                // hook builds the chain from eq_configs when it appears.
+            }
+            // Re-source the channel's links from/to the insert.
             ensure_all_links(state);
             let _ = reply.send(Ok(()));
         }
@@ -1471,6 +1601,16 @@ mod tests {
             direction: dir.to_string(),
             channel: channel.map(str::to_string),
         }
+    }
+
+    #[test]
+    fn resolve_source_prefers_live_eq_playback() {
+        assert_eq!(resolve_source(Some(77), 10), 77);
+    }
+
+    #[test]
+    fn resolve_source_falls_back_to_channel() {
+        assert_eq!(resolve_source(None, 10), 10);
     }
 
     #[test]

--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -392,3 +392,169 @@ mod mic_clamp_tests {
         assert_eq!(c, before);
     }
 }
+
+/// Hard cap on parametric EQ bands per channel. Ten matches the Sonar EQ
+/// users already know, keeps preset validation simple, and bounds the RT
+/// cost per channel.
+pub const MAX_EQ_BANDS: usize = 10;
+
+/// Parametric EQ band shapes (RBJ Audio EQ Cookbook designs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EqBandKind {
+    Peaking,
+    LowShelf,
+    HighShelf,
+    LowPass,
+    HighPass,
+}
+
+fn default_band_q() -> f32 {
+    1.0
+}
+
+/// One parametric EQ band.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct EqBand {
+    pub kind: EqBandKind,
+    pub freq_hz: f32,
+    /// Ignored by LowPass/HighPass (their shape has no gain parameter).
+    #[serde(default)]
+    pub gain_db: f32,
+    /// Peaking/LowPass/HighPass: filter Q. Shelves: RBJ shelf slope S —
+    /// one field, two meanings, so presets stay a flat 4-field record.
+    #[serde(default = "default_band_q")]
+    pub q: f32,
+}
+
+impl EqBand {
+    /// TD-050: clamp to DSP-safe ranges, replacing non-finite values, so a
+    /// hostile IPC payload or preset file can't blow up the filter design.
+    pub fn clamp_ranges(&mut self) {
+        fn finite(v: f32, fallback: f32, lo: f32, hi: f32) -> f32 {
+            if v.is_finite() {
+                v.clamp(lo, hi)
+            } else {
+                fallback
+            }
+        }
+        self.freq_hz = finite(self.freq_hz, 1000.0, 20.0, 20000.0);
+        self.gain_db = finite(self.gain_db, 0.0, -24.0, 24.0);
+        self.q = finite(self.q, default_band_q(), 0.1, 10.0);
+    }
+}
+
+/// The Sonar-style starting layout: shelves at the extremes, three mids,
+/// everything flat. Five bands; the UI can add up to MAX_EQ_BANDS.
+pub fn default_eq_bands() -> Vec<EqBand> {
+    [
+        (EqBandKind::LowShelf, 100.0, 0.71),
+        (EqBandKind::Peaking, 500.0, 1.0),
+        (EqBandKind::Peaking, 1500.0, 1.0),
+        (EqBandKind::Peaking, 5000.0, 1.0),
+        (EqBandKind::HighShelf, 10000.0, 0.71),
+    ]
+    .into_iter()
+    .map(|(kind, freq_hz, q)| EqBand {
+        kind,
+        freq_hz,
+        gain_db: 0.0,
+        q,
+    })
+    .collect()
+}
+
+/// A channel's parametric EQ (persisted per channel; applied live).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EqConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Headroom trim applied before the band cascade (dB). Boost-heavy
+    /// curves need this negative to avoid clipping.
+    #[serde(default)]
+    pub preamp_db: f32,
+    #[serde(default = "default_eq_bands")]
+    pub bands: Vec<EqBand>,
+}
+
+impl EqConfig {
+    /// TD-050-style sanitization for the whole config (see EqBand).
+    pub fn clamp_ranges(&mut self) {
+        if !self.preamp_db.is_finite() {
+            self.preamp_db = 0.0;
+        }
+        self.preamp_db = self.preamp_db.clamp(-24.0, 24.0);
+        self.bands.truncate(MAX_EQ_BANDS);
+        for band in &mut self.bands {
+            band.clamp_ranges();
+        }
+    }
+}
+
+impl Default for EqConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            preamp_db: 0.0,
+            bands: default_eq_bands(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod eq_clamp_tests {
+    use super::*;
+
+    #[test]
+    fn band_clamp_bounds_out_of_range_values() {
+        let mut b = EqBand {
+            kind: EqBandKind::Peaking,
+            freq_hz: 99999.0,
+            gain_db: -80.0,
+            q: 0.0,
+        };
+        b.clamp_ranges();
+        assert_eq!(b.freq_hz, 20000.0);
+        assert_eq!(b.gain_db, -24.0);
+        assert_eq!(b.q, 0.1);
+    }
+
+    #[test]
+    fn band_clamp_replaces_non_finite_with_defaults() {
+        let mut b = EqBand {
+            kind: EqBandKind::Peaking,
+            freq_hz: f32::NAN,
+            gain_db: f32::INFINITY,
+            q: f32::NEG_INFINITY,
+        };
+        b.clamp_ranges();
+        assert_eq!(b.freq_hz, 1000.0);
+        assert_eq!(b.gain_db, 0.0);
+        assert_eq!(b.q, default_band_q());
+    }
+
+    #[test]
+    fn config_clamp_truncates_to_max_bands() {
+        let mut c = EqConfig::default();
+        c.bands = vec![c.bands[0]; MAX_EQ_BANDS + 5];
+        c.preamp_db = f32::NAN;
+        c.clamp_ranges();
+        assert_eq!(c.bands.len(), MAX_EQ_BANDS);
+        assert_eq!(c.preamp_db, 0.0);
+    }
+
+    #[test]
+    fn config_without_fields_deserializes_with_defaults() {
+        // Old profile/eq JSON without these keys must keep loading.
+        let c: EqConfig = serde_json::from_str("{}").unwrap();
+        assert!(!c.enabled);
+        assert_eq!(c.preamp_db, 0.0);
+        assert_eq!(c.bands, default_eq_bands());
+    }
+
+    #[test]
+    fn band_kind_serializes_snake_case() {
+        let json = serde_json::to_string(&EqBandKind::LowShelf).unwrap();
+        assert_eq!(json, "\"low_shelf\"");
+    }
+}

--- a/src-tauri/src/commands/channels.rs
+++ b/src-tauri/src/commands/channels.rs
@@ -164,7 +164,7 @@ pub fn remove_channel(state: State<'_, AppState>, sink_name: String) -> Result<(
         .destroy_virtual_sink(&sink_name)
         .map_err(|e| e.to_string())?;
 
-    let (defs, assignments, outputs, buses, names) = {
+    let (defs, assignments, outputs, eq, buses, names) = {
         let mut mixer = state.lock_mixer()?;
         mixer.channels.retain(|c| c.name != sink_name);
         mixer
@@ -172,6 +172,9 @@ pub fn remove_channel(state: State<'_, AppState>, sink_name: String) -> Result<(
             .assignments
             .retain(|a| a.sink_name != sink_name);
         mixer.outputs.remove(&sink_name);
+        // The backend's DestroySink already tore down the live insert;
+        // this drops the persisted config with the channel.
+        mixer.eq.remove(&sink_name);
         // Drop the channel from every mix's membership too.
         mixer.buses.remove_channel(&sink_name);
         // Re-evaluate auto-routing with the channel gone.
@@ -181,6 +184,7 @@ pub fn remove_channel(state: State<'_, AppState>, sink_name: String) -> Result<(
             mixer.channel_defs.clone(),
             mixer.assignments.clone(),
             mixer.outputs.clone(),
+            mixer.eq.clone(),
             mixer.buses.clone(),
             crate::commands::buses::channel_names(&mixer),
         )
@@ -195,6 +199,7 @@ pub fn remove_channel(state: State<'_, AppState>, sink_name: String) -> Result<(
     defs.save().map_err(|e| e.to_string())?;
     assignments.save().map_err(|e| e.to_string())?;
     outputs.save().map_err(|e| e.to_string())?;
+    eq.save().map_err(|e| e.to_string())?;
     buses.save().map_err(|e| e.to_string())?;
     wireplumber::write(&assignments).map_err(|e| e.to_string())?;
     Ok(())

--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -231,6 +231,7 @@ pub fn init_virtual_devices(
             channels: mixer.channels.clone(),
             assignments: mixer.assignments.clone(),
             outputs: mixer.outputs.clone(),
+            eq: mixer.eq.clone(),
             trigger_device: None,
             buses: mixer.buses.clone(),
         };

--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -162,13 +162,18 @@ pub fn init_virtual_devices(
             .map_err(|e| e.to_string())?;
     }
 
-    let (outputs, mic, buses) = {
+    let (outputs, eq, mic, buses) = {
         let mut mixer = state.lock_mixer()?;
         mixer.init_defaults();
         // The master mix always carries the full channel set.
         let names: Vec<String> = defs.channels.iter().map(|c| c.name.clone()).collect();
         mixer.buses.sync_master(&names);
-        (mixer.outputs.clone(), mixer.mic.clone(), mixer.buses.clone())
+        (
+            mixer.outputs.clone(),
+            mixer.eq.clone(),
+            mixer.mic.clone(),
+            mixer.buses.clone(),
+        )
     };
     if let Err(e) = buses.save() {
         eprintln!("sink: saving mixes failed: {e}");
@@ -187,6 +192,13 @@ pub fn init_virtual_devices(
         if !outputs.failover(&def.name) {
             if let Err(e) = state.backend.set_channel_failover(&def.name, false) {
                 eprintln!("sink: failover setting for {} failed: {e}", def.name);
+            }
+        }
+        // Restore saved EQ (only channels that were ever configured; the
+        // loop builds the insert when the sink node appears).
+        if let Some(config) = eq.configs.get(&def.name) {
+            if let Err(e) = state.backend.set_channel_eq(&def.name, config) {
+                eprintln!("sink: eq restore for {} failed: {e}", def.name);
             }
         }
     }

--- a/src-tauri/src/commands/eq.rs
+++ b/src-tauri/src/commands/eq.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+
+use tauri::State;
+
+use crate::audio::types::EqConfig;
+use crate::state::AppState;
+
+/// All channels' EQ configs in one round-trip (channels without an entry
+/// have never been configured — the frontend treats them as default).
+#[tauri::command]
+pub fn get_channel_eq_configs(
+    state: State<'_, AppState>,
+) -> Result<HashMap<String, EqConfig>, String> {
+    Ok(state.lock_mixer()?.eq.configs.clone())
+}
+
+/// Apply and persist one channel's parametric EQ.
+#[tauri::command]
+pub fn set_channel_eq(
+    state: State<'_, AppState>,
+    sink_name: String,
+    mut config: EqConfig,
+) -> Result<(), String> {
+    config.clamp_ranges();
+    state
+        .backend
+        .set_channel_eq(&sink_name, &config)
+        .map_err(|e| e.to_string())?;
+    let eq = {
+        let mut mixer = state.lock_mixer()?;
+        mixer.eq.set(&sink_name, config);
+        crate::commands::profiles::autosave_active(&mixer);
+        mixer.eq.clone()
+    };
+    eq.save().map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/eq.rs
+++ b/src-tauri/src/commands/eq.rs
@@ -1,8 +1,12 @@
 use std::collections::HashMap;
 
+use serde::Serialize;
 use tauri::State;
 
+use crate::audio::eq_import::parse_autoeq;
+use crate::audio::presets::{bundled_presets, EqPreset, PRESET_SCHEMA};
 use crate::audio::types::EqConfig;
+use crate::persistence::eq_presets;
 use crate::state::AppState;
 
 /// All channels' EQ configs in one round-trip (channels without an entry
@@ -33,4 +37,117 @@ pub fn set_channel_eq(
         mixer.eq.clone()
     };
     eq.save().map_err(|e| e.to_string())
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EqPresetEntry {
+    /// "bundled" (ships in the binary) or "user" (local library).
+    pub source: String,
+    pub preset: EqPreset,
+}
+
+/// Bundled presets first, then the user's library, each sorted by name.
+#[tauri::command]
+pub fn list_eq_presets() -> Result<Vec<EqPresetEntry>, String> {
+    let mut entries: Vec<EqPresetEntry> = bundled_presets()
+        .into_iter()
+        .map(|preset| EqPresetEntry {
+            source: "bundled".into(),
+            preset,
+        })
+        .collect();
+    entries.extend(
+        eq_presets::list()
+            .map_err(|e| e.to_string())?
+            .into_iter()
+            .map(|preset| EqPresetEntry {
+                source: "user".into(),
+                preset,
+            }),
+    );
+    Ok(entries)
+}
+
+/// Save the given config into the user's local preset library.
+#[tauri::command]
+pub fn save_user_eq_preset(name: String, mut config: EqConfig) -> Result<(), String> {
+    config.clamp_ranges();
+    let preset = EqPreset {
+        schema: PRESET_SCHEMA,
+        name,
+        author: None,
+        description: None,
+        preamp_db: config.preamp_db,
+        bands: config.bands,
+    };
+    eq_presets::save(&preset).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn delete_user_eq_preset(name: String) -> Result<(), String> {
+    eq_presets::delete(&name).map_err(|e| e.to_string())
+}
+
+/// A channel's EQ as shareable preset JSON (pretty-printed, schema 1).
+#[tauri::command]
+pub fn export_channel_eq(state: State<'_, AppState>, sink_name: String) -> Result<String, String> {
+    let (config, label) = {
+        let mixer = state.lock_mixer()?;
+        let label = mixer
+            .channels
+            .iter()
+            .find(|c| c.name == sink_name)
+            .map(|c| c.label.clone())
+            .unwrap_or_else(|| sink_name.clone());
+        (mixer.eq.get(&sink_name), label)
+    };
+    let preset = EqPreset {
+        schema: PRESET_SCHEMA,
+        name: label,
+        author: None,
+        description: None,
+        preamp_db: config.preamp_db,
+        bands: config.bands,
+    };
+    serde_json::to_string_pretty(&preset).map_err(|e| e.to_string())
+}
+
+/// Write a channel's EQ preset JSON to `path` (picked via the native save
+/// dialog; the file I/O stays in Rust so no fs plugin scope is needed).
+#[tauri::command]
+pub fn export_channel_eq_to_file(
+    state: State<'_, AppState>,
+    sink_name: String,
+    path: String,
+) -> Result<(), String> {
+    let json = export_channel_eq(state, sink_name)?;
+    std::fs::write(&path, json).map_err(|e| format!("write {path}: {e}"))
+}
+
+/// Parse pasted preset text: our JSON schema or an AutoEq result block.
+/// Returns a disabled config for preview-then-apply in the modal.
+#[tauri::command]
+pub fn import_eq_config(text: String) -> Result<EqConfig, String> {
+    let trimmed = text.trim();
+    if trimmed.starts_with('{') {
+        let preset: EqPreset = serde_json::from_str(trimmed).map_err(|e| e.to_string())?;
+        if preset.schema != PRESET_SCHEMA {
+            return Err(format!("unsupported preset schema {}", preset.schema));
+        }
+        if preset.bands.is_empty() {
+            return Err("preset has no bands".into());
+        }
+        let mut config = preset.to_config();
+        config.enabled = false;
+        Ok(config)
+    } else {
+        parse_autoeq(trimmed).map_err(|e| e.to_string())
+    }
+}
+
+/// Read + parse a preset file picked via the native open dialog.
+#[tauri::command]
+pub fn import_eq_file(path: String) -> Result<EqConfig, String> {
+    let text = std::fs::read_to_string(&path).map_err(|e| format!("read {path}: {e}"))?;
+    import_eq_config(text)
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod apps;
 pub mod buses;
 pub mod channels;
 pub mod devices;
+pub mod eq;
 pub mod mic;
 pub mod profiles;
 pub mod routing;

--- a/src-tauri/src/commands/profiles.rs
+++ b/src-tauri/src/commands/profiles.rs
@@ -18,6 +18,7 @@ pub fn autosave_active(mixer: &crate::mixer::state::MixerState) {
         channels: mixer.channels.clone(),
         assignments: mixer.assignments.clone(),
         outputs: mixer.outputs.clone(),
+        eq: mixer.eq.clone(),
         // Preserved from the cache rather than re-read from disk each mutation.
         trigger_device: mixer.active_trigger.clone(),
         buses: mixer.buses.clone(),
@@ -139,6 +140,14 @@ pub fn load_profile(
         {
             eprintln!("sink: profile failover for {} failed: {e}", channel.name);
         }
+        // EQ: non-fatal like output/failover — one channel's insert failing
+        // must not abort the whole profile load.
+        if let Err(e) = state
+            .backend
+            .set_channel_eq(&channel.name, &profile.eq.get(&channel.name))
+        {
+            eprintln!("sink: profile eq for {} failed: {e}", channel.name);
+        }
     }
 
     // ---- mix bus reconciliation ----
@@ -171,7 +180,7 @@ pub fn load_profile(
         }
     }
 
-    let (defs, assignments, outputs) = {
+    let (defs, assignments, outputs, eq) = {
         let mut mixer = state.lock_mixer()?;
         mixer.buses = target_buses.clone();
         mixer.channel_defs = crate::persistence::channels::Channels {
@@ -189,17 +198,20 @@ pub fn load_profile(
         mixer.channels = profile.channels.clone();
         mixer.assignments = profile.assignments.clone();
         mixer.outputs = profile.outputs.clone();
+        mixer.eq = profile.eq.clone();
         mixer.auto_routed.clear();
         (
             mixer.channel_defs.clone(),
             mixer.assignments.clone(),
             mixer.outputs.clone(),
+            mixer.eq.clone(),
         )
     };
 
     defs.save().map_err(|e| e.to_string())?;
     assignments.save().map_err(|e| e.to_string())?;
     outputs.save().map_err(|e| e.to_string())?;
+    eq.save().map_err(|e| e.to_string())?;
     target_buses.save().map_err(|e| e.to_string())?;
     wireplumber::write(&assignments).map_err(|e| e.to_string())?;
     // The loaded profile becomes the live-bound (autosaving) one.
@@ -234,6 +246,7 @@ pub fn create_blank_profile(app: tauri::AppHandle, name: String) -> Result<(), S
         channels,
         assignments: Default::default(),
         outputs: Default::default(),
+        eq: Default::default(),
         trigger_device: None,
         buses: Default::default(),
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,6 +74,8 @@ pub fn run() {
             commands::mic::get_mic_config,
             commands::mic::set_mic_config,
             commands::mic::get_input_devices,
+            commands::eq::get_channel_eq_configs,
+            commands::eq::set_channel_eq,
             commands::profiles::list_profiles,
             commands::profiles::load_profile,
             commands::profiles::delete_profile,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,6 +38,7 @@ pub fn run() {
     let app_state = AppState::new(backend, backend_native);
 
     let result = tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
         .manage(app_state)
         .invoke_handler(tauri::generate_handler![
             commands::devices::get_virtual_devices,
@@ -76,6 +77,13 @@ pub fn run() {
             commands::mic::get_input_devices,
             commands::eq::get_channel_eq_configs,
             commands::eq::set_channel_eq,
+            commands::eq::list_eq_presets,
+            commands::eq::save_user_eq_preset,
+            commands::eq::delete_user_eq_preset,
+            commands::eq::export_channel_eq,
+            commands::eq::export_channel_eq_to_file,
+            commands::eq::import_eq_config,
+            commands::eq::import_eq_file,
             commands::profiles::list_profiles,
             commands::profiles::load_profile,
             commands::profiles::delete_profile,

--- a/src-tauri/src/mixer/state.rs
+++ b/src-tauri/src/mixer/state.rs
@@ -20,6 +20,8 @@ pub struct MixerState {
     pub aliases: Aliases,
     /// Per-channel output device choices (persisted to disk).
     pub outputs: crate::persistence::outputs::ChannelOutputs,
+    /// Per-channel parametric EQ configs (persisted to disk).
+    pub eq: crate::persistence::eq::ChannelEq,
     /// Mic chain configuration (persisted to disk).
     pub mic: crate::audio::types::MicConfig,
     /// Every app identity ever observed (history + ignore list).

--- a/src-tauri/src/persistence/eq.rs
+++ b/src-tauri/src/persistence/eq.rs
@@ -1,0 +1,110 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::audio::types::EqConfig;
+use crate::error::SinkError;
+
+/// Per-channel parametric EQ configs, stored as JSON at
+/// `$XDG_CONFIG_HOME/sink/eq.json`. A missing entry means "never touched" —
+/// the default (disabled, flat) config.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ChannelEq {
+    /// `serde(default)` keeps pre-EQ profile files loading cleanly.
+    #[serde(default)]
+    pub configs: HashMap<String, EqConfig>,
+}
+
+impl ChannelEq {
+    pub fn config_path() -> Result<PathBuf, SinkError> {
+        let dir = dirs::config_dir()
+            .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
+        Ok(dir.join("sink").join("eq.json"))
+    }
+
+    pub fn load() -> Self {
+        let Ok(path) = Self::config_path() else {
+            return Self::default();
+        };
+        match fs::read_to_string(&path) {
+            Ok(raw) => serde_json::from_str(&raw).unwrap_or_else(|e| {
+                eprintln!("sink: ignoring malformed {}: {e}", path.display());
+                Self::default()
+            }),
+            Err(_) => Self::default(),
+        }
+    }
+
+    pub fn save(&self) -> Result<(), SinkError> {
+        let path = Self::config_path()?;
+        if let Some(parent) = path.parent() {
+            crate::persistence::ensure_private_dir(parent)?;
+        }
+        let json = serde_json::to_string_pretty(self)
+            .map_err(|e| SinkError::Config(format!("serialize eq: {e}")))?;
+        super::write_atomic(&path, &json)?;
+        Ok(())
+    }
+
+    /// A channel's EQ, defaulting to disabled/flat when never configured.
+    pub fn get(&self, sink_name: &str) -> EqConfig {
+        self.configs.get(sink_name).cloned().unwrap_or_default()
+    }
+
+    pub fn set(&mut self, sink_name: &str, config: EqConfig) {
+        self.configs.insert(sink_name.to_string(), config);
+    }
+
+    /// Drop all state for a removed channel.
+    pub fn remove(&mut self, sink_name: &str) {
+        self.configs.remove(sink_name);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio::types::{default_eq_bands, EqBandKind};
+
+    #[test]
+    fn roundtrips_configured_channels() {
+        let mut eq = ChannelEq::default();
+        let mut config = EqConfig {
+            enabled: true,
+            preamp_db: -3.0,
+            ..EqConfig::default()
+        };
+        config.bands[0].gain_db = 4.5;
+        eq.set("sink_game", config.clone());
+        let json = serde_json::to_string(&eq).expect("serializes");
+        let back: ChannelEq = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(back, eq);
+        assert_eq!(back.get("sink_game"), config);
+    }
+
+    #[test]
+    fn unconfigured_channel_gets_default() {
+        let eq = ChannelEq::default();
+        let config = eq.get("sink_chat");
+        assert!(!config.enabled);
+        assert_eq!(config.bands, default_eq_bands());
+        assert_eq!(config.bands[0].kind, EqBandKind::LowShelf);
+    }
+
+    #[test]
+    fn legacy_file_without_configs_field_loads() {
+        // A pre-EQ profile (or an empty file body) has no `configs` key.
+        let eq: ChannelEq = serde_json::from_str("{}").expect("legacy loads");
+        assert_eq!(eq, ChannelEq::default());
+    }
+
+    #[test]
+    fn remove_drops_config() {
+        let mut eq = ChannelEq::default();
+        eq.set("sink_game", EqConfig::default());
+        eq.remove("sink_game");
+        assert!(eq.configs.is_empty());
+    }
+}

--- a/src-tauri/src/persistence/eq_presets.rs
+++ b/src-tauri/src/persistence/eq_presets.rs
@@ -1,0 +1,103 @@
+//! The user's local EQ preset library: named JSON files (the same schema
+//! as the bundled presets) under `$XDG_CONFIG_HOME/sink/eq_presets/`,
+//! modeled on the profiles store — including its name sanitization, so a
+//! preset name can never traverse out of the directory.
+
+use std::fs;
+use std::path::PathBuf;
+
+use crate::audio::presets::{EqPreset, PRESET_SCHEMA};
+use crate::error::SinkError;
+use crate::persistence::profiles::sanitize_name;
+
+fn presets_dir() -> Result<PathBuf, SinkError> {
+    let dir = dirs::config_dir()
+        .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
+    Ok(dir.join("sink").join("eq_presets"))
+}
+
+/// All user presets, sorted by name. Unreadable files are skipped (one
+/// corrupt preset must not hide the rest).
+pub fn list() -> Result<Vec<EqPreset>, SinkError> {
+    let dir = presets_dir()?;
+    let mut presets = Vec::new();
+    let entries = match fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(presets), // no library yet
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        match fs::read_to_string(&path)
+            .map_err(|e| e.to_string())
+            .and_then(|raw| serde_json::from_str::<EqPreset>(&raw).map_err(|e| e.to_string()))
+        {
+            Ok(preset) if preset.schema == PRESET_SCHEMA && !preset.bands.is_empty() => {
+                presets.push(preset);
+            }
+            Ok(_) => eprintln!("sink: skipping eq preset {}: bad schema", path.display()),
+            Err(e) => eprintln!("sink: skipping eq preset {}: {e}", path.display()),
+        }
+    }
+    presets.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(presets)
+}
+
+pub fn save(preset: &EqPreset) -> Result<(), SinkError> {
+    let name = sanitize_name(&preset.name)?;
+    if preset.bands.is_empty() {
+        return Err(SinkError::Config("a preset needs at least one band".into()));
+    }
+    let dir = presets_dir()?;
+    crate::persistence::ensure_private_dir(&dir)?;
+    let json = serde_json::to_string_pretty(preset)
+        .map_err(|e| SinkError::Config(format!("serialize eq preset: {e}")))?;
+    super::write_atomic(&dir.join(format!("{name}.json")), &json)?;
+    Ok(())
+}
+
+pub fn delete(name: &str) -> Result<(), SinkError> {
+    let name = sanitize_name(name)?;
+    let path = presets_dir()?.join(format!("{name}.json"));
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()), // idempotent
+        Err(e) => Err(SinkError::Io(e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn traversal_names_are_rejected() {
+        // sanitize_name (shared with profiles) is the barrier; pin that it
+        // holds for the preset entry points too.
+        assert!(delete("../etc/passwd").is_err());
+        let preset = EqPreset {
+            schema: PRESET_SCHEMA,
+            name: "../escape".into(),
+            author: None,
+            description: None,
+            preamp_db: 0.0,
+            bands: crate::audio::types::default_eq_bands(),
+        };
+        assert!(save(&preset).is_err());
+    }
+
+    #[test]
+    fn empty_band_presets_are_rejected() {
+        let preset = EqPreset {
+            schema: PRESET_SCHEMA,
+            name: "Empty".into(),
+            author: None,
+            description: None,
+            preamp_db: 0.0,
+            bands: Vec::new(),
+        };
+        assert!(save(&preset).is_err());
+    }
+}

--- a/src-tauri/src/persistence/mod.rs
+++ b/src-tauri/src/persistence/mod.rs
@@ -4,6 +4,7 @@ pub mod assignments;
 pub mod autostart;
 pub mod buses;
 pub mod channels;
+pub mod eq;
 pub mod mic;
 pub mod outputs;
 pub mod prefs;

--- a/src-tauri/src/persistence/mod.rs
+++ b/src-tauri/src/persistence/mod.rs
@@ -5,6 +5,7 @@ pub mod autostart;
 pub mod buses;
 pub mod channels;
 pub mod eq;
+pub mod eq_presets;
 pub mod mic;
 pub mod outputs;
 pub mod prefs;

--- a/src-tauri/src/persistence/profiles.rs
+++ b/src-tauri/src/persistence/profiles.rs
@@ -18,6 +18,9 @@ pub struct Profile {
     /// Added in Phase 4; default keeps older profile files loadable.
     #[serde(default)]
     pub outputs: crate::persistence::outputs::ChannelOutputs,
+    /// Per-channel parametric EQ; default keeps older profile files loadable.
+    #[serde(default)]
+    pub eq: crate::persistence::eq::ChannelEq,
     /// Phase 5: output device (node.name) whose appearance auto-loads this
     /// profile — Sonar-style hardware profile switching.
     #[serde(default)]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -36,6 +36,7 @@ impl AppState {
             assignments: crate::persistence::assignments::Assignments::load(),
             aliases: crate::persistence::aliases::Aliases::load(),
             outputs: crate::persistence::outputs::ChannelOutputs::load(),
+            eq: crate::persistence::eq::ChannelEq::load(),
             mic: crate::persistence::mic::load(),
             channel_defs,
             buses,

--- a/src/components/Eq/EqBandRow.tsx
+++ b/src/components/Eq/EqBandRow.tsx
@@ -1,0 +1,95 @@
+import type { EqBand, EqBandKind } from "../../types";
+import { EQ_FREQ_MAX_HZ, EQ_FREQ_MIN_HZ, EQ_GAIN_RANGE_DB } from "../../types";
+import { Ms } from "../Icons";
+
+const KINDS: { value: EqBandKind; label: string }[] = [
+  { value: "peaking", label: "Peak" },
+  { value: "low_shelf", label: "Low shelf" },
+  { value: "high_shelf", label: "High shelf" },
+  { value: "low_pass", label: "Low pass" },
+  { value: "high_pass", label: "High pass" },
+];
+
+const isShelf = (kind: EqBandKind) => kind === "low_shelf" || kind === "high_shelf";
+const isPass = (kind: EqBandKind) => kind === "low_pass" || kind === "high_pass";
+
+interface EqBandRowProps {
+  band: EqBand;
+  selected: boolean;
+  onSelect: () => void;
+  onChange: (patch: Partial<EqBand>) => void;
+  onRemove: () => void;
+}
+
+/** Numeric editor for one band — the keyboard-accessible twin of the
+ *  curve dot (drag isn't reachable for everyone). */
+export function EqBandRow({ band, selected, onSelect, onChange, onRemove }: EqBandRowProps) {
+  const clampNum = (v: string, lo: number, hi: number, fallback: number) => {
+    const n = Number(v);
+    return Number.isFinite(n) ? Math.max(lo, Math.min(hi, n)) : fallback;
+  };
+
+  return (
+    <div className={"eqm-band" + (selected ? " sel" : "")} onPointerDown={onSelect}>
+      <select
+        className="eqm-kind"
+        value={band.kind}
+        aria-label="Band type"
+        onChange={(e) => onChange({ kind: e.target.value as EqBandKind })}
+      >
+        {KINDS.map((k) => (
+          <option key={k.value} value={k.value}>
+            {k.label}
+          </option>
+        ))}
+      </select>
+      <label className="eqm-field">
+        <span>Hz</span>
+        <input
+          type="number"
+          min={EQ_FREQ_MIN_HZ}
+          max={EQ_FREQ_MAX_HZ}
+          step={1}
+          value={Math.round(band.freq_hz)}
+          onChange={(e) =>
+            onChange({
+              freq_hz: clampNum(e.target.value, EQ_FREQ_MIN_HZ, EQ_FREQ_MAX_HZ, band.freq_hz),
+            })
+          }
+        />
+      </label>
+      <label className="eqm-field">
+        <span>dB</span>
+        <input
+          type="number"
+          min={-EQ_GAIN_RANGE_DB}
+          max={EQ_GAIN_RANGE_DB}
+          step={0.5}
+          value={band.gain_db}
+          disabled={isPass(band.kind)}
+          title={isPass(band.kind) ? "Pass filters have no gain" : undefined}
+          onChange={(e) =>
+            onChange({
+              gain_db: clampNum(e.target.value, -EQ_GAIN_RANGE_DB, EQ_GAIN_RANGE_DB, band.gain_db),
+            })
+          }
+        />
+      </label>
+      <label className="eqm-field">
+        {/* One schema field, two meanings (see EqBand.q). */}
+        <span>{isShelf(band.kind) ? "Slope" : "Q"}</span>
+        <input
+          type="number"
+          min={0.1}
+          max={10}
+          step={0.1}
+          value={band.q}
+          onChange={(e) => onChange({ q: clampNum(e.target.value, 0.1, 10, band.q) })}
+        />
+      </label>
+      <button className="eqm-remove" title="Remove band" aria-label="Remove band" onClick={onRemove}>
+        <Ms name="close" style={{ fontSize: 14 }} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/Eq/EqCurve.tsx
+++ b/src/components/Eq/EqCurve.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { EqBand, EqConfig } from "../../types";
+import { EQ_GAIN_RANGE_DB } from "../../types";
+import { curvePoints, freqToX, xToFreq } from "../../lib/eqMath";
+
+// SVG coordinate space; the element scales responsively.
+const W = 600;
+const H = 220;
+const PAD = 8;
+
+const dbToY = (db: number) =>
+  PAD + ((EQ_GAIN_RANGE_DB - db) / (2 * EQ_GAIN_RANGE_DB)) * (H - 2 * PAD);
+const yToDb = (y: number) =>
+  EQ_GAIN_RANGE_DB - ((y - PAD) / (H - 2 * PAD)) * 2 * EQ_GAIN_RANGE_DB;
+const fxToX = (fx: number) => PAD + fx * (W - 2 * PAD);
+const xToFx = (x: number) => (x - PAD) / (W - 2 * PAD);
+
+/** Frequencies that get a labeled grid line. */
+const GRID_FREQS = [50, 100, 500, 1000, 5000, 10000];
+const GRID_DBS = [-12, 0, 12];
+
+const fmtFreq = (hz: number) => (hz >= 1000 ? `${hz / 1000}k` : `${hz}`);
+
+/** Bands without a gain axis: their dot rides the 0 dB line. */
+const gainless = (band: EqBand) => band.kind === "low_pass" || band.kind === "high_pass";
+
+interface EqCurveProps {
+  config: EqConfig;
+  selected: number;
+  onSelect: (index: number) => void;
+  onBandChange: (index: number, patch: Partial<EqBand>) => void;
+}
+
+/** The interactive response curve: drag a dot to set freq/gain, scroll on
+ *  it to tighten/widen Q, double-click to zero the band. */
+export function EqCurve({ config, selected, onSelect, onBandChange }: EqCurveProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const dragIndex = useRef<number>(-1);
+
+  const dragTo = useCallback(
+    (clientX: number, clientY: number) => {
+      const svg = svgRef.current;
+      const index = dragIndex.current;
+      if (!svg || index < 0) return;
+      const band = config.bands[index];
+      if (!band) return;
+      const r = svg.getBoundingClientRect();
+      const x = ((clientX - r.left) / r.width) * W;
+      const y = ((clientY - r.top) / r.height) * H;
+      const freq_hz = Math.round(xToFreq(xToFx(x)));
+      const patch: Partial<EqBand> = { freq_hz };
+      if (!gainless(band)) {
+        const db = Math.max(-EQ_GAIN_RANGE_DB, Math.min(EQ_GAIN_RANGE_DB, yToDb(y)));
+        patch.gain_db = Math.round(db * 10) / 10;
+      }
+      onBandChange(index, patch);
+    },
+    [config.bands, onBandChange],
+  );
+
+  // Window-level listeners attached once; latest handler via ref (Fader idiom).
+  const dragToRef = useRef(dragTo);
+  dragToRef.current = dragTo;
+
+  useEffect(() => {
+    const move = (e: PointerEvent) => {
+      if (dragIndex.current >= 0) dragToRef.current(e.clientX, e.clientY);
+    };
+    const up = () => {
+      dragIndex.current = -1;
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+    return () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+  }, []);
+
+  const points = curvePoints(config);
+  const path = points
+    .map(
+      (p, i) =>
+        `${i === 0 ? "M" : "L"}${fxToX(freqToX(p.freq)).toFixed(1)},${dbToY(
+          Math.max(-EQ_GAIN_RANGE_DB, Math.min(EQ_GAIN_RANGE_DB, p.db)),
+        ).toFixed(1)}`,
+    )
+    .join(" ");
+  const zeroY = dbToY(0);
+  const fill = `${path} L${fxToX(1).toFixed(1)},${zeroY} L${fxToX(0).toFixed(1)},${zeroY} Z`;
+
+  return (
+    <svg
+      ref={svgRef}
+      className={"eqm-curve" + (config.enabled ? "" : " off")}
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label="EQ frequency response"
+    >
+      {GRID_FREQS.map((f) => (
+        <g key={f}>
+          <line
+            className="eqm-grid"
+            x1={fxToX(freqToX(f))}
+            x2={fxToX(freqToX(f))}
+            y1={PAD}
+            y2={H - PAD}
+          />
+          <text className="eqm-grid-label" x={fxToX(freqToX(f)) + 3} y={H - PAD - 4}>
+            {fmtFreq(f)}
+          </text>
+        </g>
+      ))}
+      {GRID_DBS.map((db) => (
+        <g key={db}>
+          <line
+            className={"eqm-grid" + (db === 0 ? " zero" : "")}
+            x1={PAD}
+            x2={W - PAD}
+            y1={dbToY(db)}
+            y2={dbToY(db)}
+          />
+          <text className="eqm-grid-label" x={PAD + 2} y={dbToY(db) - 3}>
+            {db > 0 ? `+${db}` : db}
+          </text>
+        </g>
+      ))}
+      <path className="eqm-fill" d={fill} />
+      <path className="eqm-line" d={path} />
+      {config.bands.map((band, i) => (
+        <circle
+          key={i}
+          className={"eqm-dot" + (i === selected ? " sel" : "")}
+          cx={fxToX(freqToX(band.freq_hz))}
+          cy={gainless(band) ? zeroY : dbToY(band.gain_db)}
+          r={i === selected ? 8 : 6}
+          onPointerDown={(e) => {
+            e.preventDefault();
+            onSelect(i);
+            dragIndex.current = i;
+          }}
+          onDoubleClick={() => onBandChange(i, { gain_db: 0 })}
+          onWheel={(e) => {
+            // Scroll tightens/widens the band (Q, or slope on shelves).
+            const dir = e.deltaY > 0 ? -1 : 1;
+            const q = Math.max(0.1, Math.min(10, band.q * (dir > 0 ? 1.12 : 1 / 1.12)));
+            onBandChange(i, { q: Math.round(q * 100) / 100 });
+          }}
+        >
+          <title>{`${Math.round(band.freq_hz)} Hz, ${band.gain_db.toFixed(1)} dB — drag to move, scroll for width, double-click to zero`}</title>
+        </circle>
+      ))}
+    </svg>
+  );
+}

--- a/src/components/Eq/EqModal.tsx
+++ b/src/components/Eq/EqModal.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { useMixerStore } from "../../store/mixer";
+import type { EqBand, EqConfig, VirtualSink } from "../../types";
+import { defaultEqConfig, MAX_EQ_BANDS } from "../../types";
+import { Modal } from "../Modal";
+import { Ms } from "../Icons";
+import { Toggle } from "../Toggle";
+import { DspSlider } from "../Mic/DspSlider";
+import { EqBandRow } from "./EqBandRow";
+import { EqCurve } from "./EqCurve";
+
+interface EqModalProps {
+  channel: VirtualSink;
+  open: boolean;
+  onClose: () => void;
+}
+
+/** Per-channel parametric EQ editor: response curve, band list, preamp. */
+export function EqModal({ channel, open, onClose }: EqModalProps) {
+  const config = useMixerStore(
+    (s) => s.eqConfigs[channel.name] ?? null,
+  ) ?? defaultEqConfig();
+  const setChannelEq = useMixerStore((s) => s.setChannelEq);
+  const backendNative = useMixerStore((s) => s.backendNative);
+  const [selected, setSelected] = useState(0);
+
+  const apply = (next: EqConfig) => void setChannelEq(channel.name, next);
+
+  const patchBand = (index: number, patch: Partial<EqBand>) => {
+    const bands = config.bands.map((b, i) => (i === index ? { ...b, ...patch } : b));
+    apply({ ...config, bands });
+  };
+
+  const addBand = () => {
+    if (config.bands.length >= MAX_EQ_BANDS) return;
+    const bands = [...config.bands, { kind: "peaking" as const, freq_hz: 1000, gain_db: 0, q: 1 }];
+    apply({ ...config, bands });
+    setSelected(bands.length - 1);
+  };
+
+  const removeBand = (index: number) => {
+    if (config.bands.length <= 1) return;
+    const bands = config.bands.filter((_, i) => i !== index);
+    apply({ ...config, bands });
+    setSelected(Math.min(selected, bands.length - 1));
+  };
+
+  const reset = () => {
+    // Back to the flat starting layout; the enable switch is left alone.
+    apply({ ...defaultEqConfig(), enabled: config.enabled });
+    setSelected(0);
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={`${channel.label} — Equalizer`}
+      className="eqm-modal"
+    >
+      {backendNative === false && (
+        <p className="modal-text">
+          Parametric EQ requires the native PipeWire engine, which isn't
+          running on this system.
+        </p>
+      )}
+      <div className="eqm-head">
+        <div className="eqm-enable">
+          <Toggle
+            on={config.enabled}
+            onClick={() => apply({ ...config, enabled: !config.enabled })}
+          />
+          <span>{config.enabled ? "On" : "Off"}</span>
+        </div>
+        <button className="select" onClick={reset} title="Back to the flat 5-band layout">
+          <Ms name="restart_alt" style={{ fontSize: 15 }} />
+          <span>Reset</span>
+        </button>
+      </div>
+
+      <EqCurve
+        config={config}
+        selected={selected}
+        onSelect={setSelected}
+        onBandChange={patchBand}
+      />
+
+      <DspSlider
+        label="Preamp"
+        min={-24}
+        max={24}
+        step={0.5}
+        unit=" dB"
+        value={config.preamp_db}
+        defaultValue={0}
+        onChange={(v) => apply({ ...config, preamp_db: v })}
+      />
+
+      <div className="eqm-bands">
+        {config.bands.map((band, i) => (
+          <EqBandRow
+            key={i}
+            band={band}
+            selected={i === selected}
+            onSelect={() => setSelected(i)}
+            onChange={(patch) => patchBand(i, patch)}
+            onRemove={() => removeBand(i)}
+          />
+        ))}
+        {config.bands.length < MAX_EQ_BANDS && (
+          <button className="eqm-add" onClick={addBand}>
+            <Ms name="add" style={{ fontSize: 15 }} />
+            Add band
+          </button>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/Eq/EqModal.tsx
+++ b/src/components/Eq/EqModal.tsx
@@ -8,6 +8,7 @@ import { Toggle } from "../Toggle";
 import { DspSlider } from "../Mic/DspSlider";
 import { EqBandRow } from "./EqBandRow";
 import { EqCurve } from "./EqCurve";
+import { EqPresetMenu } from "./EqPresetMenu";
 
 interface EqModalProps {
   channel: VirtualSink;
@@ -23,6 +24,9 @@ export function EqModal({ channel, open, onClose }: EqModalProps) {
   const setChannelEq = useMixerStore((s) => s.setChannelEq);
   const backendNative = useMixerStore((s) => s.backendNative);
   const [selected, setSelected] = useState(0);
+
+  // Surface preset/import failures on the app's global error banner.
+  const setError = (message: string) => useMixerStore.setState({ error: message });
 
   const apply = (next: EqConfig) => void setChannelEq(channel.name, next);
 
@@ -72,10 +76,18 @@ export function EqModal({ channel, open, onClose }: EqModalProps) {
           />
           <span>{config.enabled ? "On" : "Off"}</span>
         </div>
-        <button className="select" onClick={reset} title="Back to the flat 5-band layout">
-          <Ms name="restart_alt" style={{ fontSize: 15 }} />
-          <span>Reset</span>
-        </button>
+        <div className="eqm-head-actions">
+          <EqPresetMenu
+            sinkName={channel.name}
+            config={config}
+            onApply={apply}
+            onError={setError}
+          />
+          <button className="select" onClick={reset} title="Back to the flat 5-band layout">
+            <Ms name="restart_alt" style={{ fontSize: 15 }} />
+            <span>Reset</span>
+          </button>
+        </div>
       </div>
 
       <EqCurve

--- a/src/components/Eq/EqPresetMenu.tsx
+++ b/src/components/Eq/EqPresetMenu.tsx
@@ -137,24 +137,21 @@ export function EqPresetMenu({ sinkName, config, onApply, onError }: EqPresetMen
         style={{ minWidth: 260 }}
       >
         {presets.map((entry) => (
-          <div
-            key={`${entry.source}:${entry.preset.name}`}
-            className="menu-item"
-            title={entry.preset.description ?? undefined}
-            onClick={() => applyPreset(entry)}
-          >
-            <Ms name={entry.source === "bundled" ? "verified" : "person"} />
-            <span>{entry.preset.name}</span>
+          <div key={`${entry.source}:${entry.preset.name}`} className="eqm-preset-row">
+            <button
+              className="menu-item eqm-preset-apply"
+              title={entry.preset.description ?? undefined}
+              onClick={() => applyPreset(entry)}
+            >
+              <Ms name={entry.source === "bundled" ? "verified" : "person"} />
+              <span>{entry.preset.name}</span>
+            </button>
             {entry.source === "user" && (
               <button
                 className="eqm-remove"
-                style={{ marginLeft: "auto" }}
                 title="Delete preset"
                 aria-label={`Delete preset ${entry.preset.name}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  void deletePreset(entry.preset.name);
-                }}
+                onClick={() => void deletePreset(entry.preset.name)}
               >
                 <Ms name="close" style={{ fontSize: 13 }} />
               </button>
@@ -207,15 +204,15 @@ export function EqPresetMenu({ sinkName, config, onApply, onError }: EqPresetMen
             </div>
           </div>
         ) : (
-          <div className="menu-item" onClick={() => setImporting(true)}>
+          <button className="menu-item eqm-menu-btn" onClick={() => setImporting(true)}>
             <Ms name="content_paste" />
             <span>Import (paste / AutoEq / file)</span>
-          </div>
+          </button>
         )}
-        <div className="menu-item" onClick={() => void exportToFile()}>
+        <button className="menu-item eqm-menu-btn" onClick={() => void exportToFile()}>
           <Ms name="download" />
           <span>Export to file…</span>
-        </div>
+        </button>
       </Popover>
     </div>
   );

--- a/src/components/Eq/EqPresetMenu.tsx
+++ b/src/components/Eq/EqPresetMenu.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
+import type { EqConfig } from "../../types";
+import { Ms } from "../Icons";
+import { Popover } from "../Popover";
+
+interface EqPresetEntry {
+  source: "bundled" | "user";
+  preset: {
+    schema: number;
+    name: string;
+    author?: string | null;
+    description?: string | null;
+    preamp_db: number;
+    bands: EqConfig["bands"];
+  };
+}
+
+interface EqPresetMenuProps {
+  sinkName: string;
+  config: EqConfig;
+  onApply: (config: EqConfig) => void;
+  onError: (message: string) => void;
+}
+
+/** Preset picker + import/export. Bundled presets ship inside the binary
+ *  (repo presets/eq/); user presets live in ~/.config/sink/eq_presets. */
+export function EqPresetMenu({ sinkName, config, onApply, onError }: EqPresetMenuProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [presets, setPresets] = useState<EqPresetEntry[]>([]);
+  const [saveName, setSaveName] = useState("");
+  const [importing, setImporting] = useState(false);
+  const [importText, setImportText] = useState("");
+
+  const refresh = () => {
+    invoke<EqPresetEntry[]>("list_eq_presets")
+      .then(setPresets)
+      .catch((e) => onError(String(e)));
+  };
+
+  useEffect(() => {
+    if (menuOpen) refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [menuOpen]);
+
+  const applyPreset = (entry: EqPresetEntry) => {
+    setMenuOpen(false);
+    // A preset carries bands + preamp; applying always switches the EQ on.
+    onApply({
+      enabled: true,
+      preamp_db: entry.preset.preamp_db,
+      bands: entry.preset.bands.map((b) => ({ ...b })),
+    });
+  };
+
+  const saveCurrent = async () => {
+    const name = saveName.trim();
+    if (!name) return;
+    try {
+      await invoke("save_user_eq_preset", { name, config });
+      setSaveName("");
+      refresh();
+    } catch (e) {
+      onError(String(e));
+    }
+  };
+
+  const applyImported = (imported: EqConfig) => {
+    // Imports parse to a disabled config (preview semantics); keep the
+    // channel's current on/off state so importing never surprises.
+    onApply({ ...imported, enabled: config.enabled });
+    setImporting(false);
+    setImportText("");
+    setMenuOpen(false);
+  };
+
+  const importPasted = async () => {
+    try {
+      applyImported(await invoke<EqConfig>("import_eq_config", { text: importText }));
+    } catch (e) {
+      onError(String(e));
+    }
+  };
+
+  const importFromFile = async () => {
+    try {
+      const path = await openDialog({
+        multiple: false,
+        filters: [{ name: "EQ preset", extensions: ["json", "txt"] }],
+      });
+      if (typeof path !== "string") return;
+      applyImported(await invoke<EqConfig>("import_eq_file", { path }));
+    } catch (e) {
+      onError(String(e));
+    }
+  };
+
+  const exportToFile = async () => {
+    try {
+      const path = await saveDialog({
+        defaultPath: `${sinkName.replace(/^sink_/, "")}-eq.json`,
+        filters: [{ name: "EQ preset", extensions: ["json"] }],
+      });
+      if (typeof path !== "string") return;
+      await invoke("export_channel_eq_to_file", { sinkName, path });
+      setMenuOpen(false);
+    } catch (e) {
+      onError(String(e));
+    }
+  };
+
+  const deletePreset = async (name: string) => {
+    try {
+      await invoke("delete_user_eq_preset", { name });
+      refresh();
+    } catch (e) {
+      onError(String(e));
+    }
+  };
+
+  return (
+    <div style={{ position: "relative" }}>
+      <button className="select" onClick={() => setMenuOpen((o) => !o)}>
+        <Ms name="library_music" style={{ fontSize: 15 }} />
+        <span>Presets</span>
+        <Ms name="expand_more" />
+      </button>
+      <Popover
+        open={menuOpen}
+        onClose={() => {
+          setMenuOpen(false);
+          setImporting(false);
+        }}
+        side="bottom"
+        align="end"
+        style={{ minWidth: 260 }}
+      >
+        {presets.map((entry) => (
+          <div
+            key={`${entry.source}:${entry.preset.name}`}
+            className="menu-item"
+            title={entry.preset.description ?? undefined}
+            onClick={() => applyPreset(entry)}
+          >
+            <Ms name={entry.source === "bundled" ? "verified" : "person"} />
+            <span>{entry.preset.name}</span>
+            {entry.source === "user" && (
+              <button
+                className="eqm-remove"
+                style={{ marginLeft: "auto" }}
+                title="Delete preset"
+                aria-label={`Delete preset ${entry.preset.name}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void deletePreset(entry.preset.name);
+                }}
+              >
+                <Ms name="close" style={{ fontSize: 13 }} />
+              </button>
+            )}
+          </div>
+        ))}
+
+        <div className="menu-sep" />
+        <div className="eqm-save-row">
+          <input
+            className="menu-input"
+            placeholder="Save current as…"
+            value={saveName}
+            maxLength={64}
+            onChange={(e) => setSaveName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void saveCurrent();
+            }}
+          />
+          <button
+            className="select"
+            disabled={!saveName.trim()}
+            onClick={() => void saveCurrent()}
+          >
+            <Ms name="save" style={{ fontSize: 15 }} />
+          </button>
+        </div>
+
+        <div className="menu-sep" />
+        {importing ? (
+          <div className="eqm-import">
+            <textarea
+              className="eqm-import-text"
+              placeholder={"Paste preset JSON or an AutoEq block:\nPreamp: -6.0 dB\nFilter 1: ON PK Fc 105 Hz Gain -2.4 dB Q 0.70"}
+              value={importText}
+              autoFocus
+              onChange={(e) => setImportText(e.target.value)}
+            />
+            <div className="eqm-import-btns">
+              <button
+                className="select"
+                disabled={!importText.trim()}
+                onClick={() => void importPasted()}
+              >
+                Import
+              </button>
+              <button className="select" onClick={() => void importFromFile()}>
+                From file…
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="menu-item" onClick={() => setImporting(true)}>
+            <Ms name="content_paste" />
+            <span>Import (paste / AutoEq / file)</span>
+          </div>
+        )}
+        <div className="menu-item" onClick={() => void exportToFile()}>
+          <Ms name="download" />
+          <span>Export to file…</span>
+        </div>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/MixerBoard/ChannelStrip.tsx
+++ b/src/components/MixerBoard/ChannelStrip.tsx
@@ -6,6 +6,7 @@ import { channelIcon, Ms, ICON_CHOICES } from "../Icons";
 import { Modal } from "../Modal";
 import { Popover } from "../Popover";
 import { perceptual, volToDb } from "../../lib/audio";
+import { EqModal } from "../Eq/EqModal";
 import { ChannelApps } from "./ChannelApps";
 import { Fader } from "./Fader";
 import { OutputSelect } from "./OutputSelect";
@@ -44,11 +45,14 @@ export function ChannelStrip({
   const monitoring = useMixerStore((s) => s.monitors[channel.name] ?? false);
   const toggleMonitor = useMixerStore((s) => s.toggleMonitor);
 
+  const eqEnabled = useMixerStore((s) => s.eqConfigs[channel.name]?.enabled ?? false);
+
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [pickingIcon, setPickingIcon] = useState(false);
   const [managingApps, setManagingApps] = useState(false);
+  const [editingEq, setEditingEq] = useState(false);
 
   const commitRename = () => {
     setEditing(false);
@@ -196,7 +200,17 @@ export function ChannelStrip({
         >
           <Ms name="headphones" style={{ fontSize: 16 }} />
         </button>
+        <button
+          className={"sbtn" + (eqEnabled ? " on-eq" : "")}
+          onClick={() => setEditingEq(true)}
+          aria-pressed={eqEnabled}
+          title="Equalizer"
+        >
+          <Ms name="tune" style={{ fontSize: 16 }} />
+        </button>
       </div>
+
+      <EqModal channel={channel} open={editingEq} onClose={() => setEditingEq(false)} />
 
       <OutputSelect
         compact

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -7,11 +7,14 @@ export function Modal({
   onClose,
   title,
   children,
+  className,
 }: {
   open: boolean;
   onClose: () => void;
   title: string;
   children: ReactNode;
+  /** Extra class on the dialog (e.g. a width variant). */
+  className?: string;
 }) {
   useEffect(() => {
     if (!open) return;
@@ -26,7 +29,7 @@ export function Modal({
   return (
     <div className="modal-scrim" onClick={onClose}>
       <div
-        className="modal"
+        className={"modal" + (className ? ` ${className}` : "")}
         role="dialog"
         aria-label={title}
         onClick={(e) => e.stopPropagation()}

--- a/src/lib/eqMath.test.ts
+++ b/src/lib/eqMath.test.ts
@@ -1,0 +1,54 @@
+// Pins the TS side of the hand-synced RBJ math (the Rust twin lives in
+// src-tauri/src/audio/pw_native/eq.rs with the same assertions).
+
+import { describe, expect, it } from "vitest";
+import { curvePoints, freqToX, magnitudeDb, xToFreq } from "./eqMath";
+import type { EqBand } from "../types";
+import { defaultEqConfig } from "../types";
+
+const band = (kind: EqBand["kind"], freq_hz: number, gain_db: number, q: number): EqBand => ({
+  kind,
+  freq_hz,
+  gain_db,
+  q,
+});
+
+describe("eqMath", () => {
+  it("peaking band matches its gain at the center frequency", () => {
+    const db = magnitudeDb([band("peaking", 1000, 6, 1)], 0, 1000);
+    expect(db).toBeCloseTo(6, 1);
+  });
+
+  it("peaking band is flat far from the center", () => {
+    const db = magnitudeDb([band("peaking", 1000, 12, 2)], 0, 60);
+    expect(Math.abs(db)).toBeLessThan(0.5);
+  });
+
+  it("low pass rolls off above the cutoff", () => {
+    const bands = [band("low_pass", 1000, 0, 0.71)];
+    expect(Math.abs(magnitudeDb(bands, 0, 100))).toBeLessThan(0.5);
+    expect(magnitudeDb(bands, 0, 8000)).toBeLessThan(-30);
+  });
+
+  it("a flat config is 0 dB everywhere", () => {
+    const config = defaultEqConfig();
+    for (const { db } of curvePoints(config, 32)) {
+      expect(Math.abs(db)).toBeLessThan(0.01);
+    }
+  });
+
+  it("preamp shifts the whole curve uniformly", () => {
+    const config = { ...defaultEqConfig(), preamp_db: -6 };
+    for (const { db } of curvePoints(config, 16)) {
+      expect(db).toBeCloseTo(-6, 3);
+    }
+  });
+
+  it("freqToX and xToFreq are inverses on the log axis", () => {
+    for (const freq of [20, 100, 1000, 10000, 20000]) {
+      expect(xToFreq(freqToX(freq))).toBeCloseTo(freq, 0);
+    }
+    expect(freqToX(20)).toBe(0);
+    expect(freqToX(20000)).toBe(1);
+  });
+});

--- a/src/lib/eqMath.ts
+++ b/src/lib/eqMath.ts
@@ -1,0 +1,156 @@
+// Frequency-response math for the EQ curve — a hand-synced mirror of the
+// RBJ designs in src-tauri/src/audio/pw_native/eq.rs. If a formula changes
+// on either side, change both; the parallel test suites pin the contract.
+
+import type { EqBand, EqBandKind, EqConfig } from "../types";
+import { EQ_FREQ_MAX_HZ, EQ_FREQ_MIN_HZ } from "../types";
+
+export interface Biquad {
+  b0: number;
+  b1: number;
+  b2: number;
+  a1: number;
+  a2: number;
+}
+
+/** RBJ Audio EQ Cookbook design (see eq.rs for the shared conventions:
+ *  shelves use q as slope S, low/high pass ignore gain). */
+export function biquadCoeffs(
+  kind: EqBandKind,
+  freqHz: number,
+  gainDb: number,
+  q: number,
+  sampleRate = 48000,
+): Biquad {
+  const freq = Math.min(Math.max(freqHz, 1), sampleRate * 0.49);
+  const safeQ = Math.max(q, 0.01);
+  const w0 = (2 * Math.PI * freq) / sampleRate;
+  const sinW0 = Math.sin(w0);
+  const cosW0 = Math.cos(w0);
+  const a = Math.pow(10, gainDb / 40);
+
+  let b0: number, b1: number, b2: number, a0: number, a1: number, a2: number;
+  switch (kind) {
+    case "peaking": {
+      const alpha = sinW0 / (2 * safeQ);
+      b0 = 1 + alpha * a;
+      b1 = -2 * cosW0;
+      b2 = 1 - alpha * a;
+      a0 = 1 + alpha / a;
+      a1 = -2 * cosW0;
+      a2 = 1 - alpha / a;
+      break;
+    }
+    case "low_shelf":
+    case "high_shelf": {
+      const s = safeQ;
+      const alpha =
+        (sinW0 / 2) * Math.sqrt(Math.max((a + 1 / a) * (1 / s - 1) + 2, 0));
+      const twoSqrtAAlpha = 2 * Math.sqrt(a) * alpha;
+      const ap1 = a + 1;
+      const am1 = a - 1;
+      if (kind === "low_shelf") {
+        b0 = a * (ap1 - am1 * cosW0 + twoSqrtAAlpha);
+        b1 = 2 * a * (am1 - ap1 * cosW0);
+        b2 = a * (ap1 - am1 * cosW0 - twoSqrtAAlpha);
+        a0 = ap1 + am1 * cosW0 + twoSqrtAAlpha;
+        a1 = -2 * (am1 + ap1 * cosW0);
+        a2 = ap1 + am1 * cosW0 - twoSqrtAAlpha;
+      } else {
+        b0 = a * (ap1 + am1 * cosW0 + twoSqrtAAlpha);
+        b1 = -2 * a * (am1 + ap1 * cosW0);
+        b2 = a * (ap1 + am1 * cosW0 - twoSqrtAAlpha);
+        a0 = ap1 - am1 * cosW0 + twoSqrtAAlpha;
+        a1 = 2 * (am1 - ap1 * cosW0);
+        a2 = ap1 - am1 * cosW0 - twoSqrtAAlpha;
+      }
+      break;
+    }
+    case "low_pass": {
+      const alpha = sinW0 / (2 * safeQ);
+      const oneMinusCos = 1 - cosW0;
+      b0 = oneMinusCos / 2;
+      b1 = oneMinusCos;
+      b2 = oneMinusCos / 2;
+      a0 = 1 + alpha;
+      a1 = -2 * cosW0;
+      a2 = 1 - alpha;
+      break;
+    }
+    case "high_pass": {
+      const alpha = sinW0 / (2 * safeQ);
+      const onePlusCos = 1 + cosW0;
+      b0 = onePlusCos / 2;
+      b1 = -onePlusCos;
+      b2 = onePlusCos / 2;
+      a0 = 1 + alpha;
+      a1 = -2 * cosW0;
+      a2 = 1 - alpha;
+      break;
+    }
+  }
+  return { b0: b0 / a0, b1: b1 / a0, b2: b2 / a0, a1: a1 / a0, a2: a2 / a0 };
+}
+
+/** |H(e^jw)| of one biquad at `freqHz`, in dB. */
+function biquadMagnitudeDb(c: Biquad, freqHz: number, sampleRate: number): number {
+  const w = (2 * Math.PI * freqHz) / sampleRate;
+  const numRe = c.b0 + c.b1 * Math.cos(w) + c.b2 * Math.cos(2 * w);
+  const numIm = -(c.b1 * Math.sin(w) + c.b2 * Math.sin(2 * w));
+  const denRe = 1 + c.a1 * Math.cos(w) + c.a2 * Math.cos(2 * w);
+  const denIm = -(c.a1 * Math.sin(w) + c.a2 * Math.sin(2 * w));
+  const mag = Math.sqrt(
+    (numRe * numRe + numIm * numIm) / (denRe * denRe + denIm * denIm),
+  );
+  return 20 * Math.log10(mag);
+}
+
+/** Combined response of the whole config (preamp + band cascade) at `freqHz`. */
+export function magnitudeDb(
+  bands: EqBand[],
+  preampDb: number,
+  freqHz: number,
+  sampleRate = 48000,
+): number {
+  let db = preampDb;
+  for (const band of bands) {
+    const c = biquadCoeffs(band.kind, band.freq_hz, band.gain_db, band.q, sampleRate);
+    db += biquadMagnitudeDb(c, freqHz, sampleRate);
+  }
+  return db;
+}
+
+/** Log-spaced response samples across the audible range, for the SVG path. */
+export function curvePoints(
+  config: EqConfig,
+  steps = 128,
+  sampleRate = 48000,
+): { freq: number; db: number }[] {
+  const logMin = Math.log10(EQ_FREQ_MIN_HZ);
+  const logMax = Math.log10(EQ_FREQ_MAX_HZ);
+  const points: { freq: number; db: number }[] = [];
+  for (let i = 0; i <= steps; i++) {
+    const freq = Math.pow(10, logMin + ((logMax - logMin) * i) / steps);
+    points.push({
+      freq,
+      db: magnitudeDb(config.bands, config.preamp_db, freq, sampleRate),
+    });
+  }
+  return points;
+}
+
+/** X position of a frequency on the log axis, as 0..1. */
+export function freqToX(freqHz: number): number {
+  const logMin = Math.log10(EQ_FREQ_MIN_HZ);
+  const logMax = Math.log10(EQ_FREQ_MAX_HZ);
+  const clamped = Math.min(Math.max(freqHz, EQ_FREQ_MIN_HZ), EQ_FREQ_MAX_HZ);
+  return (Math.log10(clamped) - logMin) / (logMax - logMin);
+}
+
+/** Inverse of freqToX. */
+export function xToFreq(x: number): number {
+  const logMin = Math.log10(EQ_FREQ_MIN_HZ);
+  const logMax = Math.log10(EQ_FREQ_MAX_HZ);
+  const t = Math.min(Math.max(x, 0), 1);
+  return Math.pow(10, logMin + (logMax - logMin) * t);
+}

--- a/src/store/mixer.test.ts
+++ b/src/store/mixer.test.ts
@@ -8,6 +8,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 import { useMixerStore } from "./mixer";
 import type { VirtualSink } from "../types";
+import { defaultEqConfig } from "../types";
 
 const channel = (name: string, volume = 100): VirtualSink => ({
   name,
@@ -97,5 +98,37 @@ describe("setLevels", () => {
   it("stores per-sink peaks", () => {
     useMixerStore.getState().setLevels({ sink_game: [0.5, 0.4] });
     expect(useMixerStore.getState().levels["sink_game"]).toEqual([0.5, 0.4]);
+  });
+});
+
+describe("setChannelEq", () => {
+  it("applies optimistically and debounces per channel", async () => {
+    const store = useMixerStore.getState();
+    const config = {
+      ...defaultEqConfig(),
+      enabled: true,
+    };
+
+    await store.setChannelEq("sink_game", { ...config, preamp_db: -2 });
+    await store.setChannelEq("sink_game", { ...config, preamp_db: -5 });
+    await store.setChannelEq("sink_chat", config);
+
+    // Optimistic: both channels reflect their latest config immediately…
+    expect(useMixerStore.getState().eqConfigs["sink_game"].preamp_db).toBe(-5);
+    expect(useMixerStore.getState().eqConfigs["sink_chat"].enabled).toBe(true);
+    // …but nothing has hit the backend yet (drag in progress).
+    expect(invoke).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    // One call per channel: sink_game's two edits collapsed into the last.
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenCalledWith("set_channel_eq", {
+      sinkName: "sink_game",
+      config: { ...config, preamp_db: -5 },
+    });
+    expect(invoke).toHaveBeenCalledWith("set_channel_eq", {
+      sinkName: "sink_chat",
+      config,
+    });
   });
 });

--- a/src/store/mixer.ts
+++ b/src/store/mixer.ts
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type {
   AppStream,
   BusDef,
+  EqConfig,
   MicConfig,
   OutputDevice,
   ProfileInfo,
@@ -56,6 +57,10 @@ interface MixerStore {
   setChannelFailover: (sinkName: string, enabled: boolean) => Promise<void>;
   /** Sonar-style "same device on all channels". */
   setAllOutputs: (outputName: string | null) => Promise<void>;
+  /** Channel -> parametric EQ (absent = never configured, i.e. default). */
+  eqConfigs: Record<string, EqConfig>;
+  fetchEq: () => Promise<void>;
+  setChannelEq: (sinkName: string, config: EqConfig) => Promise<void>;
   /** Mic chain (Phase 3). Null until loaded. */
   micConfig: MicConfig | null;
   inputDevices: OutputDevice[];
@@ -246,6 +251,7 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
         get().fetchAppStreams(),
         get().fetchProfiles(),
         get().fetchOutputs(),
+        get().fetchEq(),
         get().fetchMic(),
         get().fetchBuses(),
       ]);
@@ -400,6 +406,27 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
     }
   },
 
+  eqConfigs: {},
+
+  fetchEq: async () => {
+    try {
+      const eqConfigs = await invoke<Record<string, EqConfig>>("get_channel_eq_configs");
+      if (!jsonEqual(get().eqConfigs, eqConfigs)) set({ eqConfigs });
+    } catch (e) {
+      set({ error: String(e) });
+    }
+  },
+
+  setChannelEq: async (sinkName, config) => {
+    set({ eqConfigs: { ...get().eqConfigs, [sinkName]: config } });
+    // Debounced per channel: a band drag settles into one apply, and two
+    // open EQ panels never clobber each other's pending call.
+    debouncedInvoke(`eq:${sinkName}`, "set_channel_eq", { sinkName, config }, (e) => {
+      set({ error: String(e) });
+      void get().fetchEq();
+    });
+  },
+
   fetchMic: async () => {
     try {
       const [micConfig, inputDevices] = await Promise.all([
@@ -448,6 +475,7 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
       get().fetchChannels(),
       get().fetchAppStreams(),
       get().fetchOutputs(),
+      get().fetchEq(),
       get().fetchSeenApps(),
       get().fetchProfiles(),
       get().fetchBuses(),
@@ -522,6 +550,7 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
         get().fetchChannels(),
         get().fetchAppStreams(),
         get().fetchOutputs(),
+        get().fetchEq(),
         get().fetchSeenApps(),
         get().fetchBuses(),
       ]);
@@ -704,6 +733,7 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
         get().fetchChannels(),
         get().fetchAppStreams(),
         get().fetchOutputs(),
+        get().fetchEq(), // the channel's EQ entry is gone too
         get().fetchBuses(), // memberships dropped the channel
       ]);
     } catch (e) {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1923,3 +1923,40 @@ body,
   color: var(--fg-primary);
   border-color: var(--fg-secondary);
 }
+.eqm-head-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+.eqm-save-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: 4px 6px;
+}
+.eqm-save-row .menu-input {
+  flex: 1;
+  min-width: 0;
+}
+.eqm-import {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  padding: 4px 6px;
+}
+.eqm-import-text {
+  width: 100%;
+  min-height: 84px;
+  resize: vertical;
+  padding: 6px;
+  border-radius: var(--r-sm);
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+  color: var(--fg-primary);
+  font-family: inherit;
+  font-size: 11px;
+}
+.eqm-import-btns {
+  display: flex;
+  gap: var(--sp-1);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1771,3 +1771,155 @@ body,
 .row.row-sub .ricon {
   opacity: 0.7;
 }
+
+/* ---- Parametric EQ modal (eqm-) ---- */
+.sbtn.on-eq {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--on-accent);
+}
+.modal.eqm-modal {
+  width: min(640px, calc(100vw - 48px));
+}
+.eqm-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
+.eqm-enable {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--fs-meta);
+  color: var(--fg-secondary);
+}
+.eqm-curve {
+  width: 100%;
+  height: auto;
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  touch-action: none;
+}
+.eqm-curve.off {
+  opacity: 0.45;
+}
+.eqm-grid {
+  stroke: var(--border);
+  stroke-width: 1;
+}
+.eqm-grid.zero {
+  stroke: var(--fg-secondary);
+  opacity: 0.5;
+}
+.eqm-grid-label {
+  fill: var(--fg-secondary);
+  font-size: 9px;
+  font-family: inherit;
+  user-select: none;
+}
+.eqm-line {
+  fill: none;
+  stroke: var(--accent-hover);
+  stroke-width: 2;
+}
+.eqm-fill {
+  fill: var(--accent-light);
+  stroke: none;
+}
+.eqm-dot {
+  fill: var(--bg-surface);
+  stroke: var(--accent-hover);
+  stroke-width: 2;
+  cursor: grab;
+}
+.eqm-dot.sel {
+  fill: var(--accent);
+  stroke: var(--accent-hover);
+}
+.eqm-bands {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  max-height: 220px;
+  overflow-y: auto;
+}
+.eqm-band {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: 4px var(--sp-2);
+  border-radius: var(--r-sm);
+  border: 1px solid transparent;
+}
+.eqm-band.sel {
+  border-color: var(--border);
+  background: var(--bg-surface-hover);
+}
+.eqm-kind {
+  flex: 1;
+  min-width: 0;
+  height: 26px;
+  padding: 0 var(--sp-2);
+  border-radius: var(--r-sm);
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+  color: var(--fg-primary);
+  font-family: inherit;
+  font-size: var(--fs-meta);
+}
+.eqm-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  color: var(--fg-secondary);
+}
+.eqm-field input {
+  width: 62px;
+  height: 26px;
+  padding: 0 6px;
+  border-radius: var(--r-sm);
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+  color: var(--fg-primary);
+  font-family: inherit;
+  font-size: var(--fs-meta);
+}
+.eqm-field input:disabled {
+  opacity: 0.4;
+}
+.eqm-remove {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-sm);
+  border: none;
+  background: transparent;
+  color: var(--fg-secondary);
+  cursor: pointer;
+}
+.eqm-remove:hover {
+  background: var(--bg-active);
+  color: var(--danger);
+}
+.eqm-add {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  align-self: flex-start;
+  padding: 5px var(--sp-3);
+  border-radius: var(--r-sm);
+  border: 1px dashed var(--border);
+  background: transparent;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--fs-meta);
+}
+.eqm-add:hover {
+  color: var(--fg-primary);
+  border-color: var(--fg-secondary);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1960,3 +1960,25 @@ body,
   display: flex;
   gap: var(--sp-1);
 }
+/* menu-item as a real button (a11y): strip UA button chrome, keep the
+   menu look; the row wrapper hosts the apply button + a delete sibling
+   so no button ever nests inside another. */
+.eqm-preset-row {
+  display: flex;
+  align-items: center;
+}
+.eqm-preset-row .eqm-remove {
+  margin-left: auto;
+  margin-right: 4px;
+}
+button.menu-item {
+  width: 100%;
+  background: none;
+  border: none;
+  font-family: inherit;
+  text-align: left;
+}
+.eqm-preset-apply {
+  flex: 1;
+  min-width: 0;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,6 +68,55 @@ export const MIC_DSP_DEFAULTS = {
   limiter_ceiling_db: -1,
 } as const;
 
+/** Parametric EQ band shapes (mirrors Rust EqBandKind). */
+export type EqBandKind =
+  | "peaking"
+  | "low_shelf"
+  | "high_shelf"
+  | "low_pass"
+  | "high_pass";
+
+/** One parametric EQ band (mirrors Rust EqBand). */
+export interface EqBand {
+  kind: EqBandKind;
+  freq_hz: number;
+  /** Ignored by low_pass/high_pass. */
+  gain_db: number;
+  /** Peaking/LP/HP: filter Q. Shelves: RBJ shelf slope. */
+  q: number;
+}
+
+/** A channel's parametric EQ (mirrors Rust EqConfig). */
+export interface EqConfig {
+  enabled: boolean;
+  /** Headroom trim applied before the band cascade (dB). */
+  preamp_db: number;
+  bands: EqBand[];
+}
+
+export const MAX_EQ_BANDS = 10;
+export const EQ_GAIN_RANGE_DB = 24;
+export const EQ_FREQ_MIN_HZ = 20;
+export const EQ_FREQ_MAX_HZ = 20000;
+
+/** The Sonar-style starting layout (mirrors Rust default_eq_bands). */
+export const DEFAULT_EQ_BANDS: EqBand[] = [
+  { kind: "low_shelf", freq_hz: 100, gain_db: 0, q: 0.71 },
+  { kind: "peaking", freq_hz: 500, gain_db: 0, q: 1 },
+  { kind: "peaking", freq_hz: 1500, gain_db: 0, q: 1 },
+  { kind: "peaking", freq_hz: 5000, gain_db: 0, q: 1 },
+  { kind: "high_shelf", freq_hz: 10000, gain_db: 0, q: 0.71 },
+];
+
+/** A channel's EQ when it has never been configured. */
+export function defaultEqConfig(): EqConfig {
+  return {
+    enabled: false,
+    preamp_db: 0,
+    bands: DEFAULT_EQ_BANDS.map((b) => ({ ...b })),
+  };
+}
+
 /** App history entry (mirrors Rust SeenApp). */
 export interface SeenApp {
   match_prop: string;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
closes #2. per-channel parametric eq, split out from the dev branch so it can land on its own (the headset-off work stays on dev-pipeline for now).

what's in it:
- eq button on each channel strip opens a modal with a draggable response curve, up to 10 bands (peak, shelves, low/high pass), preamp, and numeric rows for keyboard access
- native dsp in the channel path, same capture->ring->playback shape as the mic chain. band edits apply live over atomics, no relink. device, mix bus, and monitor links all re-source from the insert so everything hears the same audio, and the link police keeps wireplumber from leaking a dry copy to the default sink
- community presets live in presets/eq/ and get embedded into the binary at build time, so packaging doesn't change at all. plus save-as into a local library, import of pasted autoeq blocks or preset json or files, and export via the native save dialog
- eq persists per channel, travels with profiles, restores on launch. pactl fallback errors cleanly like the mic chain

verified end to end on real pipewire: played the same 1khz sine through an eq'd channel (+12 db peak) and a dry channel, recorded the master bus, measured exactly +12.0 db difference. graph checks confirm the insert nodes only exist while enabled and there's no duplicate dry path.

also rides along: the outstanding dependency bumps, folded in from the dependabot queue
- pipewire-rs v0.10.0 (#13), cargo group (#7), actions group (#6), npm group (#8)
- vite 8 + plugin-react 6 + typescript 6 together (#10/#12/#11 fail individually - plugin-react 4 peer-rejects vite 8; ts 6 needed the standard vite-env.d.ts for css imports)
- react-dom 19 (#9) deliberately skipped: react itself is still 18, that's a real migration for later

111 rust tests, 16 vitest, clippy -D warnings clean, tsc clean, all rechecked against the new dependency set.