### PR TITLE
sonar cleanup: flatten ternaries, readonly props, css dedup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,12 @@ export default function App() {
       ? { label: "Settings" }
       : (NAV.find((n) => n.id === nav) ?? NAV[0]);
 
+  let screen;
+  if (nav === "mixer") screen = <MixerBoard />;
+  else if (nav === "apps") screen = <AppList />;
+  else if (nav === "mic") screen = <MicScreen />;
+  else screen = <SettingsScreen />;
+
   return (
     <div className="window">
       <TitleBar screen={current.label} />
@@ -78,15 +84,7 @@ export default function App() {
           {version && <div className="rail-version">v{version}</div>}
         </nav>
 
-        {nav === "mixer" ? (
-          <MixerBoard />
-        ) : nav === "apps" ? (
-          <AppList />
-        ) : nav === "mic" ? (
-          <MicScreen />
-        ) : (
-          <SettingsScreen />
-        )}
+        {screen}
       </div>
 
       <OnboardingModal />

--- a/src/components/AppList/AppIcon.tsx
+++ b/src/components/AppList/AppIcon.tsx
@@ -9,7 +9,7 @@ interface AppIconProps {
 }
 
 /** App icon via the asset protocol, generic glyph fallback. */
-export function AppIcon({ iconPath }: AppIconProps) {
+export function AppIcon({ iconPath }: Readonly<AppIconProps>) {
   const [failed, setFailed] = useState(false);
   useEffect(() => setFailed(false), [iconPath]);
 

--- a/src/components/AppList/AppRow.tsx
+++ b/src/components/AppList/AppRow.tsx
@@ -10,7 +10,7 @@ interface AppRowProps {
   stream: AppStream;
 }
 
-export function AppRow({ stream }: AppRowProps) {
+export function AppRow({ stream }: Readonly<AppRowProps>) {
   const routeApp = useMixerStore((s) => s.routeApp);
   const setAppVolume = useMixerStore((s) => s.setAppVolume);
   const renameApp = useMixerStore((s) => s.renameApp);

--- a/src/components/AppList/ChannelSelect.tsx
+++ b/src/components/AppList/ChannelSelect.tsx
@@ -11,7 +11,7 @@ interface ChannelSelectProps {
 }
 
 /** Dropdown to route an app stream onto a channel. */
-export function ChannelSelect({ value, onChange }: ChannelSelectProps) {
+export function ChannelSelect({ value, onChange }: Readonly<ChannelSelectProps>) {
   const [open, setOpen] = useState(false);
   const channels = useMixerStore((s) => s.channels);
 

--- a/src/components/AppList/HSlider.tsx
+++ b/src/components/AppList/HSlider.tsx
@@ -7,7 +7,7 @@ interface HSliderProps {
 }
 
 /** Horizontal per-app volume slider. */
-export function HSlider({ value, max, onChange }: HSliderProps) {
+export function HSlider({ value, max, onChange }: Readonly<HSliderProps>) {
   const trackRef = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
 

--- a/src/components/AppList/InactiveRow.tsx
+++ b/src/components/AppList/InactiveRow.tsx
@@ -9,7 +9,7 @@ import { ChannelSelect } from "./ChannelSelect";
  * A previously-seen app that isn't currently playing. Routing edits here
  * are "pre-routing": they take effect the moment the app next plays audio.
  */
-export function InactiveRow({ app }: { app: SeenApp }) {
+export function InactiveRow({ app }: Readonly<{ app: SeenApp }>) {
   const setAppAssignment = useMixerStore((s) => s.setAppAssignment);
   const setAppIgnored = useMixerStore((s) => s.setAppIgnored);
   const forgetApp = useMixerStore((s) => s.forgetApp);

--- a/src/components/Eq/EqBandRow.tsx
+++ b/src/components/Eq/EqBandRow.tsx
@@ -29,7 +29,7 @@ interface EqBandRowProps {
 
 /** Numeric editor for one band - the keyboard-accessible twin of the
  *  curve dot (drag isn't reachable for everyone). */
-export function EqBandRow({ index, band, color, selected, canRemove, onSelect, onChange, onRemove }: EqBandRowProps) {
+export function EqBandRow({ index, band, color, selected, canRemove, onSelect, onChange, onRemove }: Readonly<EqBandRowProps>) {
   const clampNum = (v: string, lo: number, hi: number, fallback: number) => {
     const n = Number(v);
     return Number.isFinite(n) ? Math.max(lo, Math.min(hi, n)) : fallback;

--- a/src/components/Eq/EqCurve.tsx
+++ b/src/components/Eq/EqCurve.tsx
@@ -59,6 +59,13 @@ export const bandColor = (index: number) => BAND_COLORS[index % BAND_COLORS.leng
 /** Bands without a gain axis: their dot rides the 0 dB line. */
 const gainless = (band: EqBand) => band.kind === "low_pass" || band.kind === "high_pass";
 
+/** Edge frequency labels hug inward so they don't clip at the plot borders. */
+function edgeAnchor(i: number, n: number): "start" | "end" | "middle" {
+  if (i === 0) return "start";
+  if (i === n - 1) return "end";
+  return "middle";
+}
+
 interface EqCurveProps {
   config: EqConfig;
   selected: number;
@@ -68,7 +75,7 @@ interface EqCurveProps {
 
 /** The interactive response curve: drag a dot to set freq/gain, scroll on
  *  it to tighten/widen Q, double-click to zero the band. */
-export function EqCurve({ config, selected, onSelect, onBandChange }: EqCurveProps) {
+export function EqCurve({ config, selected, onSelect, onBandChange }: Readonly<EqCurveProps>) {
   const svgRef = useRef<SVGSVGElement>(null);
   const dragIndex = useRef<number>(-1);
 
@@ -164,15 +171,16 @@ export function EqCurve({ config, selected, onSelect, onBandChange }: EqCurvePro
       {/* vertical grid + frequency labels (below the plot) */}
       {GRID_FREQS.map((f, i) => {
         const x = fxToX(freqToX(f));
-        // Edge labels hug inward so they don't clip at the borders.
-        const edge =
-          i === 0 ? "start" : i === GRID_FREQS.length - 1 ? "end" : "middle";
+        const edge = edgeAnchor(i, GRID_FREQS.length);
+        let labelX = x;
+        if (edge === "start") labelX = x - 4;
+        else if (edge === "end") labelX = x + 4;
         return (
           <g key={f}>
             <line className="eqm-grid" x1={x} x2={x} y1={TOP} y2={BOTTOM} />
             <text
               className="eqm-axis-label freq"
-              x={edge === "start" ? x - 4 : edge === "end" ? x + 4 : x}
+              x={labelX}
               y={H - 5}
               style={{ textAnchor: edge }}
             >

--- a/src/components/Eq/EqModal.tsx
+++ b/src/components/Eq/EqModal.tsx
@@ -17,7 +17,7 @@ interface EqModalProps {
 }
 
 /** Per-channel parametric EQ editor: response curve, band list, preamp. */
-export function EqModal({ channel, open, onClose }: EqModalProps) {
+export function EqModal({ channel, open, onClose }: Readonly<EqModalProps>) {
   const config = useMixerStore(
     (s) => s.eqConfigs[channel.name] ?? null,
   ) ?? defaultEqConfig();

--- a/src/components/Eq/EqPresetMenu.tsx
+++ b/src/components/Eq/EqPresetMenu.tsx
@@ -26,7 +26,7 @@ interface EqPresetMenuProps {
 
 /** Preset picker + import/export. Bundled presets ship inside the binary
  *  (repo presets/eq/); user presets live in ~/.config/sink/eq_presets. */
-export function EqPresetMenu({ sinkName, config, onApply, onError }: EqPresetMenuProps) {
+export function EqPresetMenu({ sinkName, config, onApply, onError }: Readonly<EqPresetMenuProps>) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [presets, setPresets] = useState<EqPresetEntry[]>([]);
   const [saveName, setSaveName] = useState("");

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -5,11 +5,11 @@ export function Ms({
   name,
   className,
   style,
-}: {
+}: Readonly<{
   name: string;
   className?: string;
   style?: CSSProperties;
-}) {
+}>) {
   return (
     <span
       className={"ms material-symbols-outlined" + (className ? " " + className : "")}

--- a/src/components/Mic/DspSlider.tsx
+++ b/src/components/Mic/DspSlider.tsx
@@ -13,7 +13,7 @@ interface DspSliderProps {
 }
 
 /** Horizontal parameter slider with a default-value tick. */
-export function DspSlider({ label, min, max, step, value, defaultValue, unit, onChange }: DspSliderProps) {
+export function DspSlider({ label, min, max, step, value, defaultValue, unit, onChange }: Readonly<DspSliderProps>) {
   const trackRef = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
 

--- a/src/components/Mic/MicScreen.tsx
+++ b/src/components/Mic/MicScreen.tsx
@@ -36,6 +36,12 @@ function MicLevel() {
   );
 }
 
+function micStatusLabel(enabled: boolean, muted: boolean): string {
+  if (!enabled) return "Off";
+  if (muted) return "Muted";
+  return "Live";
+}
+
 export function MicScreen() {
   const micConfig = useMixerStore((s) => s.micConfig);
   const inputDevices = useMixerStore((s) => s.inputDevices);
@@ -71,7 +77,7 @@ export function MicScreen() {
             }
           >
             <Ms name="fiber_manual_record" style={{ fontSize: 11 }} />
-            {!micConfig.enabled ? "Off" : micConfig.muted ? "Muted" : "Live"}
+            {micStatusLabel(micConfig.enabled, micConfig.muted)}
           </span>
           <Toggle
             on={micConfig.enabled}

--- a/src/components/MixerBoard/ChannelApps.tsx
+++ b/src/components/MixerBoard/ChannelApps.tsx
@@ -25,11 +25,11 @@ export function ChannelApps({
   channel,
   open,
   onClose,
-}: {
+}: Readonly<{
   channel: VirtualSink;
   open: boolean;
   onClose: () => void;
-}) {
+}>) {
   const appStreams = useMixerStore((s) => s.appStreams);
   const seenApps = useMixerStore((s) => s.seenApps);
   const routeApp = useMixerStore((s) => s.routeApp);

--- a/src/components/MixerBoard/ChannelStrip.tsx
+++ b/src/components/MixerBoard/ChannelStrip.tsx
@@ -29,7 +29,7 @@ export function ChannelStrip({
   onGripDragStart,
   onGripDragEnd,
   onStripDragOver,
-}: ChannelStripProps) {
+}: Readonly<ChannelStripProps>) {
   const setChannelVolume = useMixerStore((s) => s.setChannelVolume);
   const toggleMute = useMixerStore((s) => s.toggleMute);
   const level = useMixerStore((s) => s.levels[channel.name]);

--- a/src/components/MixerBoard/Fader.tsx
+++ b/src/components/MixerBoard/Fader.tsx
@@ -7,7 +7,7 @@ interface FaderProps {
 }
 
 /** Vertical channel fader (pointer-driven, design-system styling). */
-export function Fader({ value, max, onChange }: FaderProps) {
+export function Fader({ value, max, onChange }: Readonly<FaderProps>) {
   const trackRef = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
 

--- a/src/components/MixerBoard/MixerBoard.tsx
+++ b/src/components/MixerBoard/MixerBoard.tsx
@@ -23,7 +23,7 @@ function MixGroup({
   onAdd,
   addTitle,
   children,
-}: {
+}: Readonly<{
   kind: string;
   icon: string;
   label: string;
@@ -33,7 +33,7 @@ function MixGroup({
   onAdd?: () => void;
   addTitle?: string;
   children: ReactNode;
-}) {
+}>) {
   return (
     <div className={"mix-group is-" + kind}>
       <div className="group-head" title={hint}>

--- a/src/components/MixerBoard/OutputSelect.tsx
+++ b/src/components/MixerBoard/OutputSelect.tsx
@@ -43,7 +43,7 @@ export function OutputSelect({
   onChange,
   compact,
   popoverStyle,
-}: OutputSelectProps) {
+}: Readonly<OutputSelectProps>) {
   const [open, setOpen] = useState(false);
   const outputDevices = useMixerStore((s) => s.outputDevices);
 
@@ -54,20 +54,19 @@ export function OutputSelect({
     value === null && resolved ? outputDevices.find((d) => d.name === resolved) : undefined;
   const shown = current ?? resolvedDevice;
 
-  const label = mixed
-    ? "Per-channel"
-    : value === null
-      ? resolvedDevice
-        ? `System default (${resolvedDevice.description})`
-        : "System default"
-      : (current?.description ?? value);
+  let label: string;
+  if (mixed) label = "Per-channel";
+  else if (value !== null) label = current?.description ?? value;
+  else if (resolvedDevice) label = `System default (${resolvedDevice.description})`;
+  else label = "System default";
+
   // Compact footer label: a single meaningful word that fits a 122px strip.
   // Following default shows the live device so the user sees where it lands.
-  const shortLabel = mixed
-    ? "Mixed"
-    : value === null
-      ? (resolvedDevice ? resolvedDevice.description.split(" ")[0] : "Default")
-      : label.split(" ")[0];
+  let shortLabel: string;
+  if (mixed) shortLabel = "Mixed";
+  else if (value !== null) shortLabel = label.split(" ")[0];
+  else if (resolvedDevice) shortLabel = resolvedDevice.description.split(" ")[0];
+  else shortLabel = "Default";
 
   const items = (
     <>

--- a/src/components/MixerBoard/StreamMixStrip.tsx
+++ b/src/components/MixerBoard/StreamMixStrip.tsx
@@ -15,7 +15,14 @@ import { VuMeter } from "./VuMeter";
  * it and OBS sees the new name. Volume/mute shape what recorders hear,
  * not what you hear.
  */
-export function BusStrip({ bus }: { bus: BusDef }) {
+/** Compact "what this mix carries" label for the membership button. */
+function memberLabel(exclude: boolean, carried: number, all: number): string {
+  if (!exclude) return `${carried} ${carried === 1 ? "channel" : "channels"}`;
+  if (carried === all) return "all channels";
+  return `all but ${all - carried}`;
+}
+
+export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
   const channels = useMixerStore((s) => s.channels);
   const setBusMembers = useMixerStore((s) => s.setBusMembers);
   const setBusExclude = useMixerStore((s) => s.setBusExclude);
@@ -113,11 +120,7 @@ export function BusStrip({ bus }: { bus: BusDef }) {
               title="Choose which channels this mix carries"
               onClick={() => setManaging(true)}
             >
-              {bus.exclude
-                ? carried.length === allNames.length
-                  ? "all channels"
-                  : `all but ${allNames.length - carried.length}`
-                : `${carried.length} ${carried.length === 1 ? "channel" : "channels"}`}
+              {memberLabel(bus.exclude, carried.length, allNames.length)}
               <Ms name="expand_more" style={{ fontSize: 13 }} />
             </button>
             <Popover

--- a/src/components/MixerBoard/VuMeter.tsx
+++ b/src/components/MixerBoard/VuMeter.tsx
@@ -23,7 +23,7 @@ const CLIP_AT = heightForDb(-0.2);
  * touches 0 dBFS. The readout shows the held peak in dBFS.
  * Under the pactl fallback no events arrive and the meter rests at zero.
  */
-export function VuMeter({ target }: VuMeterProps) {
+export function VuMeter({ target }: Readonly<VuMeterProps>) {
   const fillRef = useRef<HTMLDivElement>(null);
   const peakRef = useRef<HTMLDivElement>(null);
   const clipRef = useRef<HTMLDivElement>(null);

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -8,14 +8,14 @@ export function Modal({
   title,
   children,
   className,
-}: {
+}: Readonly<{
   open: boolean;
   onClose: () => void;
   title: string;
   children: ReactNode;
   /** Extra class on the dialog (e.g. a width variant). */
   className?: string;
-}) {
+}>) {
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {

--- a/src/components/Onboarding/OnboardingModal.tsx
+++ b/src/components/Onboarding/OnboardingModal.tsx
@@ -69,6 +69,17 @@ const STEPS: Step[] = [
   },
 ];
 
+/** Progress dots: one per concept card plus the final choice page. */
+function ObDots({ step }: Readonly<{ step: number }>) {
+  return (
+    <div className="ob-dots">
+      {[...STEPS, null].map((s, i) => (
+        <span key={s?.title ?? "choice"} className={"ob-dot" + (i === step ? " on" : "")} />
+      ))}
+    </div>
+  );
+}
+
 /** First-run tutorial: one card per concept, then a starting-point choice. */
 export function OnboardingModal() {
   const show = useMixerStore((s) => s.showOnboarding);
@@ -86,99 +97,90 @@ export function OnboardingModal() {
   const last = step === STEPS.length; // the choice page
   const current = STEPS[step];
 
+  let body;
+  if (last && replay) {
+    body = (
+      <>
+        <div className="modal-title">That's the tour</div>
+        <p className="modal-text">
+          Channels, apps and the mic are all live - your setup is untouched.
+        </p>
+        <div className="ob-foot">
+          <button className="modal-btn" onClick={() => setStep(step - 1)}>
+            Back
+          </button>
+          <ObDots step={step} />
+          <button className="modal-btn primary" onClick={() => void finishOnboarding(false)}>
+            Done
+          </button>
+        </div>
+      </>
+    );
+  } else if (last) {
+    body = (
+      <>
+        <div className="modal-title">How do you want to start?</div>
+        <p className="modal-text">
+          Either way you can add, rename or delete channels whenever - this just
+          lays out your first board.
+        </p>
+        <div className="ob-choices">
+          <button className="ob-choice" onClick={() => void finishOnboarding(false)}>
+            <Ms name="dashboard" />
+            <div className="ob-choice-title">Set up a board for me</div>
+            <div className="ob-choice-sub">
+              Game, Chat, Music and System - ready to drop apps onto
+            </div>
+          </button>
+          <button className="ob-choice" onClick={() => void finishOnboarding(true)}>
+            <Ms name="check_box_outline_blank" />
+            <div className="ob-choice-title">I'll build my own</div>
+            <div className="ob-choice-sub">One Main channel - add the rest as you go</div>
+          </button>
+        </div>
+        <div className="ob-foot">
+          <button className="modal-btn" onClick={() => setStep(step - 1)}>
+            Back
+          </button>
+          <ObDots step={step} />
+          <span style={{ width: 64 }} />
+        </div>
+      </>
+    );
+  } else {
+    body = (
+      <>
+        <div className="ob-icon">
+          <Ms name={current.icon} />
+        </div>
+        <div className="modal-title" style={{ textAlign: "center" }}>
+          {current.title}
+        </div>
+        <p className="modal-text ob-body">{current.body}</p>
+        {current.diagram && <FlowDiagram />}
+        <div className="ob-foot">
+          {step > 0 ? (
+            <button className="modal-btn" onClick={() => setStep(step - 1)}>
+              Back
+            </button>
+          ) : (
+            <button className="modal-btn" onClick={() => void finishOnboarding(false)}>
+              Skip
+            </button>
+          )}
+          <ObDots step={step} />
+          <button className="modal-btn primary" onClick={() => setStep(step + 1)}>
+            Next
+          </button>
+        </div>
+      </>
+    );
+  }
+
   return (
     <div className="modal-scrim">
       <div className="modal ob-modal" role="dialog" aria-label="Welcome to Sink">
-        {last && replay ? (
-          <>
-            <div className="modal-title">That's the tour</div>
-            <p className="modal-text">
-              Channels, apps and the mic are all live - your setup is
-              untouched.
-            </p>
-            <div className="ob-foot">
-              <button className="modal-btn" onClick={() => setStep(step - 1)}>
-                Back
-              </button>
-              <div className="ob-dots">
-                {[...STEPS, null].map((_, i) => (
-                  <span key={i} className={"ob-dot" + (i === step ? " on" : "")} />
-                ))}
-              </div>
-              <button
-                className="modal-btn primary"
-                onClick={() => void finishOnboarding(false)}
-              >
-                Done
-              </button>
-            </div>
-          </>
-        ) : last ? (
-          <>
-            <div className="modal-title">How do you want to start?</div>
-            <p className="modal-text">
-              Either way you can add, rename or delete channels whenever -
-              this just lays out your first board.
-            </p>
-            <div className="ob-choices">
-              <button className="ob-choice" onClick={() => void finishOnboarding(false)}>
-                <Ms name="dashboard" />
-                <div className="ob-choice-title">Set up a board for me</div>
-                <div className="ob-choice-sub">
-                  Game, Chat, Music and System - ready to drop apps onto
-                </div>
-              </button>
-              <button className="ob-choice" onClick={() => void finishOnboarding(true)}>
-                <Ms name="check_box_outline_blank" />
-                <div className="ob-choice-title">I'll build my own</div>
-                <div className="ob-choice-sub">
-                  One Main channel - add the rest as you go
-                </div>
-              </button>
-            </div>
-            <div className="ob-foot">
-              <button className="modal-btn" onClick={() => setStep(step - 1)}>
-                Back
-              </button>
-              <div className="ob-dots">
-                {[...STEPS, null].map((_, i) => (
-                  <span key={i} className={"ob-dot" + (i === step ? " on" : "")} />
-                ))}
-              </div>
-              <span style={{ width: 64 }} />
-            </div>
-          </>
-        ) : (
-          <>
-            <div className="ob-icon">
-              <Ms name={current.icon} />
-            </div>
-            <div className="modal-title" style={{ textAlign: "center" }}>
-              {current.title}
-            </div>
-            <p className="modal-text ob-body">{current.body}</p>
-            {current.diagram && <FlowDiagram />}
-            <div className="ob-foot">
-              {step > 0 ? (
-                <button className="modal-btn" onClick={() => setStep(step - 1)}>
-                  Back
-                </button>
-              ) : (
-                <button className="modal-btn" onClick={() => void finishOnboarding(false)}>
-                  Skip
-                </button>
-              )}
-              <div className="ob-dots">
-                {[...STEPS, null].map((_, i) => (
-                  <span key={i} className={"ob-dot" + (i === step ? " on" : "")} />
-                ))}
-              </div>
-              <button className="modal-btn primary" onClick={() => setStep(step + 1)}>
-                Next
-              </button>
-            </div>
-          </>
-        )}
+        {body}
       </div>
     </div>
   );

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -23,7 +23,7 @@ const GAP = 6;
  * the parent element of the marker span (call sites wrap trigger+Popover
  * in a relative container, which keeps working unchanged).
  */
-export function Popover({ open, onClose, children, side = "bottom", align = "start", style }: PopoverProps) {
+export function Popover({ open, onClose, children, side = "bottom", align = "start", style }: Readonly<PopoverProps>) {
   const markerRef = useRef<HTMLSpanElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState<CSSProperties | null>(null);

--- a/src/components/Settings/SettingsScreen.tsx
+++ b/src/components/Settings/SettingsScreen.tsx
@@ -29,7 +29,7 @@ function DeviceRow({
   devices,
   current,
   onPick,
-}: {
+}: Readonly<{
   icon: string;
   title: string;
   /** What this default is used for. */
@@ -37,7 +37,7 @@ function DeviceRow({
   devices: OutputDevice[];
   current: string | null;
   onPick: (name: string) => void;
-}) {
+}>) {
   const [open, setOpen] = useState(false);
   const currentDesc = devices.find((d) => d.name === current)?.description ?? current ?? "-";
 
@@ -74,6 +74,13 @@ function DeviceRow({
       </div>
     </div>
   );
+}
+
+function engineDesc(native: boolean | null): string {
+  if (native === null) return "…";
+  return native
+    ? "Native PipeWire (pipewire-rs) - live metering, passive routing"
+    : "pactl fallback - native engine unavailable on this system";
 }
 
 export function SettingsScreen() {
@@ -250,11 +257,7 @@ export function SettingsScreen() {
             <div className="rmain">
               <div className="rtitle">Audio engine</div>
               <div className="rsub">
-                {backendNative === null
-                  ? "…"
-                  : backendNative
-                    ? "Native PipeWire (pipewire-rs) - live metering, passive routing"
-                    : "pactl fallback - native engine unavailable on this system"}
+                {engineDesc(backendNative)}
               </div>
             </div>
             {backendNative !== null && (

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -9,12 +9,14 @@ import { ProfileMenu } from "./ProfileMenu";
  * controls. The close button triggers the normal close-requested flow,
  * which the Rust side intercepts to hide to tray.
  */
-export function TitleBar({ screen }: { screen: string }) {
+export function TitleBar({ screen }: Readonly<{ screen: string }>) {
   const win = getCurrentWindow();
   const error = useMixerStore((s) => s.error);
   const initialized = useMixerStore((s) => s.initialized);
 
-  const status = error ? "Engine error" : initialized ? "Engine running" : "Starting…";
+  let status = "Starting…";
+  if (error) status = "Engine error";
+  else if (initialized) status = "Engine running";
 
   return (
     <header data-tauri-drag-region className="headerbar">

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -1,7 +1,7 @@
 import { Ms } from "./Icons";
 
 /** Design-system switch. */
-export function Toggle({ on, onClick }: { on: boolean; onClick: () => void }) {
+export function Toggle({ on, onClick }: Readonly<{ on: boolean; onClick: () => void }>) {
   return <button className={"toggle" + (on ? " on" : "")} onClick={onClick} aria-pressed={on} />;
 }
 
@@ -12,13 +12,13 @@ export function ToggleRow({
   sub,
   on,
   onToggle,
-}: {
+}: Readonly<{
   icon: string;
   title: string;
   sub: string;
   on: boolean;
   onToggle: () => void;
-}) {
+}>) {
   return (
     <div className="row">
       <div className="ricon">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -451,6 +451,7 @@ body,
   }
 }
 .strip {
+  position: relative;
   width: 132px;
   flex: 0 0 132px;
   display: flex;
@@ -464,9 +465,6 @@ body,
 }
 .strip.muted {
   opacity: 0.62;
-}
-.strip {
-  position: relative;
 }
 /* delete ×: corner-anchored, appears on strip hover (design .strip-x) */
 .strip-x {


### PR DESCRIPTION
a code-quality pass, mostly guided by the sonarcloud findings, sticking to low-risk stuff and skipping anything that would be a real refactor.

what changed:

- flattened the 14 nested ternaries into small helpers or if/else (the app screen switch, output labels, mic/engine status, the mix membership label, the eq axis anchors). mostly a readability thing, no behavior change.
- marked component props readonly (the s6759 rule). purely mechanical.
- removed a duplicate .strip css selector, and pulled the onboarding progress dots into one small component so they aren't copy-pasted three times (that also drops the array-index keys).

what i left alone on purpose:

- the `void promise` pattern (s3735, 87 of them) is intentional, it's how we mark fire-and-forget calls so eslint's no-floating-promises stays happy. changing it would just trade one linter's complaint for another's.
- the keyboard-accessibility cluster (mouse handlers without keyboard handlers on the menu rows). that's a real fix but it's its own piece of work, not a quick one.
- a couple cognitive-complexity refactors, and a contrast warning that looks like a false positive since the checker can't see through the alpha background.

tsc, vitest and the build all pass.
