### PR TITLE
feat(apps): forget stale apps, componentize menus, fix wide-window layout

### DIFF
--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -282,7 +282,7 @@ pub struct MicConfig {
     /// What other apps list the processed mic as (node description).
     #[serde(default = "default_mic_label")]
     pub output_label: String,
-    /// 0–200; 100 = unity.
+    /// 0-200; 100 = unity.
     pub gain_percent: u8,
     pub gate_enabled: bool,
     pub comp_enabled: bool,

--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -3,6 +3,8 @@ use tauri::State;
 use crate::audio::types::{AppStream, OutputDevice, VirtualSink};
 use crate::state::AppState;
 
+/// How often the poll force-saves app history to refresh `last_seen` on disk.
+const SEEN_FLUSH_SECS: u64 = 15 * 60;
 
 /// Current channel state (volume/mute as tracked by MixerState).
 #[tauri::command]
@@ -38,10 +40,7 @@ pub fn get_app_streams(state: State<'_, AppState>) -> Result<Vec<AppStream>, Str
         }
     }
 
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+    let now = crate::persistence::unix_now();
 
     // Phase 1: under the lock, update history and *plan* auto-routing - but do
     // no blocking work. Holding the mixer mutex across the disk save or the
@@ -61,6 +60,18 @@ pub fn get_app_streams(state: State<'_, AppState>) -> Result<Vec<AppStream>, Str
                 now,
             );
         }
+        // A pure last_seen bump never reports a structural change, so without
+        // this the freshest timestamps only reach disk on a clean tray-quit -
+        // and an unclean exit would leave a daily-used app looking stale
+        // enough for the prune to forget it. Flushing on a slow cadence
+        // bounds that drift, and re-runs the prune for sessions that outlive
+        // the window.
+        if now.saturating_sub(mixer.seen_saved_at) >= SEEN_FLUSH_SECS {
+            mixer.prune_stale_apps(now);
+            mixer.seen_saved_at = now;
+            structural_change = true;
+        }
+
         // Hide ignored identities (also exempts them from auto-routing).
         streams.retain(|s| !mixer.seen.is_ignored(&s.match_prop, &s.match_value));
 

--- a/src-tauri/src/commands/routing.rs
+++ b/src-tauri/src/commands/routing.rs
@@ -56,7 +56,7 @@ pub fn route_app_to_channel(
     Ok(())
 }
 
