### PR TITLE
fix(mix): make the mix volume/mute faders actually work

### DIFF
--- a/src-tauri/src/audio/pw_native/thread.rs
+++ b/src-tauri/src/audio/pw_native/thread.rs
@@ -1020,6 +1020,10 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
     s.eq_desired_targets = eq_targets;
 }
 
+fn node_needs_monitor_volumes(kind: u8) -> bool {
+    kind == 0 || kind == 1
+}
+
 /// The three virtual node shapes we own (kind 0=channel sink, 1=mix bus,
 /// 2=virtual mic). The heal path mirrors the create handlers with this.
 fn create_node_object(
@@ -1037,7 +1041,7 @@ fn create_node_object(
         "media.class" => class,
         "audio.position" => position,
     };
-    if kind == 0 {
+    if node_needs_monitor_volumes(kind) {
         props.insert("monitor.channel-volumes", "true");
     }
     core.create_object::<Node>("adapter", &props)
@@ -1218,16 +1222,7 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
                 let _ = reply.send(Err(SinkError::Config("core is gone".into())));
                 return;
             };
-            match core.create_object::<Node>(
-                "adapter",
-                &pw::properties::properties! {
-                    "factory.name" => "support.null-audio-sink",
-                    "node.name" => name.as_str(),
-                    "node.description" => label.as_str(),
-                    "media.class" => VIRTUAL_SOURCE_CLASS,
-                    "audio.position" => "[ FL FR ]",
-                },
-            ) {
+            match create_node_object(&core, &name, &label, 1) {
                 Ok(proxy) => {
                     s.desired.insert(name.clone(), (label, 1));
                     s.bus_sources.insert(name, proxy);
@@ -1606,6 +1601,13 @@ mod tests {
     #[test]
     fn resolve_source_prefers_live_eq_playback() {
         assert_eq!(resolve_source(Some(77), 10), 77);
+    }
+
+    #[test]
+    fn mixes_get_monitor_volumes_like_channels() {
+        assert!(node_needs_monitor_volumes(0));
+        assert!(node_needs_monitor_volumes(1));
+        assert!(!node_needs_monitor_volumes(2));
     }
 
     #[test]


### PR DESCRIPTION
someone on reddit reported the master mix fader on cachyos did nothing, and it turned out to be real on every distro, not their setup or an old version.

a mix (the master mix and any custom mix) is a null-audio-sink presented as a virtual source. the fader sets the node's channelVolumes, which is correct, but the meter, the "listen" link, and obs all read the node's capture ports, and those stay pre-volume unless the node is created with monitor.channel-volumes. channel sinks already set that flag, so their faders work. the mix nodes didn't, so the fader turned a knob nothing in the signal path could see - no sound change, meter flat, no error.

the create path and the heal path for mixes now go through the same node helper the channels use, which sets monitor.channel-volumes for channels and mixes alike. the mic is exempt since it scales in its own dsp.

worth noting this is a different bug from the reserved-name one i fixed before. that made the fader's command reach the node instead of being rejected. this makes the value the command sets actually reach the audio. the first fix made it look like it worked (value persists, no error) while it still did nothing, which is how it slipped to release.

verified locally: with the fix, playing music, turning a channel down, then enabling listen on a mix and moving the mix fader changes the level and the meter tracks it. before, all three were dead. the node now carries monitor.channel-volumes in the live graph where it was absent before.

added a regression test that locks in that mixes get the flag channels do, since the original slipped through because the tests only checked the command persisted, never that it changed the audio.