### PR TITLE
install openssh so the aur auto-publish can actually push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,8 @@ jobs:
     container: archlinux:latest
     steps:
       - name: Install build tooling
-        run: pacman -Syu --noconfirm --needed base-devel git github-cli
+        # openssh: git's ssh:// transport for the AUR push (not in base-devel).
+        run: pacman -Syu --noconfirm --needed base-devel git github-cli openssh
 
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
the v0.1.20 release hit the best-effort warning path on the aur step: the archlinux container has no ssh client (base-devel doesn't include one), so git couldn't talk to the aur remote. one word fix, add openssh to the tooling install.

the release itself was fine, and 0.1.20 is on the aur now (pushed manually). next stable release should go through on its own.