-/// Set a channel's volume (0–150%).
+/// Set a channel's volume (0-150%).
 #[tauri::command]
 pub fn set_channel_volume(
     state: State<'_, AppState>,
@@ -147,7 +147,7 @@ pub fn rename_app(
     aliases.save().map_err(|e| e.to_string())
 }
 
-/// Set the volume of a single app stream (0–150%).
+/// Set the volume of a single app stream (0-150%).
 #[tauri::command]
 pub fn set_app_volume(
     state: State<'_, AppState>,

--- a/src-tauri/src/mixer/state.rs
+++ b/src-tauri/src/mixer/state.rs
@@ -26,6 +26,11 @@ pub struct MixerState {
     pub mic: crate::audio::types::MicConfig,
     /// Every app identity ever observed (history + ignore list).
     pub seen: crate::persistence::seen::SeenApps,
+    /// Unix seconds of the last `seen` write. The poll only saves on
+    /// structural changes, so this drives a slow flush that bounds how stale
+    /// on-disk `last_seen` timestamps can get if Sink dies without a clean
+    /// quit - the age-based prune trusts them.
+    pub seen_saved_at: u64,
     /// Profile changes autosave into this profile (live-bound, not a
     /// snapshot). None = unmanaged state.
     pub active_profile: Option<String>,
@@ -67,6 +72,27 @@ impl MixerState {
         self.channels.iter_mut().find(|c| c.name == sink_name)
     }
 
+    /// Forget history entries the user never acted on and hasn't seen in a
+    /// week, so the "not running" list stays about apps they actually use.
+    /// Returns true when the history changed and should be saved.
+    pub fn prune_stale_apps(&mut self, now: u64) -> bool {
+        // Disjoint field borrows: `prune` needs `seen` mutably while the
+        // intent test reads the other two.
+        let Self {
+            seen,
+            assignments,
+            aliases,
+            ..
+        } = self;
+        seen.prune(
+            now,
+            crate::persistence::seen::MAX_SEEN_AGE_SECS,
+            |prop, value| {
+                assignments.sink_for(prop, value).is_some() || aliases.get(prop, value).is_some()
+            },
+        )
+    }
+
     pub fn reset(&mut self) {
         self.channels.clear();
         self.initialized = false;
@@ -86,6 +112,26 @@ mod tests {
         assert_eq!(state.channels[0].name, "sink_game");
         assert_eq!(state.channels[0].label, "Game");
         assert!(state.channels.iter().all(|c| c.volume_percent == 100 && !c.muted));
+    }
+
+    #[test]
+    fn prune_stale_apps_exempts_assigned_and_aliased() {
+        const DAY: u64 = 24 * 60 * 60;
+        let now = 100 * DAY;
+        let old = now - 30 * DAY;
+        let mut state = MixerState::default();
+        for value in ["plain", "assigned", "aliased"] {
+            state.seen.upsert("application.name", value, value, None, old);
+        }
+        state
+            .assignments
+            .set("application.name", "assigned", "sink_game");
+        state.aliases.set("application.name", "aliased", "My App");
+
+        assert!(state.prune_stale_apps(now));
+        assert!(state.seen.get("application.name", "plain").is_none());
+        assert!(state.seen.get("application.name", "assigned").is_some());
+        assert!(state.seen.get("application.name", "aliased").is_some());
     }
 
     #[test]

--- a/src-tauri/src/persistence/buses.rs
+++ b/src-tauri/src/persistence/buses.rs
@@ -209,7 +209,7 @@ impl Buses {
     pub fn add(&mut self, label: &str) -> Result<BusDef, SinkError> {
         let label = label.trim();
         if label.is_empty() || label.len() > 24 {
-            return Err(SinkError::Config("mix label must be 1–24 characters".into()));
+            return Err(SinkError::Config("mix label must be 1-24 characters".into()));
         }
         // The master mix doesn't count against the user's mixes.
         if self.buses.iter().filter(|b| !is_master(&b.name)).count() >= MAX_BUSES {
@@ -242,7 +242,7 @@ impl Buses {
     pub fn rename(&mut self, name: &str, label: &str) -> Result<(), SinkError> {
         let label = label.trim();
         if label.is_empty() || label.len() > 24 {
-            return Err(SinkError::Config("mix label must be 1–24 characters".into()));
+            return Err(SinkError::Config("mix label must be 1-24 characters".into()));
         }
         let def = self
             .buses

--- a/src-tauri/src/persistence/channels.rs
+++ b/src-tauri/src/persistence/channels.rs
@@ -161,7 +161,7 @@ impl Channels {
     pub fn add(&mut self, label: &str, icon: Option<String>) -> Result<ChannelDef, SinkError> {
         let label = label.trim();
         if label.is_empty() || label.len() > 24 {
-            return Err(SinkError::Config("channel label must be 1–24 characters".into()));
+            return Err(SinkError::Config("channel label must be 1-24 characters".into()));
         }
         if self.channels.len() >= MAX_CHANNELS {
             return Err(SinkError::Config(format!(
@@ -188,7 +188,7 @@ impl Channels {
     pub fn rename(&mut self, name: &str, label: &str) -> Result<(), SinkError> {
         let label = label.trim();
         if label.is_empty() || label.len() > 24 {
-            return Err(SinkError::Config("channel label must be 1–24 characters".into()));
+            return Err(SinkError::Config("channel label must be 1-24 characters".into()));
         }
         let def = self
             .channels

--- a/src-tauri/src/persistence/mod.rs
+++ b/src-tauri/src/persistence/mod.rs
@@ -13,6 +13,14 @@ pub mod seen;
 pub mod profiles;
 pub mod wireplumber;
 
+/// Seconds since the Unix epoch, or 0 if the clock predates it.
+pub fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
 /// Create Sink's config directory (and parents) with owner-only access -
 /// routing rules and app history are nobody else's business. Used by every
 /// save path that writes under `$XDG_CONFIG_HOME/sink`.

--- a/src-tauri/src/persistence/profiles.rs
+++ b/src-tauri/src/persistence/profiles.rs
@@ -49,7 +49,7 @@ pub fn sanitize_name(name: &str) -> Result<String, SinkError> {
     let trimmed = name.trim();
     if trimmed.is_empty() || trimmed.len() > 64 {
         return Err(SinkError::Config(
-            "profile name must be 1–64 characters".into(),
+            "profile name must be 1-64 characters".into(),
         ));
     }
     if !trimmed

--- a/src-tauri/src/persistence/seen.rs
+++ b/src-tauri/src/persistence/seen.rs
@@ -5,6 +5,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::SinkError;
 
+/// How long an app the user never touched stays in the history before it is
+/// forgotten. Entries carrying user intent (an assignment, an alias, or the
+/// ignore flag) are exempt and kept indefinitely.
+pub const MAX_SEEN_AGE_SECS: u64 = 7 * 24 * 60 * 60;
+
 /// One app identity Sink has ever observed playing audio.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SeenEntry {
@@ -130,6 +135,24 @@ impl SeenApps {
         self.apps
             .retain(|a| !(a.match_prop == match_prop && a.match_value == match_value));
     }
+
+    /// Drop history entries last seen over `max_age_secs` ago that the user
+    /// never acted on. `has_intent` reports whether an identity carries an
+    /// assignment or an alias; those and ignored entries survive forever, so
+    /// a game played once a month keeps its channel. Returns true when
+    /// anything was removed (i.e. the caller should persist).
+    pub fn prune<F>(&mut self, now: u64, max_age_secs: u64, has_intent: F) -> bool
+    where
+        F: Fn(&str, &str) -> bool,
+    {
+        let before = self.apps.len();
+        self.apps.retain(|a| {
+            a.ignored
+                || now.saturating_sub(a.last_seen) <= max_age_secs
+                || has_intent(&a.match_prop, &a.match_value)
+        });
+        self.apps.len() != before
+    }
 }
 
 #[cfg(test)]
@@ -156,5 +179,38 @@ mod tests {
         assert!(!seen.set_ignored("media.name", "nope", true));
         seen.forget("media.name", "audio-src");
         assert!(seen.get("media.name", "audio-src").is_none());
+    }
+
+    #[test]
+    fn prune_drops_only_stale_untouched_entries() {
+        const DAY: u64 = 24 * 60 * 60;
+        let now = 100 * DAY;
+        let mut seen = SeenApps::default();
+        seen.upsert("application.name", "recent", "Recent", None, now - DAY);
+        seen.upsert("application.name", "stale", "Stale", None, now - 8 * DAY);
+        seen.upsert("application.name", "routed", "Routed", None, now - 60 * DAY);
+        seen.upsert("application.name", "hidden", "Hidden", None, now - 60 * DAY);
+        seen.set_ignored("application.name", "hidden", true);
+
+        let routed = |_prop: &str, value: &str| value == "routed";
+        assert!(seen.prune(now, MAX_SEEN_AGE_SECS, routed));
+
+        assert!(seen.get("application.name", "recent").is_some());
+        assert!(seen.get("application.name", "stale").is_none());
+        // Assigned and ignored entries outlive the window.
+        assert!(seen.get("application.name", "routed").is_some());
+        assert!(seen.get("application.name", "hidden").is_some());
+
+        // Nothing left to drop - the caller shouldn't be told to save.
+        assert!(!seen.prune(now, MAX_SEEN_AGE_SECS, routed));
+    }
+
+    #[test]
+    fn prune_tolerates_timestamps_from_the_future() {
+        let mut seen = SeenApps::default();
+        // A clock jump backwards must not make every entry look ancient.
+        seen.upsert("application.name", "ahead", "Ahead", None, 5_000);
+        assert!(!seen.prune(1_000, MAX_SEEN_AGE_SECS, |_, _| false));
+        assert!(seen.get("application.name", "ahead").is_some());
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -32,7 +32,8 @@ impl AppState {
             .as_deref()
             .and_then(|name| crate::persistence::profiles::load(name).ok())
             .and_then(|p| p.trigger_device);
-        let mixer = MixerState {
+        let now = crate::persistence::unix_now();
+        let mut mixer = MixerState {
             assignments: crate::persistence::assignments::Assignments::load(),
             aliases: crate::persistence::aliases::Aliases::load(),
             outputs: crate::persistence::outputs::ChannelOutputs::load(),
@@ -44,8 +45,14 @@ impl AppState {
             active_profile,
             active_trigger,
             prefs: crate::persistence::prefs::Prefs::load(),
+            seen_saved_at: now,
             ..MixerState::default()
         };
+        if mixer.prune_stale_apps(now) {
+            if let Err(e) = mixer.seen.save() {
+                eprintln!("sink: pruning app history failed: {e}");
+            }
+        }
         Self {
             backend,
             backend_native,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ export default function App() {
             <strong>Audio error:</strong> {error}
           </span>
           <button
+            type="button"
             className="error-banner-x"
             aria-label="Dismiss error"
             title="Dismiss"
@@ -65,6 +66,7 @@ export default function App() {
         <nav className="rail">
           {NAV.map((n) => (
             <button
+              type="button"
               key={n.id}
               className={"nav-item" + (n.id === nav ? " active" : "")}
               onClick={() => setNav(n.id)}
@@ -75,6 +77,7 @@ export default function App() {
           ))}
           <div className="rail-spacer" />
           <button
+            type="button"
             className={"nav-item" + (nav === "settings" ? " active" : "")}
             onClick={() => setNav("settings")}
           >

--- a/src/components/AppList/AppList.tsx
+++ b/src/components/AppList/AppList.tsx
@@ -82,7 +82,7 @@ export function AppList() {
 
         {ignored.length > 0 && (
           <>
-            <button className="ignored-toggle" onClick={() => setShowIgnored((v) => !v)}>
+            <button type="button" className="ignored-toggle" onClick={() => setShowIgnored((v) => !v)}>
               <Ms name={showIgnored ? "expand_less" : "expand_more"} />
               {ignored.length} ignored {ignored.length === 1 ? "app" : "apps"}
             </button>

--- a/src/components/AppList/AppList.tsx
+++ b/src/components/AppList/AppList.tsx
@@ -3,9 +3,7 @@ import { useMixerStore } from "../../store/mixer";
 import type { AppStream } from "../../types";
 import { Ms } from "../Icons";
 import { AppRow } from "./AppRow";
-import { AppIcon } from "./AppIcon";
 import { InactiveRow } from "./InactiveRow";
-import { relativeTime } from "../../lib/format";
 
 /** Apps screen: live apps grouped by channel, previously-seen apps below
  * (pre-routable while closed), ignored apps tucked away at the bottom. */
@@ -13,8 +11,6 @@ export function AppList() {
   const appStreams = useMixerStore((s) => s.appStreams);
   const channels = useMixerStore((s) => s.channels);
   const seenApps = useMixerStore((s) => s.seenApps);
-  const setAppIgnored = useMixerStore((s) => s.setAppIgnored);
-  const forgetApp = useMixerStore((s) => s.forgetApp);
   const [showIgnored, setShowIgnored] = useState(false);
 
   const byName = (a: AppStream, b: AppStream) =>
@@ -93,35 +89,7 @@ export function AppList() {
             {showIgnored && (
               <div className="card card-inactive">
                 {ignored.map((app) => (
-                  <div className="row row-inactive" key={`${app.match_prop}:${app.match_value}`}>
-                    <div className="ricon">
-                      <AppIcon iconPath={app.icon_path} />
-                    </div>
-                    <div className="rmain">
-                      <div className="rtitle">
-                        <span className="rname">{app.alias ?? app.display_name}</span>
-                      </div>
-                      <div className="rsub">last seen {relativeTime(app.last_seen)}</div>
-                    </div>
-                    <div className="rtrail">
-                      <button
-                        className="rename-btn row-action"
-                        title="Stop ignoring"
-                        aria-label={`Stop ignoring ${app.display_name}`}
-                        onClick={() => void setAppIgnored(app, false)}
-                      >
-                        <Ms name="visibility" style={{ fontSize: 16 }} />
-                      </button>
-                      <button
-                        className="rename-btn row-action"
-                        title="Forget - erase from history"
-                        aria-label={`Forget ${app.display_name}`}
-                        onClick={() => void forgetApp(app)}
-                      >
-                        <Ms name="delete" style={{ fontSize: 16 }} />
-                      </button>
-                    </div>
-                  </div>
+                  <InactiveRow key={`${app.match_prop}:${app.match_value}`} app={app} ignored />
                 ))}
               </div>
             )}

--- a/src/components/AppList/AppRow.tsx
+++ b/src/components/AppList/AppRow.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useMixerStore } from "../../store/mixer";
 import type { AppStream } from "../../types";
-import { Ms } from "../Icons";
+import { IconButton } from "../IconButton";
 import { AppIcon } from "./AppIcon";
 import { ChannelSelect } from "./ChannelSelect";
 import { HSlider } from "./HSlider";
@@ -69,17 +69,22 @@ export function AppRow({ stream }: Readonly<AppRowProps>) {
                 {stream.app_name}
               </span>
             )}
-            <button className="rename-btn" aria-label={`Rename ${displayName}`} onClick={startEdit}>
-              <Ms name="edit" style={{ fontSize: 14 }} />
-            </button>
-            <button
-              className="rename-btn"
+            <IconButton
+              reveal
+              size={14}
+              icon="edit"
+              title="Rename"
+              label={`Rename ${displayName}`}
+              onClick={startEdit}
+            />
+            <IconButton
+              reveal
+              size={14}
+              icon="visibility_off"
               title="Ignore - hide this app from Sink"
-              aria-label={`Ignore ${displayName}`}
+              label={`Ignore ${displayName}`}
               onClick={() => void setAppIgnored(stream, true)}
-            >
-              <Ms name="visibility_off" style={{ fontSize: 14 }} />
-            </button>
+            />
           </div>
         )}
         <div className="rsub">stream #{stream.index}</div>

--- a/src/components/AppList/ChannelSelect.tsx
+++ b/src/components/AppList/ChannelSelect.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useMixerStore } from "../../store/mixer";
 import { UNASSIGNED } from "../../types";
 import { channelIcon, Ms } from "../Icons";
+import { MenuItem } from "../MenuItem";
 import { Popover } from "../Popover";
 
 interface ChannelSelectProps {
@@ -16,42 +17,62 @@ export function ChannelSelect({ value, onChange }: Readonly<ChannelSelectProps>)
   const channels = useMixerStore((s) => s.channels);
 
   const current = channels.find((c) => c.name === value);
+  // An assignment outlives the channel it names - deleted here, or belonging
+  // to a profile that isn't loaded. Reporting that as "Unrouted" would be a
+  // lie, and picking Unrouted to confirm it would delete a real assignment.
+  const missing = value !== null && !current;
+
+  let icon: string;
+  if (current) icon = channelIcon(current);
+  else if (missing) icon = "link_off";
+  else icon = "block";
+
+  let label: string;
+  if (current) label = current.label;
+  else if (missing) label = "Missing";
+  else label = "Unrouted";
 
   return (
     <div style={{ position: "relative" }}>
-      <button className="select" onClick={() => setOpen((o) => !o)}>
-        <Ms name={current ? channelIcon(current) : "help"} />
-        <span style={{ minWidth: 52, textAlign: "left" }}>
-          {current ? current.label : "Unrouted"}
-        </span>
+      <button
+        className="select"
+        onClick={() => setOpen((o) => !o)}
+        title={
+          missing
+            ? `Assigned to "${value}", which no profile in use has. Audio plays on the default output until that channel exists again.`
+            : undefined
+        }
+      >
+        <Ms name={icon} />
+        <span style={{ minWidth: 52, textAlign: "left" }}>{label}</span>
         <Ms name="expand_more" />
       </button>
       <Popover open={open} onClose={() => setOpen(false)} side="bottom" align="end">
         {channels.map((c) => (
-          <div
+          <MenuItem
             key={c.name}
-            className={"menu-item" + (c.name === value ? " sel" : "")}
+            icon={channelIcon(c)}
+            selected={c.name === value}
+            showCheck
             onClick={() => {
               onChange(c.name);
               setOpen(false);
             }}
           >
-            <Ms name={channelIcon(c)} />
-            <span>{c.label}</span>
-            {c.name === value && <Ms name="check" style={{ marginLeft: "auto" }} />}
-          </div>
+            {c.label}
+          </MenuItem>
         ))}
-        <div
-          className={"menu-item" + (value === null ? " sel" : "")}
+        <MenuItem
+          icon="block"
+          selected={value === null}
+          showCheck
           onClick={() => {
             onChange(UNASSIGNED);
             setOpen(false);
           }}
         >
-          <Ms name="block" />
-          <span>Unrouted</span>
-          {value === null && <Ms name="check" style={{ marginLeft: "auto" }} />}
-        </div>
+          Unrouted
+        </MenuItem>
       </Popover>
     </div>
   );

--- a/src/components/AppList/ChannelSelect.tsx
+++ b/src/components/AppList/ChannelSelect.tsx
@@ -35,6 +35,7 @@ export function ChannelSelect({ value, onChange }: Readonly<ChannelSelectProps>)
   return (
     <div style={{ position: "relative" }}>
       <button
+        type="button"
         className="select"
         onClick={() => setOpen((o) => !o)}
         title={

--- a/src/components/AppList/InactiveRow.tsx
+++ b/src/components/AppList/InactiveRow.tsx
@@ -1,15 +1,17 @@
 import { useMixerStore } from "../../store/mixer";
 import type { SeenApp } from "../../types";
 import { relativeTime } from "../../lib/format";
-import { Ms } from "../Icons";
+import { IconButton } from "../IconButton";
 import { AppIcon } from "./AppIcon";
 import { ChannelSelect } from "./ChannelSelect";
 
 /**
  * A previously-seen app that isn't currently playing. Routing edits here
  * are "pre-routing": they take effect the moment the app next plays audio.
+ * Ignored apps use the same row minus the routing control - they are hidden
+ * from Sink until un-ignored, so there is nothing to route.
  */
-export function InactiveRow({ app }: Readonly<{ app: SeenApp }>) {
+export function InactiveRow({ app, ignored }: Readonly<{ app: SeenApp; ignored?: boolean }>) {
   const setAppAssignment = useMixerStore((s) => s.setAppAssignment);
   const setAppIgnored = useMixerStore((s) => s.setAppIgnored);
   const forgetApp = useMixerStore((s) => s.forgetApp);
@@ -26,26 +28,36 @@ export function InactiveRow({ app }: Readonly<{ app: SeenApp }>) {
         <div className="rsub">last seen {relativeTime(app.last_seen)}</div>
       </div>
       <div className="rtrail">
-        <ChannelSelect
-          value={app.assigned_sink}
-          onChange={(sinkName) => void setAppAssignment(app, sinkName === "" ? null : sinkName)}
-        />
-        <button
-          className="rename-btn row-action"
-          title="Ignore - hide this app from Sink"
-          aria-label={`Ignore ${app.display_name}`}
-          onClick={() => void setAppIgnored(app, true)}
-        >
-          <Ms name="visibility_off" style={{ fontSize: 16 }} />
-        </button>
-        <button
-          className="rename-btn row-action"
+        {!ignored && (
+          <ChannelSelect
+            value={app.assigned_sink}
+            onChange={(sinkName) => void setAppAssignment(app, sinkName === "" ? null : sinkName)}
+          />
+        )}
+        {ignored ? (
+          <IconButton
+            reveal
+            icon="visibility"
+            title="Stop ignoring"
+            label={`Stop ignoring ${app.display_name}`}
+            onClick={() => void setAppIgnored(app, false)}
+          />
+        ) : (
+          <IconButton
+            reveal
+            icon="visibility_off"
+            title="Ignore - hide this app from Sink"
+            label={`Ignore ${app.display_name}`}
+            onClick={() => void setAppIgnored(app, true)}
+          />
+        )}
+        <IconButton
+          reveal
+          icon="delete"
           title="Forget - erase from history (and its routing/alias)"
-          aria-label={`Forget ${app.display_name}`}
+          label={`Forget ${app.display_name}`}
           onClick={() => void forgetApp(app)}
-        >
-          <Ms name="delete" style={{ fontSize: 16 }} />
-        </button>
+        />
       </div>
     </div>
   );

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -26,6 +26,7 @@ export function ConfirmModal({
       <p className="modal-text">{children}</p>
       <div className="modal-btns">
         <button
+          type="button"
           className="modal-btn danger"
           onClick={() => {
             onClose();
@@ -34,7 +35,7 @@ export function ConfirmModal({
         >
           {confirmLabel}
         </button>
-        <button className="modal-btn" onClick={onClose}>
+        <button type="button" className="modal-btn" onClick={onClose}>
           Cancel
         </button>
       </div>

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+import { Modal } from "./Modal";
+
+interface ConfirmModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  /** Label for the destructive action, e.g. "Delete channel". */
+  confirmLabel: string;
+  onConfirm: () => void;
+  /** What the user is about to lose. */
+  children: ReactNode;
+}
+
+/** Destructive-action confirmation: an explanation and a danger/cancel pair. */
+export function ConfirmModal({
+  open,
+  onClose,
+  title,
+  confirmLabel,
+  onConfirm,
+  children,
+}: Readonly<ConfirmModalProps>) {
+  return (
+    <Modal open={open} onClose={onClose} title={title}>
+      <p className="modal-text">{children}</p>
+      <div className="modal-btns">
+        <button
+          className="modal-btn danger"
+          onClick={() => {
+            onClose();
+            onConfirm();
+          }}
+        >
+          {confirmLabel}
+        </button>
+        <button className="modal-btn" onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/Eq/EqBandRow.tsx
+++ b/src/components/Eq/EqBandRow.tsx
@@ -105,6 +105,7 @@ export function EqBandRow({ index, band, color, selected, canRemove, onSelect, o
         />
       </label>
       <button
+        type="button"
         className="eqm-remove"
         disabled={!canRemove}
         title={canRemove ? "Remove band" : "The EQ keeps at least one band"}

--- a/src/components/Eq/EqModal.tsx
+++ b/src/components/Eq/EqModal.tsx
@@ -84,6 +84,7 @@ export function EqModal({ channel, open, onClose }: Readonly<EqModalProps>) {
             onError={setError}
           />
           <button
+            type="button"
             className="select eqm-iconbtn"
             onClick={reset}
             title="Reset to the flat 5-band layout"
@@ -135,7 +136,7 @@ export function EqModal({ channel, open, onClose }: Readonly<EqModalProps>) {
           </div>
         </div>
         {config.bands.length < MAX_EQ_BANDS && (
-          <button className="eqm-add" onClick={addBand}>
+          <button type="button" className="eqm-add" onClick={addBand}>
             <Ms name="add" style={{ fontSize: 15 }} />
             Add band
           </button>

--- a/src/components/Eq/EqPresetMenu.tsx
+++ b/src/components/Eq/EqPresetMenu.tsx
@@ -146,6 +146,7 @@ export function EqPresetMenu({ sinkName, config, onApply, onError }: Readonly<Eq
   const presetRow = (entry: EqPresetEntry) => (
     <div key={`${entry.source}:${entry.preset.name}`} className="eqm-preset-row">
       <button
+        type="button"
         className={"menu-item eqm-preset-apply" + (entry === activePreset ? " sel" : "")}
         title={entry.preset.description ?? undefined}
         onClick={() => applyPreset(entry)}
@@ -157,6 +158,7 @@ export function EqPresetMenu({ sinkName, config, onApply, onError }: Readonly<Eq
         (confirmDelete === entry.preset.name ? (
           <span className="eqm-preset-confirm">
             <button
+              type="button"
               className="eqm-remove danger"
               title="Delete this preset"
               aria-label={`Confirm delete ${entry.preset.name}`}
@@ -165,6 +167,7 @@ export function EqPresetMenu({ sinkName, config, onApply, onError }: Readonly<Eq
               <Ms name="check" style={{ fontSize: 14 }} />
             </button>
             <button
+              type="button"
               className="eqm-remove"
               title="Keep it"
               aria-label="Cancel delete"
@@ -175,6 +178,7 @@ export function EqPresetMenu({ sinkName, config, onApply, onError }: Readonly<Eq
           </span>
         ) : (
           <button
+            type="button"
             className="eqm-remove"
             title="Delete preset"
             aria-label={`Delete preset ${entry.preset.name}`}
@@ -189,6 +193,7 @@ export function EqPresetMenu({ sinkName, config, onApply, onError }: Readonly<Eq
   return (
     <div style={{ position: "relative" }}>
       <button
+        type="button"
         className="select"
         onClick={() => setMenuOpen((o) => !o)}
         title={activePreset ? `Preset: ${activePreset.preset.name}` : undefined}
@@ -239,6 +244,7 @@ export function EqPresetMenu({ sinkName, config, onApply, onError }: Readonly<Eq
             }}
           />
           <button
+            type="button"
             className="select"
             disabled={!saveName.trim()}
             title="Save current curve as a preset"
@@ -251,6 +257,7 @@ export function EqPresetMenu({ sinkName, config, onApply, onError }: Readonly<Eq
         <div className="menu-sep" />
         <div className="eqm-io-row">
           <button
+            type="button"
             className={"select eqm-io-btn" + (importing ? " on" : "")}
             aria-expanded={importing}
             title="Import a preset (paste JSON / AutoEq, or a file)"
@@ -260,6 +267,7 @@ export function EqPresetMenu({ sinkName, config, onApply, onError }: Readonly<Eq
             <span>Import</span>
           </button>
           <button
+            type="button"
             className="select eqm-io-btn"
             title="Export this curve to a JSON file"
             onClick={() => void exportToFile()}
@@ -279,13 +287,14 @@ export function EqPresetMenu({ sinkName, config, onApply, onError }: Readonly<Eq
             />
             <div className="eqm-import-btns">
               <button
+                type="button"
                 className="select"
                 disabled={!importText.trim()}
                 onClick={() => void importPasted()}
               >
                 Apply pasted
               </button>
-              <button className="select" onClick={() => void importFromFile()}>
+              <button type="button" className="select" onClick={() => void importFromFile()}>
                 From file…
               </button>
             </div>

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,0 +1,43 @@
+import { cx } from "../lib/cx";
+import { Ms } from "./Icons";
+
+interface IconButtonProps {
+  icon: string;
+  /** Tooltip text, and the accessible name unless `label` overrides it. */
+  title: string;
+  /** Accessible name for when the tooltip is too terse to name its target
+   *  (e.g. "Ignore" on a list of apps). */
+  label?: string;
+  /** Hidden until the containing `.row` is hovered - list-row actions. */
+  reveal?: boolean;
+  /** Boxed 24px hit area with a hover fill, for always-visible actions. */
+  boxed?: boolean;
+  danger?: boolean;
+  /** Glyph size in px; varies by row density. */
+  size?: number;
+  onClick: () => void;
+}
+
+/** Borderless icon-only action button used in list rows and menus. */
+export function IconButton({
+  icon,
+  title,
+  label,
+  reveal,
+  boxed,
+  danger,
+  size = 16,
+  onClick,
+}: Readonly<IconButtonProps>) {
+  return (
+    <button
+      type="button"
+      className={cx("icon-btn", reveal && "reveal", boxed && "boxed", danger && "danger")}
+      title={title}
+      aria-label={label ?? title}
+      onClick={onClick}
+    >
+      <Ms name={icon} style={{ fontSize: size }} />
+    </button>
+  );
+}

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from "react";
+import { cx } from "../lib/cx";
+import { Ms } from "./Icons";
+
+interface MenuItemProps {
+  /** Leading Material symbol. Omitted for text-only rows. */
+  icon?: string;
+  /** The current choice: accent styling plus, optionally, a trailing check. */
+  selected?: boolean;
+  /** Show the trailing check mark. Menus that signal choice by colour alone
+   *  leave this off. */
+  showCheck?: boolean;
+  onClick: () => void;
+  title?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * One choice in a Popover menu. A real `<button>`, so every menu is
+ * reachable by keyboard and announced as a control rather than as text.
+ */
+export function MenuItem({
+  icon,
+  selected = false,
+  showCheck = false,
+  onClick,
+  title,
+  className,
+  children,
+}: Readonly<MenuItemProps>) {
+  return (
+    <button
+      type="button"
+      role="menuitemradio"
+      aria-checked={selected}
+      className={cx("menu-item", selected && "sel", className)}
+      title={title}
+      onClick={onClick}
+    >
+      {icon && <Ms name={icon} />}
+      <span className="menu-item-label">{children}</span>
+      {showCheck && selected && <Ms name="check" className="menu-item-check" />}
+    </button>
+  );
+}
+
+interface MenuCheckItemProps {
+  checked: boolean;
+  onClick: () => void;
+  title?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+/** A menu row that toggles rather than picks: membership lists and flags. */
+export function MenuCheckItem({
+  checked,
+  onClick,
+  title,
+  className,
+  children,
+}: Readonly<MenuCheckItemProps>) {
+  return (
+    <button
+      type="button"
+      role="menuitemcheckbox"
+      aria-checked={checked}
+      className={cx("menu-item", className)}
+      title={title}
+      onClick={onClick}
+    >
+      <Ms
+        name={checked ? "check_box" : "check_box_outline_blank"}
+        className={cx(checked && "menu-check-on")}
+      />
+      {children}
+    </button>
+  );
+}

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -17,7 +17,7 @@ interface MenuItemProps {
 }
 
 /**
- * One choice in a Popover menu. A real `<button>`, so every menu is
+ * One choice in a Popover menu. A real button element, so every menu is
  * reachable by keyboard and announced as a control rather than as text.
  */
 export function MenuItem({

--- a/src/components/Mic/MicScreen.tsx
+++ b/src/components/Mic/MicScreen.tsx
@@ -107,7 +107,7 @@ export function MicScreen() {
                   <Ms name="settings_voice" />
                 </div>
                 <div style={{ position: "relative", flex: 1, minWidth: 0 }}>
-                  <button className="select mic-device-select" onClick={() => setDeviceOpen((o) => !o)}>
+                  <button type="button" className="select mic-device-select" onClick={() => setDeviceOpen((o) => !o)}>
                     <span className="mic-device-name">{deviceLabel}</span>
                     <Ms name="expand_more" />
                   </button>
@@ -143,6 +143,7 @@ export function MicScreen() {
                   </Popover>
                 </div>
                 <button
+                  type="button"
                   className={"sbtn" + (micConfig.muted ? " on-mute" : "")}
                   style={{ width: 34, flex: "0 0 34px" }}
                   title={micConfig.muted ? "Unmute mic" : "Mute mic"}
@@ -151,6 +152,7 @@ export function MicScreen() {
                   <Ms name={micConfig.muted ? "mic_off" : "mic"} style={{ fontSize: 18 }} />
                 </button>
                 <button
+                  type="button"
                   className={"sbtn" + (listening ? " on-mon" : "")}
                   style={{ width: 34, flex: "0 0 34px" }}
                   title="Listen to yourself - hear the processed mic to tune the chain (wear headphones)"

--- a/src/components/Mic/MicScreen.tsx
+++ b/src/components/Mic/MicScreen.tsx
@@ -5,6 +5,7 @@ import { DspSlider } from "./DspSlider";
 import { perceptual } from "../../lib/audio";
 import { HSlider } from "../AppList/HSlider";
 import { Ms } from "../Icons";
+import { MenuItem } from "../MenuItem";
 import { Popover } from "../Popover";
 import { Toggle, ToggleRow } from "../Toggle";
 
@@ -67,7 +68,7 @@ export function MicScreen() {
       : (currentDevice?.description ?? micConfig.input_device);
 
   return (
-    <div className="content">
+    <div className="content narrow">
       <div className="screen-head">
         <h1>Microphone</h1>
         <div className="screen-head-actions">
@@ -85,7 +86,7 @@ export function MicScreen() {
           />
         </div>
       </div>
-      <div className="screen-scroll" style={{ maxWidth: 680 }}>
+      <div className="screen-scroll">
         <div className={micConfig.enabled ? undefined : "mic-disabled"}>
             <div className="section-label">Input</div>
             <div className="card mic-card">
@@ -116,30 +117,28 @@ export function MicScreen() {
                     side="bottom"
                     align="start"
                   >
-                    <div
-                      className={"menu-item" + (micConfig.input_device === null ? " sel" : "")}
+                    <MenuItem
+                      icon="mic"
+                      selected={micConfig.input_device === null}
                       onClick={() => {
                         void setMicConfig({ input_device: null });
                         setDeviceOpen(false);
                       }}
                     >
-                      <Ms name="mic" />
-                      <span>System default</span>
-                    </div>
+                      System default
+                    </MenuItem>
                     {inputDevices.map((d) => (
-                      <div
+                      <MenuItem
                         key={d.name}
-                        className={
-                          "menu-item" + (d.name === micConfig.input_device ? " sel" : "")
-                        }
+                        icon="mic"
+                        selected={d.name === micConfig.input_device}
                         onClick={() => {
                           void setMicConfig({ input_device: d.name });
                           setDeviceOpen(false);
                         }}
                       >
-                        <Ms name="mic" />
-                        <span>{d.description}</span>
-                      </div>
+                        {d.description}
+                      </MenuItem>
                     ))}
                   </Popover>
                 </div>

--- a/src/components/MixerBoard/BalanceBar.tsx
+++ b/src/components/MixerBoard/BalanceBar.tsx
@@ -84,6 +84,7 @@ export function BalanceBar() {
   ) => (
     <div style={{ position: "relative", display: "flex" }}>
       <button
+        type="button"
         className="bal-side"
         onClick={() => setOpen(!open)}
         title={`${channel.label} - click to pick the channel on this side`}

--- a/src/components/MixerBoard/BalanceBar.tsx
+++ b/src/components/MixerBoard/BalanceBar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useMixerStore } from "../../store/mixer";
 import type { VirtualSink } from "../../types";
 import { Ms } from "../Icons";
+import { MenuItem } from "../MenuItem";
 import { Popover } from "../Popover";
 
 /**
@@ -93,17 +94,17 @@ export function BalanceBar() {
         {channels
           .filter((c) => c.name !== other.name)
           .map((c) => (
-            <div
+            <MenuItem
               key={c.name}
-              className={"menu-item" + (c.name === channel.name ? " sel" : "")}
+              icon={c.icon ?? "graphic_eq"}
+              selected={c.name === channel.name}
               onClick={() => {
                 pick(c.name);
                 setOpen(false);
               }}
             >
-              <Ms name={c.icon ?? "graphic_eq"} />
-              <span>{c.label}</span>
-            </div>
+              {c.label}
+            </MenuItem>
           ))}
       </Popover>
     </div>

--- a/src/components/MixerBoard/ChannelApps.tsx
+++ b/src/components/MixerBoard/ChannelApps.tsx
@@ -1,7 +1,7 @@
 import { useMixerStore } from "../../store/mixer";
 import type { VirtualSink } from "../../types";
-import { Ms } from "../Icons";
 import { AppIcon } from "../AppList/AppIcon";
+import { MenuCheckItem } from "../MenuItem";
 import { Popover } from "../Popover";
 
 interface Entry {
@@ -81,32 +81,24 @@ export function ChannelApps({
   return (
     <Popover open={open} onClose={onClose} side="bottom" align="center" style={{ minWidth: 250 }}>
       {entries.length === 0 && (
-        <div className="menu-item" style={{ cursor: "default", color: "var(--fg-muted)" }}>
-          No apps discovered yet
-        </div>
+        <div className="menu-item static muted">No apps discovered yet</div>
       )}
       {entries.map((entry) => (
-        <div key={entry.key} className="menu-item" onClick={() => toggle(entry)}>
-          <Ms
-            name={entry.checked ? "check_box" : "check_box_outline_blank"}
-            style={entry.checked ? { color: "var(--accent-hover)" } : undefined}
-          />
+        <MenuCheckItem key={entry.key} checked={entry.checked} onClick={() => toggle(entry)}>
           <span className="channel-apps-icon">
             <AppIcon iconPath={entry.iconPath} />
           </span>
           <span className="channel-apps-name">{entry.name}</span>
           {entry.active ? (
-            <span className="eq on" style={{ marginLeft: "auto" }} aria-hidden="true">
+            <span className="eq on channel-apps-eq" aria-hidden="true">
               <i />
               <i />
               <i />
             </span>
           ) : (
-            entry.streamIndex === null && (
-              <span className="channel-apps-off">off</span>
-            )
+            entry.streamIndex === null && <span className="channel-apps-off">off</span>
           )}
-        </div>
+        </MenuCheckItem>
       ))}
     </Popover>
   );

--- a/src/components/MixerBoard/ChannelStrip.tsx
+++ b/src/components/MixerBoard/ChannelStrip.tsx
@@ -84,6 +84,7 @@ export function ChannelStrip({
       )}
       {channelCount > 1 && (
         <button
+          type="button"
           className="strip-x"
           aria-label={`Delete channel ${channel.label}`}
           title="Delete channel"
@@ -96,6 +97,7 @@ export function ChannelStrip({
       <div className="strip-head">
         <div style={{ position: "relative" }}>
           <button
+            type="button"
             className="strip-icon strip-icon-btn"
             title="Change icon"
             aria-label={`Change icon for ${channel.label}`}
@@ -113,6 +115,7 @@ export function ChannelStrip({
             <div className="icon-grid">
               {ICON_CHOICES.map((icon) => (
                 <button
+                  type="button"
                   key={icon}
                   className={"icon-cell" + (channelIcon(channel) === icon ? " sel" : "")}
                   onClick={() => {
@@ -153,6 +156,7 @@ export function ChannelStrip({
         )}
         <div style={{ position: "relative" }}>
           <button
+            type="button"
             className="strip-meta strip-meta-btn"
             title="Choose which apps play through this channel"
             onClick={() => setManagingApps(true)}
@@ -185,6 +189,7 @@ export function ChannelStrip({
 
       <div className="strip-btns">
         <button
+          type="button"
           className={"sbtn" + (channel.muted ? " on-mute" : "")}
           onClick={() => void toggleMute(channel.name, !channel.muted)}
           aria-pressed={channel.muted}
@@ -193,6 +198,7 @@ export function ChannelStrip({
           <Ms name={channel.muted ? "volume_off" : "volume_up"} style={{ fontSize: 16 }} />
         </button>
         <button
+          type="button"
           className={"sbtn" + (monitoring ? " on-mon" : "")}
           onClick={() => void toggleMonitor(channel.name)}
           aria-pressed={monitoring}
@@ -201,6 +207,7 @@ export function ChannelStrip({
           <Ms name="headphones" style={{ fontSize: 16 }} />
         </button>
         <button
+          type="button"
           className={"sbtn" + (eqEnabled ? " on-eq" : "")}
           onClick={() => setEditingEq(true)}
           aria-pressed={eqEnabled}

--- a/src/components/MixerBoard/ChannelStrip.tsx
+++ b/src/components/MixerBoard/ChannelStrip.tsx
@@ -3,7 +3,7 @@ import { useMixerStore } from "../../store/mixer";
 import type { VirtualSink } from "../../types";
 import { MAX_VOLUME } from "../../types";
 import { channelIcon, Ms, ICON_CHOICES } from "../Icons";
-import { Modal } from "../Modal";
+import { ConfirmModal } from "../ConfirmModal";
 import { Popover } from "../Popover";
 import { perceptual, volToDb } from "../../lib/audio";
 import { EqModal } from "../Eq/EqModal";
@@ -221,30 +221,16 @@ export function ChannelStrip({
         onChange={(o) => void setChannelOutput(channel.name, o)}
       />
 
-      <Modal
+      <ConfirmModal
         open={confirmingDelete}
         onClose={() => setConfirmingDelete(false)}
         title={`Delete "${channel.label}"?`}
+        confirmLabel="Delete channel"
+        onConfirm={() => void removeChannel(channel.name)}
       >
-        <p className="modal-text">
-          Apps routed to this channel return to the default output. Its saved
-          routing is removed.
-        </p>
-        <div className="modal-btns">
-          <button
-            className="modal-btn danger"
-            onClick={() => {
-              setConfirmingDelete(false);
-              void removeChannel(channel.name);
-            }}
-          >
-            Delete channel
-          </button>
-          <button className="modal-btn" onClick={() => setConfirmingDelete(false)}>
-            Cancel
-          </button>
-        </div>
-      </Modal>
+        Apps routed to this channel return to the default output. Its saved
+        routing is removed.
+      </ConfirmModal>
     </div>
   );
 }

--- a/src/components/MixerBoard/MicStrip.tsx
+++ b/src/components/MixerBoard/MicStrip.tsx
@@ -79,6 +79,7 @@ export function MicStrip() {
 
       <div className="strip-btns">
         <button
+          type="button"
           className={"sbtn" + (micConfig.muted ? " on-mute" : "")}
           onClick={() => void setMicConfig({ muted: !micConfig.muted })}
           aria-pressed={micConfig.muted}
@@ -87,6 +88,7 @@ export function MicStrip() {
           <Ms name={micConfig.muted ? "mic_off" : "mic"} style={{ fontSize: 16 }} />
         </button>
         <button
+          type="button"
           className={"sbtn" + (monitoring ? " on-mon" : "")}
           onClick={() => void toggleMonitor(MIC_LEVEL_KEY)}
           aria-pressed={monitoring}

--- a/src/components/MixerBoard/MixerBoard.tsx
+++ b/src/components/MixerBoard/MixerBoard.tsx
@@ -15,7 +15,6 @@ const MAX_BUSES = 4;
 /** Signal-flow group: header row (icon, label, count, optional +) above
  * its strips - per the updated design. */
 function MixGroup({
-  kind,
   icon,
   label,
   count,
@@ -24,7 +23,6 @@ function MixGroup({
   addTitle,
   children,
 }: Readonly<{
-  kind: string;
   icon: string;
   label: string;
   count: string;
@@ -35,7 +33,7 @@ function MixGroup({
   children: ReactNode;
 }>) {
   return (
-    <div className={"mix-group is-" + kind}>
+    <div className="mix-group">
       <div className="group-head" title={hint}>
         <Ms name={icon} className="gh-icon" />
         <span className="gh-label">{label}</span>
@@ -125,7 +123,6 @@ export function MixerBoard() {
           {micConfig?.enabled && (
             <>
               <MixGroup
-                kind="capture"
                 icon="mic"
                 label="Capture"
                 count="1"
@@ -138,7 +135,6 @@ export function MixerBoard() {
           )}
 
           <MixGroup
-            kind="playback"
             icon="apps"
             label="Channels"
             count={`${channels.length}`}
@@ -177,7 +173,6 @@ export function MixerBoard() {
            * fallback instead of showing strips that can't work. */}
           {backendNative !== false && (
           <MixGroup
-            kind="mix"
             icon="podcasts"
             label="Mixes"
             count={`${buses.length}`}

--- a/src/components/MixerBoard/MixerBoard.tsx
+++ b/src/components/MixerBoard/MixerBoard.tsx
@@ -40,7 +40,7 @@ function MixGroup({
         <span className="gh-count">{count}</span>
         {onAdd && (
           <div className="gh-add-wrap">
-            <button className="gh-add" onClick={onAdd} title={addTitle}>
+            <button type="button" className="gh-add" onClick={onAdd} title={addTitle}>
               <Ms name="add" />
             </button>
           </div>
@@ -208,6 +208,7 @@ export function MixerBoard() {
         <div className="icon-grid">
           {ICON_CHOICES.map((choice) => (
             <button
+              type="button"
               key={choice}
               className={"icon-cell" + (choice === channelIcon ? " sel" : "")}
               onClick={() => setChannelIcon(choice)}
@@ -218,10 +219,10 @@ export function MixerBoard() {
           ))}
         </div>
         <div className="modal-btns">
-          <button className="modal-btn primary" onClick={createChannel} disabled={!channelLabel.trim()}>
+          <button type="button" className="modal-btn primary" onClick={createChannel} disabled={!channelLabel.trim()}>
             Create channel
           </button>
-          <button className="modal-btn" onClick={closeChannelModal}>
+          <button type="button" className="modal-btn" onClick={closeChannelModal}>
             Cancel
           </button>
         </div>
@@ -244,10 +245,10 @@ export function MixerBoard() {
           }}
         />
         <div className="modal-btns">
-          <button className="modal-btn primary" onClick={createMix} disabled={!mixLabel.trim()}>
+          <button type="button" className="modal-btn primary" onClick={createMix} disabled={!mixLabel.trim()}>
             Create mix
           </button>
-          <button className="modal-btn" onClick={() => setAddingMix(false)}>
+          <button type="button" className="modal-btn" onClick={() => setAddingMix(false)}>
             Cancel
           </button>
         </div>

--- a/src/components/MixerBoard/OutputSelect.tsx
+++ b/src/components/MixerBoard/OutputSelect.tsx
@@ -118,6 +118,7 @@ export function OutputSelect({
     return (
       <div style={{ position: "relative" }}>
         <button
+          type="button"
           className="strip-route strip-route-btn"
           onClick={() => setOpen((o) => !o)}
           title={`Output: ${label}`}
@@ -141,7 +142,7 @@ export function OutputSelect({
 
   return (
     <div style={{ position: "relative" }}>
-      <button className="out-pill" onClick={() => setOpen((o) => !o)}>
+      <button type="button" className="out-pill" onClick={() => setOpen((o) => !o)}>
         <Ms name={shown ? deviceIcon(shown.description) : "speaker_group"} />
         <span>{label}</span>
         <Ms name="expand_more" className="chev" />

--- a/src/components/MixerBoard/OutputSelect.tsx
+++ b/src/components/MixerBoard/OutputSelect.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { CSSProperties } from "react";
 import { useMixerStore } from "../../store/mixer";
 import { Ms } from "../Icons";
+import { MenuItem } from "../MenuItem";
 import { Popover } from "../Popover";
 import { Toggle } from "../Toggle";
 
@@ -70,41 +71,42 @@ export function OutputSelect({
 
   const items = (
     <>
-      <div
-        className={"menu-item" + (!mixed && value === null ? " sel" : "")}
+      <MenuItem
+        icon="speaker_group"
+        selected={!mixed && value === null}
+        showCheck
         onClick={() => {
           onChange(null);
           setOpen(false);
         }}
       >
-        <Ms name="speaker_group" />
-        <span>System default</span>
-        {!mixed && value === null && <Ms name="check" style={{ marginLeft: "auto" }} />}
-      </div>
+        System default
+      </MenuItem>
       {outputDevices.map((d) => (
-        <div
+        <MenuItem
           key={d.name}
-          className={"menu-item" + (!mixed && d.name === value ? " sel" : "")}
+          icon={deviceIcon(d.description)}
+          selected={!mixed && d.name === value}
+          showCheck
           onClick={() => {
             onChange(d.name);
             setOpen(false);
           }}
         >
-          <Ms name={deviceIcon(d.description)} />
-          <span>{d.description}</span>
-          {!mixed && d.name === value && <Ms name="check" style={{ marginLeft: "auto" }} />}
-        </div>
+          {d.description}
+        </MenuItem>
       ))}
       {onFailoverChange && !mixed && (
         <>
           <div className="menu-sep" />
+          {/* Static row: the Toggle is the control, so this must not be a
+              button of its own. */}
           <div
-            className="menu-item"
-            style={{ cursor: "default" }}
+            className="menu-item static"
             title="Off: this channel plays only on the device above (or the exact system default) and stays silent if it's gone, instead of failing over to another output."
           >
             <Ms name="sync_alt" />
-            <span style={{ marginRight: "auto" }}>Fail over to another device</span>
+            <span className="menu-item-label">Fail over to another device</span>
             <Toggle on={failover ?? true} onClick={() => onFailoverChange(!(failover ?? true))} />
           </div>
         </>

--- a/src/components/MixerBoard/StreamMixStrip.tsx
+++ b/src/components/MixerBoard/StreamMixStrip.tsx
@@ -72,6 +72,7 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
     <div className={"strip bus-strip" + (muted ? " muted" : "")}>
       {!isMaster && (
         <button
+          type="button"
           className="strip-x"
           aria-label={`Delete mix ${bus.label}`}
           title="Delete mix"
@@ -117,6 +118,7 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
         ) : (
           <div style={{ position: "relative" }}>
             <button
+              type="button"
               className="strip-meta strip-meta-btn"
               title="Choose which channels this mix carries"
               onClick={() => setManaging(true)}
@@ -165,6 +167,7 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
 
       <div className="strip-btns">
         <button
+          type="button"
           className={"sbtn" + (muted ? " on-mute" : "")}
           onClick={toggleMute}
           aria-pressed={muted}
@@ -173,6 +176,7 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
           <Ms name={muted ? "volume_off" : "volume_up"} style={{ fontSize: 16 }} />
         </button>
         <button
+          type="button"
           className={"sbtn" + (monitoring ? " on-mon" : "")}
           onClick={() => void toggleMonitor(bus.name)}
           aria-pressed={monitoring}

--- a/src/components/MixerBoard/StreamMixStrip.tsx
+++ b/src/components/MixerBoard/StreamMixStrip.tsx
@@ -4,7 +4,8 @@ import type { BusDef } from "../../types";
 import { busMembers, MASTER_BUS, MAX_VOLUME } from "../../types";
 import { perceptual, volToDb } from "../../lib/audio";
 import { Ms } from "../Icons";
-import { Modal } from "../Modal";
+import { ConfirmModal } from "../ConfirmModal";
+import { MenuCheckItem } from "../MenuItem";
 import { Popover } from "../Popover";
 import { Fader } from "./Fader";
 import { VuMeter } from "./VuMeter";
@@ -130,30 +131,23 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
               align="center"
               style={{ minWidth: 220 }}
             >
-              {channels.map((c) => {
-                const checked = carried.includes(c.name);
-                return (
-                  <div key={c.name} className="menu-item" onClick={() => toggleMember(c.name)}>
-                    <Ms
-                      name={checked ? "check_box" : "check_box_outline_blank"}
-                      style={checked ? { color: "var(--accent-hover)" } : undefined}
-                    />
-                    <span>{c.label}</span>
-                  </div>
-                );
-              })}
+              {channels.map((c) => (
+                <MenuCheckItem
+                  key={c.name}
+                  checked={carried.includes(c.name)}
+                  onClick={() => toggleMember(c.name)}
+                >
+                  <span className="menu-item-label">{c.label}</span>
+                </MenuCheckItem>
+              ))}
               <div className="menu-div" />
-              <div
-                className="menu-item"
+              <MenuCheckItem
+                checked={bus.exclude}
                 title="New channels join this mix automatically - keep the ones you don't want unchecked"
                 onClick={() => void setBusExclude(bus.name, !bus.exclude)}
               >
-                <Ms
-                  name={bus.exclude ? "check_box" : "check_box_outline_blank"}
-                  style={bus.exclude ? { color: "var(--accent-hover)" } : undefined}
-                />
-                <span>Auto-include new channels</span>
-              </div>
+                <span className="menu-item-label">Auto-include new channels</span>
+              </MenuCheckItem>
             </Popover>
           </div>
         )}
@@ -193,29 +187,15 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
         title={`Select "${bus.label}" as an audio source in OBS or any recorder`}
       />
 
-      <Modal
+      <ConfirmModal
         open={confirmingDelete}
         onClose={() => setConfirmingDelete(false)}
         title={`Delete mix "${bus.label}"?`}
+        confirmLabel="Delete mix"
+        onConfirm={() => void removeBus(bus.name)}
       >
-        <p className="modal-text">
-          Recorders capturing "{bus.label}" will go silent. Channels are unaffected.
-        </p>
-        <div className="modal-btns">
-          <button
-            className="modal-btn danger"
-            onClick={() => {
-              setConfirmingDelete(false);
-              void removeBus(bus.name);
-            }}
-          >
-            Delete mix
-          </button>
-          <button className="modal-btn" onClick={() => setConfirmingDelete(false)}>
-            Cancel
-          </button>
-        </div>
-      </Modal>
+        Recorders capturing "{bus.label}" will go silent. Channels are unaffected.
+      </ConfirmModal>
     </div>
   );
 }

--- a/src/components/MixerBoard/VuMeter.tsx
+++ b/src/components/MixerBoard/VuMeter.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from "react";
 
 interface VuMeterProps {
-  /** Peak amplitude target 0–1 (real level from the native backend). */
+  /** Peak amplitude target 0-1 (real level from the native backend). */
   target: number;
 }
 
-/** Meter height (0–1) for a dBFS value, matching the sqrt display curve:
+/** Meter height (0-1) for a dBFS value, matching the sqrt display curve:
  * height = sqrt(amplitude) = 10^(dB/40). */
 const heightForDb = (db: number) => Math.pow(10, db / 40);
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import type { ReactNode } from "react";
+import { IconButton } from "./IconButton";
 
 /** Centered modal dialog with a dimming scrim. Escape or scrim-click closes. */
 export function Modal({
@@ -34,7 +35,10 @@ export function Modal({
         aria-label={title}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="modal-title">{title}</div>
+        <div className="modal-head">
+          <div className="modal-title">{title}</div>
+          <IconButton boxed icon="close" title="Close" onClick={onClose} size={18} />
+        </div>
         {children}
       </div>
     </div>

--- a/src/components/Onboarding/OnboardingModal.tsx
+++ b/src/components/Onboarding/OnboardingModal.tsx
@@ -106,11 +106,11 @@ export function OnboardingModal() {
           Channels, apps and the mic are all live - your setup is untouched.
         </p>
         <div className="ob-foot">
-          <button className="modal-btn" onClick={() => setStep(step - 1)}>
+          <button type="button" className="modal-btn" onClick={() => setStep(step - 1)}>
             Back
           </button>
           <ObDots step={step} />
-          <button className="modal-btn primary" onClick={() => void finishOnboarding(false)}>
+          <button type="button" className="modal-btn primary" onClick={() => void finishOnboarding(false)}>
             Done
           </button>
         </div>
@@ -125,21 +125,21 @@ export function OnboardingModal() {
           lays out your first board.
         </p>
         <div className="ob-choices">
-          <button className="ob-choice" onClick={() => void finishOnboarding(false)}>
+          <button type="button" className="ob-choice" onClick={() => void finishOnboarding(false)}>
             <Ms name="dashboard" />
             <div className="ob-choice-title">Set up a board for me</div>
             <div className="ob-choice-sub">
               Game, Chat, Music and System - ready to drop apps onto
             </div>
           </button>
-          <button className="ob-choice" onClick={() => void finishOnboarding(true)}>
+          <button type="button" className="ob-choice" onClick={() => void finishOnboarding(true)}>
             <Ms name="check_box_outline_blank" />
             <div className="ob-choice-title">I'll build my own</div>
             <div className="ob-choice-sub">One Main channel - add the rest as you go</div>
           </button>
         </div>
         <div className="ob-foot">
-          <button className="modal-btn" onClick={() => setStep(step - 1)}>
+          <button type="button" className="modal-btn" onClick={() => setStep(step - 1)}>
             Back
           </button>
           <ObDots step={step} />
@@ -160,16 +160,16 @@ export function OnboardingModal() {
         {current.diagram && <FlowDiagram />}
         <div className="ob-foot">
           {step > 0 ? (
-            <button className="modal-btn" onClick={() => setStep(step - 1)}>
+            <button type="button" className="modal-btn" onClick={() => setStep(step - 1)}>
               Back
             </button>
           ) : (
-            <button className="modal-btn" onClick={() => void finishOnboarding(false)}>
+            <button type="button" className="modal-btn" onClick={() => void finishOnboarding(false)}>
               Skip
             </button>
           )}
           <ObDots step={step} />
-          <button className="modal-btn primary" onClick={() => setStep(step + 1)}>
+          <button type="button" className="modal-btn primary" onClick={() => setStep(step + 1)}>
             Next
           </button>
         </div>

--- a/src/components/Settings/SettingsScreen.tsx
+++ b/src/components/Settings/SettingsScreen.tsx
@@ -52,7 +52,7 @@ function DeviceRow({
         <div className="rsub">{sub}</div>
       </div>
       <div style={{ position: "relative" }}>
-        <button className="select device-select" onClick={() => setOpen((o) => !o)}>
+        <button type="button" className="select device-select" onClick={() => setOpen((o) => !o)}>
           <span className="device-select-name">{currentDesc}</span>
           <Ms name="expand_more" />
         </button>
@@ -175,7 +175,7 @@ export function SettingsScreen() {
               <div className="rsub">Naming scheme for Sink-managed devices</div>
             </div>
             <div style={{ position: "relative" }}>
-              <button className="select" onClick={() => setLabelStyleOpen((o) => !o)}>
+              <button type="button" className="select" onClick={() => setLabelStyleOpen((o) => !o)}>
                 <span>{LABEL_STYLES.find((s) => s.value === labelStyle)?.label}</span>
                 <Ms name="expand_more" />
               </button>
@@ -284,7 +284,7 @@ export function SettingsScreen() {
               <div className="rtitle">Tutorial</div>
               <div className="rsub">Replay the first-run tour</div>
             </div>
-            <button className="select" onClick={replayOnboarding}>
+            <button type="button" className="select" onClick={replayOnboarding}>
               <span>Replay</span>
             </button>
           </div>
@@ -298,7 +298,7 @@ export function SettingsScreen() {
                 Erase all channels, mixes, profiles, app history and preferences
               </div>
             </div>
-            <button className="select" onClick={() => setConfirmingReset(true)}>
+            <button type="button" className="select" onClick={() => setConfirmingReset(true)}>
               <span>Reset…</span>
             </button>
           </div>

--- a/src/components/Settings/SettingsScreen.tsx
+++ b/src/components/Settings/SettingsScreen.tsx
@@ -4,7 +4,8 @@ import { getVersion } from "@tauri-apps/api/app";
 import { useMixerStore } from "../../store/mixer";
 import type { OutputDevice } from "../../types";
 import { Ms } from "../Icons";
-import { Modal } from "../Modal";
+import { ConfirmModal } from "../ConfirmModal";
+import { MenuItem } from "../MenuItem";
 import { Popover } from "../Popover";
 import { Toggle } from "../Toggle";
 
@@ -57,18 +58,18 @@ function DeviceRow({
         </button>
         <Popover open={open} onClose={() => setOpen(false)} side="bottom" align="end">
           {devices.map((d) => (
-            <div
+            <MenuItem
               key={d.name}
-              className={"menu-item" + (d.name === current ? " sel" : "")}
+              icon={icon}
+              selected={d.name === current}
+              showCheck
               onClick={() => {
                 onPick(d.name);
                 setOpen(false);
               }}
             >
-              <Ms name={icon} />
-              <span>{d.description}</span>
-              {d.name === current && <Ms name="check" style={{ marginLeft: "auto" }} />}
-            </div>
+              {d.description}
+            </MenuItem>
           ))}
         </Popover>
       </div>
@@ -156,11 +157,11 @@ export function SettingsScreen() {
   };
 
   return (
-    <div className="content">
+    <div className="content narrow">
       <div className="screen-head">
         <h1>Settings</h1>
       </div>
-      <div className="screen-scroll" style={{ maxWidth: 720 }}>
+      <div className="screen-scroll">
         {error && <div className="error-banner" style={{ borderRadius: 8 }}>{error}</div>}
 
         <div className="section-label">Preferences</div>
@@ -180,17 +181,17 @@ export function SettingsScreen() {
               </button>
               <Popover open={labelStyleOpen} onClose={() => setLabelStyleOpen(false)} side="bottom" align="end">
                 {LABEL_STYLES.map((s) => (
-                  <div
+                  <MenuItem
                     key={s.value}
-                    className={"menu-item" + (s.value === labelStyle ? " sel" : "")}
+                    selected={s.value === labelStyle}
+                    showCheck
                     onClick={() => {
                       void pickLabelStyle(s.value);
                       setLabelStyleOpen(false);
                     }}
                   >
-                    <span>{s.example}</span>
-                    {s.value === labelStyle && <Ms name="check" style={{ marginLeft: "auto" }} />}
-                  </div>
+                    {s.example}
+                  </MenuItem>
                 ))}
               </Popover>
             </div>
@@ -304,31 +305,17 @@ export function SettingsScreen() {
         </div>
       </div>
 
-      <Modal
+      <ConfirmModal
         open={confirmingReset}
         onClose={() => setConfirmingReset(false)}
         title="Reset Sink?"
+        confirmLabel="Reset everything"
+        onConfirm={() => void invoke("reset_app").catch((e) => setError(String(e)))}
       >
-        <p className="modal-text">
-          Everything you've set up - channels, mixes, profiles, app assignments,
-          history and preferences - is permanently deleted, and Sink relaunches
-          as if freshly installed.
-        </p>
-        <div className="modal-btns">
-          <button
-            className="modal-btn danger"
-            onClick={() => {
-              setConfirmingReset(false);
-              void invoke("reset_app").catch((e) => setError(String(e)));
-            }}
-          >
-            Reset everything
-          </button>
-          <button className="modal-btn" onClick={() => setConfirmingReset(false)}>
-            Cancel
-          </button>
-        </div>
-      </Modal>
+        Everything you've set up - channels, mixes, profiles, app assignments,
+        history and preferences - is permanently deleted, and Sink relaunches
+        as if freshly installed.
+      </ConfirmModal>
     </div>
   );
 }

--- a/src/components/TitleBar/ProfileMenu.tsx
+++ b/src/components/TitleBar/ProfileMenu.tsx
@@ -42,7 +42,7 @@ export function ProfileMenu() {
 
   return (
     <div style={{ position: "relative" }}>
-      <button className="select" onClick={() => setOpen((o) => !o)} title="Profiles">
+      <button type="button" className="select" onClick={() => setOpen((o) => !o)} title="Profiles">
         <Ms name="bookmarks" />
         <span>{activeProfile ?? "Profiles"}</span>
         <Ms name="expand_more" />
@@ -143,6 +143,7 @@ export function ProfileMenu() {
             }}
           />
           <button
+            type="button"
             className="select"
             onClick={create}
             disabled={!newName.trim()}

--- a/src/components/TitleBar/ProfileMenu.tsx
+++ b/src/components/TitleBar/ProfileMenu.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { useMixerStore } from "../../store/mixer";
+import { IconButton } from "../IconButton";
 import { Ms } from "../Icons";
+import { MenuItem } from "../MenuItem";
 import { Popover } from "../Popover";
 
 /**
@@ -51,75 +53,76 @@ export function ProfileMenu() {
           const trigger = triggerLabel(profile.trigger_device);
           return (
             <div key={profile.name}>
-              <div
-                className={"menu-item profile-row" + (isActive ? " sel" : "")}
-                onClick={() => {
-                  if (!isActive) void loadProfile(profile.name);
-                  close();
-                }}
-              >
-                <Ms name={isActive ? "check" : "bookmark"} />
-                <div className="profile-row-main">
-                  <span>{profile.name}</span>
-                  {trigger && (
-                    <span className="profile-row-trigger">
-                      <Ms name="bolt" style={{ fontSize: 12 }} />
-                      auto-loads with {trigger}
-                    </span>
-                  )}
-                </div>
+              {/* The actions are siblings of the load button, never children:
+                  a button inside a button is invalid, and the old nesting
+                  needed stopPropagation on every action to stay usable. */}
+              <div className="profile-row">
+                <MenuItem
+                  className="profile-row-btn"
+                  icon={isActive ? "check" : "bookmark"}
+                  selected={isActive}
+                  onClick={() => {
+                    if (!isActive) void loadProfile(profile.name);
+                    close();
+                  }}
+                >
+                  <span className="profile-row-main">
+                    <span>{profile.name}</span>
+                    {trigger && (
+                      <span className="profile-row-trigger">
+                        <Ms name="bolt" style={{ fontSize: 12 }} />
+                        <span className="profile-row-trigger-name">
+                          auto-loads with {trigger}
+                        </span>
+                      </span>
+                    )}
+                  </span>
+                </MenuItem>
                 <div className="profile-row-actions">
-                  <button
-                    className="row-icon-btn"
+                  <IconButton
+                    boxed
+                    size={15}
+                    icon="bolt"
                     title="Auto-load when a device connects"
-                    aria-label={`Auto-switch settings for ${profile.name}`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setTriggerFor((t) => (t === profile.name ? null : profile.name));
-                    }}
-                  >
-                    <Ms name="bolt" style={{ fontSize: 15 }} />
-                  </button>
-                  <button
-                    className="row-icon-btn danger"
+                    label={`Auto-switch settings for ${profile.name}`}
+                    onClick={() => setTriggerFor((t) => (t === profile.name ? null : profile.name))}
+                  />
+                  <IconButton
+                    boxed
+                    danger
+                    size={15}
+                    icon="delete"
                     title="Delete profile"
-                    aria-label={`Delete profile ${profile.name}`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      void deleteProfile(profile.name);
-                    }}
-                  >
-                    <Ms name="delete" style={{ fontSize: 15 }} />
-                  </button>
+                    label={`Delete profile ${profile.name}`}
+                    onClick={() => void deleteProfile(profile.name)}
+                  />
                 </div>
               </div>
               {triggerFor === profile.name && (
                 <div className="trigger-panel">
                   <div className="trigger-hint">Auto-load when this device connects:</div>
-                  <div
-                    className={"menu-item" + (profile.trigger_device === null ? " sel" : "")}
+                  <MenuItem
+                    icon="block"
+                    selected={profile.trigger_device === null}
                     onClick={() => {
                       void setProfileTrigger(profile.name, null);
                       setTriggerFor(null);
                     }}
                   >
-                    <Ms name="block" />
-                    <span>No auto-switch</span>
-                  </div>
+                    No auto-switch
+                  </MenuItem>
                   {outputDevices.map((d) => (
-                    <div
+                    <MenuItem
                       key={d.name}
-                      className={
-                        "menu-item" + (d.name === profile.trigger_device ? " sel" : "")
-                      }
+                      icon="speaker"
+                      selected={d.name === profile.trigger_device}
                       onClick={() => {
                         void setProfileTrigger(profile.name, d.name);
                         setTriggerFor(null);
                       }}
                     >
-                      <Ms name="speaker" />
-                      <span>{d.description}</span>
-                    </div>
+                      {d.description}
+                    </MenuItem>
                   ))}
                 </div>
               )}

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -39,10 +39,11 @@ export function TitleBar({ screen }: Readonly<{ screen: string }>) {
         {status}
       </div>
       <div className="wctl">
-        <button className="wbtn" aria-label="Minimize" onClick={() => void win.minimize()}>
+        <button type="button" className="wbtn" aria-label="Minimize" onClick={() => void win.minimize()}>
           <Ms name="remove" />
         </button>
         <button
+          type="button"
           className="wbtn"
           aria-label="Maximize"
           onClick={() => void win.toggleMaximize()}
@@ -50,6 +51,7 @@ export function TitleBar({ screen }: Readonly<{ screen: string }>) {
           <Ms name="crop_square" style={{ fontSize: 13 }} />
         </button>
         <button
+          type="button"
           className="wbtn close"
           aria-label="Close (hide to tray)"
           title="Hides to tray - quit from the tray menu"

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -2,7 +2,7 @@ import { Ms } from "./Icons";
 
 /** Design-system switch. */
 export function Toggle({ on, onClick }: Readonly<{ on: boolean; onClick: () => void }>) {
-  return <button className={"toggle" + (on ? " on" : "")} onClick={onClick} aria-pressed={on} />;
+  return <button type="button" className={"toggle" + (on ? " on" : "")} onClick={onClick} aria-pressed={on} />;
 }
 
 /** Card row with an icon, title/subtitle and a trailing switch. */

--- a/src/lib/audio.test.ts
+++ b/src/lib/audio.test.ts
@@ -14,7 +14,7 @@ describe("volToDb", () => {
 });
 
 describe("perceptual", () => {
-  it("clamps to the 0–1 meter range", () => {
+  it("clamps to the 0-1 meter range", () => {
     expect(perceptual(0)).toBe(0);
     expect(perceptual(1)).toBe(1);
     expect(perceptual(4)).toBe(1); // over-unity peaks don't overflow the bar

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -7,7 +7,7 @@ export function volToDb(v: number): string {
   return (db >= 0 ? "+" : "") + db.toFixed(1) + " dB";
 }
 
-/** Map a linear peak amplitude (0–1) to a perceptual meter height. */
+/** Map a linear peak amplitude (0-1) to a perceptual meter height. */
 export function perceptual(amplitude: number): number {
   return Math.min(1, Math.sqrt(Math.max(0, amplitude)));
 }

--- a/src/lib/cx.ts
+++ b/src/lib/cx.ts
@@ -1,0 +1,3 @@
+/** Join class names, dropping the falsy ones. */
+export const cx = (...parts: (string | false | null | undefined)[]) =>
+  parts.filter(Boolean).join(" ");

--- a/src/store/mixer.ts
+++ b/src/store/mixer.ts
@@ -27,7 +27,7 @@ function debouncedInvoke(key: string, cmd: string, args: Record<string, unknown>
   );
 }
 
-/** Per-sink [left, right] peak amplitudes (0–1), streamed from the native backend. */
+/** Per-sink [left, right] peak amplitudes (0-1), streamed from the native backend. */
 export type Levels = Record<string, [number, number]>;
 
 interface MixerStore {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -62,8 +62,16 @@
   --accent-light: rgba(85, 87, 224, 0.1);
   --on-accent: #ffffff;
 
+  /* Floating layers (menus, popovers). Deliberately lighter than
+     --bg-surface: a menu opens on top of cards and strips that are already
+     --bg-surface, and matching them left the panel with no visible edge. */
+  --bg-popover: #2b2b31;
+  --bg-popover-hover: #38383f;
+
   /* Lines */
   --border: #27272a;
+  /* Edge for floating layers, light enough to read against a surface. */
+  --border-popover: #45454e;
 
   /* Semantic */
   --online: #22c55e;
@@ -94,7 +102,8 @@
   --r-xl: 12px;
   --r-pill: 9999px;
 
-  --shadow-popover: 0 8px 24px rgba(0, 0, 0, 0.18);
+  /* Strong enough to separate a panel from an equally dark surface below. */
+  --shadow-popover: 0 16px 40px rgba(0, 0, 0, 0.7), 0 2px 8px rgba(0, 0, 0, 0.45);
 }
 
 * {
@@ -1255,8 +1264,8 @@ body,
   min-width: 220px;
   /* Long device names would otherwise stretch a menu across the window. */
   max-width: min(420px, calc(100vw - 32px));
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
+  background: var(--bg-popover);
+  border: 1px solid var(--border-popover);
   border-radius: var(--r-lg);
   padding: var(--sp-2);
   box-shadow: var(--shadow-popover);
@@ -1280,7 +1289,7 @@ body,
   cursor: pointer;
 }
 .menu-item:hover {
-  background: var(--bg-surface-hover);
+  background: var(--bg-popover-hover);
 }
 .menu-item:focus-visible {
   outline: 2px solid var(--accent);
@@ -1316,7 +1325,7 @@ body,
 }
 .menu-sep {
   height: 1px;
-  background: var(--border);
+  background: var(--border-popover);
   margin: var(--sp-2) 0;
 }
 .menu-save {
@@ -1392,7 +1401,7 @@ body,
 .trigger-panel {
   margin: 2px 0 var(--sp-2) var(--sp-6);
   padding-left: var(--sp-2);
-  border-left: 2px solid var(--border);
+  border-left: 2px solid var(--border-popover);
 }
 .trigger-hint {
   font-size: var(--fs-caption);
@@ -1434,9 +1443,23 @@ body,
   flex-direction: column;
   gap: var(--sp-4);
 }
+/* Title row with the close affordance; flex: 0 0 auto so it survives the
+   EQ panel turning its body into a flex column. */
+.modal-head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+}
 .modal-title {
+  flex: 1;
+  min-width: 0;
   font-size: var(--fs-title-lg, 16px);
   font-weight: 600;
+}
+/* Pull the close button out to the panel's padding edge. */
+.modal-head .icon-btn {
+  margin-right: -4px;
 }
 .modal-text {
   font-size: var(--fs-meta);
@@ -1786,7 +1809,7 @@ body,
 /* divider inside popover menus */
 .menu-div {
   height: 1px;
-  background: var(--border);
+  background: var(--border-popover);
   margin: var(--sp-1) var(--sp-2);
 }
 
@@ -1899,9 +1922,14 @@ body,
   color: var(--on-accent);
 }
 .modal.eqm-modal {
-  /* Extra room for the curve and the band rows; sizing itself comes from
-     .modal.lg. */
-  --modal-w: 900px;
+  --modal-w: 860px;
+  /* The band list is the scroller, not the panel, so the curve stays put
+     while you work through the rows. */
+  overflow: hidden;
+}
+/* Everything above the list keeps its natural height; only the list flexes. */
+.modal.eqm-modal > * {
+  flex-shrink: 0;
 }
 .eqm-head {
   display: flex;
@@ -1919,6 +1947,12 @@ body,
 .eqm-curve {
   width: 100%;
   height: auto;
+  /* A wider window should buy more band rows, not a taller graph - past this
+     the plot stops growing and centres, and the freed height goes to the
+     list below. */
+  max-width: 640px;
+  margin-inline: auto;
+  display: block;
   /* Labels live in gutters outside the plot; the rect carries the frame. */
   background: transparent;
   touch-action: none;
@@ -2005,9 +2039,16 @@ body,
   display: flex;
   flex-direction: column;
   gap: var(--sp-2);
+  /* Claim the panel's leftover height so the rows only scroll when they
+     genuinely do not fit. */
+  flex: 1;
+  min-height: 0;
 }
 .eqm-bands-viewport {
   position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
 }
 /* Fade the bottom edge so a clipped row reads as "scroll for more", not a bug. */
 .eqm-bands-viewport::after {
@@ -2024,7 +2065,10 @@ body,
   display: flex;
   flex-direction: column;
   gap: var(--sp-1);
-  max-height: 220px;
+  flex: 1;
+  /* Two rows, so a short window shrinks the list instead of clipping the
+     panel it lives in. */
+  min-height: 72px;
   overflow-y: auto;
   /* keep rows clear of the scrollbar and the bottom fade */
   padding-right: 4px;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -298,15 +298,24 @@ body,
 
 /* ---------- Content ---------- */
 .content {
+  /* Width of the readable column. Head and scroll body both centre on it so
+     a wide window doesn't stretch a row's controls half a screen from its
+     name; the head's bottom border still spans full width. */
+  --content-w: 900px;
   flex: 1;
   min-width: 0;
   display: flex;
   flex-direction: column;
   background: var(--bg-main);
 }
+/* Form-like screens (mic, settings) read better in a tighter column. */
+.content.narrow {
+  --content-w: 720px;
+}
 .screen-head {
   flex: 0 0 auto;
   padding: var(--sp-6) var(--sp-7) var(--sp-4);
+  padding-inline: max(var(--sp-7), calc((100% - var(--content-w)) / 2));
   display: flex;
   align-items: flex-end;
   gap: var(--sp-4);
@@ -333,6 +342,18 @@ body,
   overflow-y: auto;
   overflow-x: hidden;
   padding: var(--sp-6) var(--sp-7);
+  /* Matches .screen-head so rows line up under the title. The mixer opts out
+     with an inline padding of 0 - its strips centre themselves. */
+  padding-inline: max(var(--sp-7), calc((100% - var(--content-w)) / 2));
+}
+
+/* Shown when a list has nothing in it yet. */
+.empty-hint {
+  padding: var(--sp-7) var(--sp-6);
+  text-align: center;
+  font-size: var(--fs-meta);
+  line-height: 1.6;
+  color: var(--fg-muted);
 }
 .screen-scroll::-webkit-scrollbar {
   width: 10px;
@@ -372,6 +393,11 @@ body,
 .mix-scroll {
   display: flex;
   align-items: stretch;
+  /* Centre the groups so a wide window isn't dead space on the right. The
+     `safe` keyword keeps the left edge reachable when they overflow instead
+     of clipping both sides; where it's unsupported the whole declaration is
+     dropped and this falls back to flex-start. */
+  justify-content: safe center;
   padding: var(--sp-5) var(--sp-6);
   height: 100%;
   min-height: 0;
@@ -574,6 +600,9 @@ body,
   margin-left: auto;
   font-size: var(--fs-caption);
   color: var(--fg-muted);
+}
+.channel-apps-eq {
+  margin-left: auto;
 }
 
 .strip-head {
@@ -945,7 +974,9 @@ body,
   }
 }
 
-.rename-btn {
+/* Borderless icon action (IconButton.tsx). `.reveal` hides until the row is
+   hovered; `.boxed` is an always-visible 24px hit area with a hover fill. */
+.icon-btn {
   border: none;
   background: none;
   color: var(--fg-muted);
@@ -954,14 +985,29 @@ body,
   border-radius: var(--r-xs);
   display: grid;
   place-items: center;
-  opacity: 0;
-  transition: opacity 0.12s, color 0.12s;
+  transition: opacity 0.12s, background 0.12s, color 0.12s;
 }
-.row:hover .rename-btn {
+.icon-btn:hover {
+  color: var(--fg-primary);
+}
+.icon-btn.reveal {
+  opacity: 0;
+}
+.row:hover .icon-btn.reveal,
+.icon-btn.reveal:focus-visible {
   opacity: 1;
 }
-.rename-btn:hover {
-  color: var(--fg-primary);
+.icon-btn.boxed {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+}
+.icon-btn.boxed:hover {
+  background: var(--bg-active);
+}
+.icon-btn.danger:hover {
+  background: rgba(239, 68, 68, 0.16);
+  color: var(--danger);
 }
 .row .rtrail {
   display: flex;
@@ -1181,12 +1227,6 @@ body,
 .row-inactive .rname {
   color: var(--fg-secondary);
 }
-.row-action {
-  opacity: 0;
-}
-.row:hover .row-action {
-  opacity: 1;
-}
 .ignored-toggle {
   display: flex;
   align-items: center;
@@ -1213,34 +1253,66 @@ body,
   position: absolute;
   z-index: 60;
   min-width: 220px;
+  /* Long device names would otherwise stretch a menu across the window. */
+  max-width: min(420px, calc(100vw - 32px));
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
   padding: var(--sp-2);
   box-shadow: var(--shadow-popover);
 }
+/* Menu rows are real <button>s (see MenuItem.tsx) so menus are keyboard
+   reachable; the reset here strips UA button chrome. Static rows stay divs:
+   they host their own control (a Toggle) or are plain text. */
 .menu-item {
+  width: 100%;
   display: flex;
   align-items: center;
   gap: var(--sp-3);
   padding: 8px var(--sp-3);
+  border: none;
   border-radius: var(--r-sm);
+  background: none;
+  font-family: inherit;
   font-size: var(--fs-meta);
+  text-align: left;
   color: var(--fg-primary);
   cursor: pointer;
 }
 .menu-item:hover {
   background: var(--bg-surface-hover);
 }
+.menu-item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
 .menu-item.sel {
   color: var(--accent-hover);
+}
+.menu-item.static {
+  cursor: default;
+}
+.menu-item.static:hover {
+  background: none;
+}
+.menu-item.muted {
+  color: var(--fg-muted);
 }
 .menu-item .ms {
   font-size: 18px;
   color: var(--fg-muted);
 }
-.menu-item.sel .ms {
+.menu-item.sel .ms,
+.menu-item .ms.menu-check-on {
   color: var(--accent-hover);
+}
+/* Takes the slack so trailing content (check, toggle, badge) sits right. */
+.menu-item-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .menu-sep {
   height: 1px;
@@ -1274,6 +1346,16 @@ body,
 }
 
 /* profile menu */
+/* Wrapper, not a menu row: the load button and the action buttons are
+   siblings so no button is ever nested inside another. */
+.profile-row {
+  display: flex;
+  align-items: center;
+}
+.profile-row-btn {
+  flex: 1;
+  min-width: 0;
+}
 .profile-row-main {
   flex: 1;
   min-width: 0;
@@ -1285,9 +1367,17 @@ body,
   display: inline-flex;
   align-items: center;
   gap: 3px;
+  min-width: 0;
   font-size: var(--fs-caption);
   color: var(--warning);
   opacity: 0.85;
+}
+/* Device names are unbounded; ellipsis rather than stretch the menu. */
+.profile-row-trigger-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .profile-row-actions {
   display: flex;
@@ -1298,27 +1388,6 @@ body,
 .profile-row:hover .profile-row-actions {
   opacity: 1;
 }
-.row-icon-btn {
-  width: 24px;
-  height: 24px;
-  border: none;
-  border-radius: var(--r-xs);
-  background: none;
-  color: var(--fg-muted);
-  cursor: pointer;
-  display: grid;
-  place-items: center;
-  transition: background 0.12s, color 0.12s;
-}
-.row-icon-btn:hover {
-  background: var(--bg-active);
-  color: var(--fg-primary);
-}
-.row-icon-btn.danger:hover {
-  background: rgba(239, 68, 68, 0.16);
-  color: var(--danger);
-}
-
 /* profile trigger sub-panel */
 .trigger-panel {
   margin: 2px 0 var(--sp-2) var(--sp-6);
@@ -1350,7 +1419,12 @@ body,
   justify-content: center;
 }
 .modal {
-  width: min(380px, calc(100vw - 48px));
+  /* Grow with the window up to --modal-w, shrink to fit narrow ones, and
+     never exceed the window height - scroll the panel instead. */
+  --modal-w: 380px;
+  width: min(var(--modal-w), calc(100vw - 48px));
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: var(--r-xl);
@@ -1825,12 +1899,9 @@ body,
   color: var(--on-accent);
 }
 .modal.eqm-modal {
-  /* Grow with the window (bigger curve + roomier rows) up to a cap, so a
-     wide window isn't wasted; shrink to fit narrow ones. */
-  width: min(900px, calc(100vw - 48px));
-  /* Never taller than the window; scroll the whole panel on short screens. */
-  max-height: calc(100vh - 48px);
-  overflow-y: auto;
+  /* Extra room for the curve and the band rows; sizing itself comes from
+     .modal.lg. */
+  --modal-w: 900px;
 }
 .eqm-head {
   display: flex;
@@ -2107,9 +2178,8 @@ body,
   display: flex;
   gap: var(--sp-1);
 }
-/* menu-item as a real button (a11y): strip UA button chrome, keep the
-   menu look; the row wrapper hosts the apply button + a delete sibling
-   so no button ever nests inside another. */
+/* The row wrapper hosts the apply button plus a delete sibling, so no
+   button ever nests inside another (same shape as .profile-row). */
 .eqm-preset-row {
   display: flex;
   align-items: center;
@@ -2117,13 +2187,6 @@ body,
 .eqm-preset-row .eqm-remove {
   margin-left: auto;
   margin-right: 4px;
-}
-button.menu-item {
-  width: 100%;
-  background: none;
-  border: none;
-  font-family: inherit;
-  text-align: left;
 }
 .eqm-preset-apply {
   flex: 1;
@@ -2235,4 +2298,18 @@ button.menu-item {
 .eqm-preset-row .eqm-preset-confirm .eqm-remove {
   margin-left: 0;
   margin-right: 0;
+}
+
+/* ---------- Reduced motion ---------- */
+/* Entrance animations and hover transitions are decoration; honour the OS
+   setting rather than moving things for people who asked us not to. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,7 +48,7 @@ export interface MicConfig {
   input_device: string | null;
   /** What other apps list the processed mic as. */
   output_label: string;
-  /** 0–200; 100 = unity. */
+  /** 0-200; 100 = unity. */
   gain_percent: number;
   gate_enabled: boolean;
   comp_enabled: boolean;


### PR DESCRIPTION
two things: the week-long app-history cutoff you asked for, and the cleanup that came out of the audit.

## forget untouched apps after a week

the "not running" list never stopped growing. anything that ever made a sound stayed forever, so it fills with installers, notification blips and desktop-shell processes.

entries last seen more than a week ago now get dropped, but only if you never did anything with them. an assignment, an alias or the ignore flag keeps an entry indefinitely, so a game you play once a month still keeps its channel and "assign once, remembered forever" stays true.

one thing had to be fixed first. `upsert` only reported a change worth saving when the identity was new or its name/icon changed, so a plain last-seen bump only reached disk on a clean tray-quit. if sink got killed by a logout or a crash, an app you use daily could look weeks idle on disk and the prune would forget it. the poll now flushes history every 15 minutes, which bounds that drift and re-runs the prune for sessions that outlive the window.

ran the predicate against my own live config: 58 entries down to 28. it dropped `polkit-kde-authentication-agent-1`, `ksmserver`, `Window Manager`, `xdg-desktop-portal-kde` and four stale factorio version strings. everything with an assignment survived.

worth knowing: ignored entries count as intent and never expire, so a batch of ignored loopback nodes still sits in the collapsed "ignored apps" section. happy to let those age out too if that reads better.

## cleanup

**menus.** 16 hand-rolled click-handling `<div>`s became one `MenuItem`/`MenuCheckItem` component rendering a real `<button>` with proper menu roles. that makes every popover keyboard reachable in one place rather than 16 scattered edits. the profile menu was nesting two buttons inside a third, which is invalid html and needed a `stopPropagation` on every action to stay usable; the actions are siblings now and the workaround is gone.

**also componentized.** `ConfirmModal` (three verbatim copies of scrim + text + danger/cancel) and `IconButton` (the same control under two class names, plus a `row-action` class that only restated what `.rename-btn` already did). the ignored-app row was a hand-inlined near-copy of `InactiveRow` and is now that component with a variant prop.

**resizing.** nothing in 2238 lines of css reacted to window width. a wide window left the mixer hugging the left edge with dead space to the right, and stretched list rows until a row's control sat half a screen from its name. screens now centre on a shared `--content-w` column (the header's divider still spans full width), and the mixer centres its groups with `safe center` so an overflowing board still scrolls from the left edge. modal width moved to a `--modal-w` token, which collapses the eq modal's bespoke sizing rule into one line.

**a real bug found on the way.** `ChannelSelect` rendered an assignment whose channel no longer exists as "Unrouted". that is a lie - the assignment is still on disk - and clicking "Unrouted" to confirm what you saw would silently delete it. it now reads "Missing" and explains itself in the tooltip.

**dead or unstyled.** `.mix-group.is-*` was emitted with no rules behind it, `.empty-hint` had no styling at all, and a long device name could stretch a menu past 500px. added a `prefers-reduced-motion` guard and swapped the remaining en dashes for plain dashes.

## checks

clippy clean, 115 rust tests, 16 frontend tests, tsc clean, production build green.

verified visually in headless chrome against a mocked backend - mixer at 960/1280/1920, apps, settings, mic, both menus, the confirm modal and the eq modal. the harness was torn down afterwards, nothing of it is in the diff.