### PR TITLE
eq curve: sonar-style regions, unit labels, colored band dots

### DIFF
--- a/src/components/Eq/EqBandRow.tsx
+++ b/src/components/Eq/EqBandRow.tsx
@@ -15,6 +15,8 @@ const isPass = (kind: EqBandKind) => kind === "low_pass" || kind === "high_pass"
 
 interface EqBandRowProps {
   band: EqBand;
+  /** Dot color on the curve — repeated here so row and dot read as one. */
+  color: string;
   selected: boolean;
   onSelect: () => void;
   onChange: (patch: Partial<EqBand>) => void;
@@ -23,7 +25,7 @@ interface EqBandRowProps {
 
 /** Numeric editor for one band — the keyboard-accessible twin of the
  *  curve dot (drag isn't reachable for everyone). */
-export function EqBandRow({ band, selected, onSelect, onChange, onRemove }: EqBandRowProps) {
+export function EqBandRow({ band, color, selected, onSelect, onChange, onRemove }: EqBandRowProps) {
   const clampNum = (v: string, lo: number, hi: number, fallback: number) => {
     const n = Number(v);
     return Number.isFinite(n) ? Math.max(lo, Math.min(hi, n)) : fallback;
@@ -31,6 +33,7 @@ export function EqBandRow({ band, selected, onSelect, onChange, onRemove }: EqBa
 
   return (
     <div className={"eqm-band" + (selected ? " sel" : "")} onPointerDown={onSelect}>
+      <span className="eqm-chip" style={{ background: color }} aria-hidden="true" />
       <select
         className="eqm-kind"
         value={band.kind}

--- a/src/components/Eq/EqCurve.tsx
+++ b/src/components/Eq/EqCurve.tsx
@@ -5,21 +5,55 @@ import { curvePoints, freqToX, xToFreq } from "../../lib/eqMath";
 
 // SVG coordinate space; the element scales responsively.
 const W = 600;
-const H = 220;
+const H = 252;
 const PAD = 8;
+/** Region-label strip at the top and frequency-label strip at the bottom. */
+const HEAD = 20;
+const FOOT = 16;
+const TOP = HEAD + 4;
+const BOTTOM = H - FOOT - 4;
 
 const dbToY = (db: number) =>
-  PAD + ((EQ_GAIN_RANGE_DB - db) / (2 * EQ_GAIN_RANGE_DB)) * (H - 2 * PAD);
+  TOP + ((EQ_GAIN_RANGE_DB - db) / (2 * EQ_GAIN_RANGE_DB)) * (BOTTOM - TOP);
 const yToDb = (y: number) =>
-  EQ_GAIN_RANGE_DB - ((y - PAD) / (H - 2 * PAD)) * 2 * EQ_GAIN_RANGE_DB;
+  EQ_GAIN_RANGE_DB - ((y - TOP) / (BOTTOM - TOP)) * 2 * EQ_GAIN_RANGE_DB;
 const fxToX = (fx: number) => PAD + fx * (W - 2 * PAD);
 const xToFx = (x: number) => (x - PAD) / (W - 2 * PAD);
 
-/** Frequencies that get a labeled grid line. */
-const GRID_FREQS = [50, 100, 500, 1000, 5000, 10000];
-const GRID_DBS = [-12, 0, 12];
+/** Sonar-style frequency regions across the top of the plot. */
+const REGIONS: { label: string; to: number }[] = [
+  { label: "SUB BASS", to: 60 },
+  { label: "BASS", to: 250 },
+  { label: "LOW MIDS", to: 500 },
+  { label: "MID RANGE", to: 2000 },
+  { label: "UPPER MIDS", to: 6000 },
+  { label: "HIGHS", to: 20000 },
+];
 
-const fmtFreq = (hz: number) => (hz >= 1000 ? `${hz / 1000}k` : `${hz}`);
+/** Frequencies that get a labeled vertical grid line. */
+const GRID_FREQS = [20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000];
+/** dB lines: labeled majors and unlabeled minors (plot edges are ±24). */
+const GRID_DBS_MAJOR = [-12, 0, 12];
+const GRID_DBS_MINOR = [-18, -6, 6, 18];
+
+const fmtFreq = (hz: number) => (hz >= 1000 ? `${hz / 1000}kHz` : `${hz}Hz`);
+const fmtDb = (db: number) => `${db > 0 ? "+" : ""}${db} dB`;
+
+/** Per-band dot colors (index-keyed; mirrored as chips on the band rows). */
+const BAND_COLORS = [
+  "#a78bfa",
+  "#6366f1",
+  "#ec4899",
+  "#ef4444",
+  "#f97316",
+  "#f59e0b",
+  "#a3e635",
+  "#22c55e",
+  "#2dd4bf",
+  "#38bdf8",
+];
+
+export const bandColor = (index: number) => BAND_COLORS[index % BAND_COLORS.length];
 
 /** Bands without a gain axis: their dot rides the 0 dB line. */
 const gainless = (band: EqBand) => band.kind === "low_pass" || band.kind === "high_pass";
@@ -89,6 +123,15 @@ export function EqCurve({ config, selected, onSelect, onBandChange }: EqCurvePro
   const zeroY = dbToY(0);
   const fill = `${path} L${fxToX(1).toFixed(1)},${zeroY} L${fxToX(0).toFixed(1)},${zeroY} Z`;
 
+  // Region strip geometry (log axis).
+  let regionFrom = 20;
+  const regions = REGIONS.map(({ label, to }) => {
+    const x0 = fxToX(freqToX(regionFrom));
+    const x1 = fxToX(freqToX(to));
+    regionFrom = to;
+    return { label, x0, x1 };
+  });
+
   return (
     <svg
       ref={svgRef}
@@ -97,21 +140,52 @@ export function EqCurve({ config, selected, onSelect, onBandChange }: EqCurvePro
       role="img"
       aria-label="EQ frequency response"
     >
-      {GRID_FREQS.map((f) => (
-        <g key={f}>
-          <line
-            className="eqm-grid"
-            x1={fxToX(freqToX(f))}
-            x2={fxToX(freqToX(f))}
-            y1={PAD}
-            y2={H - PAD}
-          />
-          <text className="eqm-grid-label" x={fxToX(freqToX(f)) + 3} y={H - PAD - 4}>
-            {fmtFreq(f)}
+      {/* frequency-region strip */}
+      {regions.map(({ label, x0, x1 }, i) => (
+        <g key={label}>
+          <rect className="eqm-region" x={x0 + 1} y={PAD - 4} width={x1 - x0 - 2} height={HEAD - 4} rx={3} />
+          <text className="eqm-region-label" x={(x0 + x1) / 2} y={PAD + HEAD / 2 + 1}>
+            {label}
           </text>
+          {i > 0 && (
+            <line className="eqm-grid region" x1={x0} x2={x0} y1={TOP} y2={BOTTOM} />
+          )}
         </g>
       ))}
-      {GRID_DBS.map((db) => (
+
+      {/* vertical grid + frequency labels (with units, Sonar-style) */}
+      {GRID_FREQS.map((f, i) => {
+        const x = fxToX(freqToX(f));
+        // Edge labels hug inward so they don't clip at the borders.
+        const edge =
+          i === 0 ? "start" : i === GRID_FREQS.length - 1 ? "end" : "middle";
+        return (
+          <g key={f}>
+            <line className="eqm-grid" x1={x} x2={x} y1={TOP} y2={BOTTOM} />
+            <text
+              className="eqm-axis-label freq"
+              x={edge === "start" ? x + 2 : edge === "end" ? x - 2 : x}
+              y={H - 5}
+              textAnchor={edge}
+            >
+              {fmtFreq(f)}
+            </text>
+          </g>
+        );
+      })}
+
+      {/* horizontal grid + dB labels */}
+      {GRID_DBS_MINOR.map((db) => (
+        <line
+          key={db}
+          className="eqm-grid minor"
+          x1={PAD}
+          x2={W - PAD}
+          y1={dbToY(db)}
+          y2={dbToY(db)}
+        />
+      ))}
+      {GRID_DBS_MAJOR.map((db) => (
         <g key={db}>
           <line
             className={"eqm-grid" + (db === 0 ? " zero" : "")}
@@ -120,17 +194,19 @@ export function EqCurve({ config, selected, onSelect, onBandChange }: EqCurvePro
             y1={dbToY(db)}
             y2={dbToY(db)}
           />
-          <text className="eqm-grid-label" x={PAD + 2} y={dbToY(db) - 3}>
-            {db > 0 ? `+${db}` : db}
+          <text className="eqm-axis-label" x={PAD + 3} y={dbToY(db) - 4}>
+            {fmtDb(db)}
           </text>
         </g>
       ))}
+
       <path className="eqm-fill" d={fill} />
       <path className="eqm-line" d={path} />
       {config.bands.map((band, i) => (
         <circle
           key={i}
           className={"eqm-dot" + (i === selected ? " sel" : "")}
+          style={{ fill: bandColor(i) }}
           cx={fxToX(freqToX(band.freq_hz))}
           cy={gainless(band) ? zeroY : dbToY(band.gain_db)}
           r={i === selected ? 8 : 6}

--- a/src/components/Eq/EqModal.tsx
+++ b/src/components/Eq/EqModal.tsx
@@ -7,7 +7,7 @@ import { Ms } from "../Icons";
 import { Toggle } from "../Toggle";
 import { DspSlider } from "../Mic/DspSlider";
 import { EqBandRow } from "./EqBandRow";
-import { EqCurve } from "./EqCurve";
+import { bandColor, EqCurve } from "./EqCurve";
 import { EqPresetMenu } from "./EqPresetMenu";
 
 interface EqModalProps {
@@ -113,6 +113,7 @@ export function EqModal({ channel, open, onClose }: EqModalProps) {
           <EqBandRow
             key={i}
             band={band}
+            color={bandColor(i)}
             selected={i === selected}
             onSelect={() => setSelected(i)}
             onChange={(patch) => patchBand(i, patch)}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1816,30 +1816,60 @@ body,
   stroke: var(--fg-secondary);
   opacity: 0.5;
 }
-.eqm-grid-label {
+.eqm-grid.minor {
+  opacity: 0.4;
+}
+.eqm-grid.region {
+  stroke: var(--border);
+  opacity: 0.9;
+}
+.eqm-region {
+  fill: var(--bg-surface);
+}
+.eqm-region-label {
+  fill: var(--fg-secondary);
+  font-size: 8.5px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-anchor: middle;
+  dominant-baseline: middle;
+  font-family: inherit;
+  user-select: none;
+}
+.eqm-axis-label {
   fill: var(--fg-secondary);
   font-size: 9px;
   font-family: inherit;
   user-select: none;
 }
+.eqm-axis-label.freq {
+  text-anchor: middle;
+}
 .eqm-line {
   fill: none;
-  stroke: var(--accent-hover);
-  stroke-width: 2;
+  /* Sonar-style: neutral curve, per-band colored dots. */
+  stroke: var(--fg-primary);
+  stroke-width: 1.8;
+  opacity: 0.9;
 }
 .eqm-fill {
   fill: var(--accent-light);
   stroke: none;
 }
 .eqm-dot {
-  fill: var(--bg-surface);
-  stroke: var(--accent-hover);
+  /* fill = the band's color (inline style). */
+  stroke: var(--bg-main);
   stroke-width: 2;
   cursor: grab;
 }
 .eqm-dot.sel {
-  fill: var(--accent);
-  stroke: var(--accent-hover);
+  stroke: var(--fg-primary);
+}
+.eqm-chip {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
 }
 .eqm-bands {
   display: flex;


### PR DESCRIPTION
makes the eq curve read like sonar's:

- frequency region strip across the top: sub bass / bass / low mids / mid range / upper mids / highs, sized on the log axis
- axis labels carry their units now, +12 dB and 100Hz instead of bare numbers, plus minor gridlines at 6 db steps
- each band gets its own dot color, and the band rows get a matching color chip so you can tell which row is which dot at a glance
- curve line goes neutral white so the colored dots pop

verified visually with a standalone render (screenshot in the conversation). css + component only, no dsp changes.