### PR TITLE
feat(ui): add a Tokyo Night theme with a Settings theme picker

### DIFF
--- a/src/components/Settings/SettingsScreen.tsx
+++ b/src/components/Settings/SettingsScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getVersion } from "@tauri-apps/api/app";
 import { useMixerStore } from "../../store/mixer";
+import { useTheme, THEMES } from "../../store/theme";
 import type { OutputDevice } from "../../types";
 import { Ms } from "../Icons";
 import { ConfirmModal } from "../ConfirmModal";
@@ -85,6 +86,7 @@ function engineDesc(native: boolean | null): string {
 }
 
 export function SettingsScreen() {
+  const { theme, setTheme } = useTheme();
   const [autostart, setAutostart] = useState<boolean | null>(null);
   const [startMinimized, setStartMinimized] = useState(false);
   const [backendNative, setBackendNative] = useState<boolean | null>(null);
@@ -163,6 +165,37 @@ export function SettingsScreen() {
       </div>
       <div className="screen-scroll">
         {error && <div className="error-banner" style={{ borderRadius: 8 }}>{error}</div>}
+
+        <div className="section-label">Appearance</div>
+        <div className="card" style={{ padding: "var(--sp-2)" }}>
+          <div className="row">
+            <div className="ricon">
+              <Ms name="palette" />
+            </div>
+            <div className="rmain">
+              <div className="rtitle">Theme</div>
+              <div className="rsub">Original, or Tokyo Night to match your desktop</div>
+            </div>
+            <div className="theme-picker">
+              {THEMES.map((t) => (
+                <button
+                  key={t.id}
+                  type="button"
+                  className={"theme-swatch" + (t.id === theme ? " active" : "")}
+                  onClick={() => setTheme(t.id)}
+                  title={t.label}
+                >
+                  <span className="theme-swatch-colors">
+                    {t.swatch.map((c) => (
+                      <i key={c} style={{ background: c }} />
+                    ))}
+                  </span>
+                  <span className="theme-swatch-label">{t.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
 
         <div className="section-label">Preferences</div>
         <div className="card" style={{ padding: "var(--sp-2)" }}>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,11 @@
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { bootTheme } from "./store/theme";
 import "material-symbols/outlined.css";
 import "./styles/globals.css";
+
+// Apply the saved theme before first paint to avoid a flash of the default.
+bootTheme();
 
 const root = document.getElementById("root");
 if (root) {

--- a/src/store/theme.ts
+++ b/src/store/theme.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+
+export type ThemeId = "original" | "tokyo-night";
+
+export const THEMES: { id: ThemeId; label: string; swatch: string[] }[] = [
+  { id: "original", label: "Original", swatch: ["#0a0a0b", "#5557e0", "#ededef"] },
+  { id: "tokyo-night", label: "Tokyo Night", swatch: ["#1a1b26", "#7aa2f7", "#bb9af7"] },
+];
+
+const STORAGE_KEY = "sink-theme";
+
+function apply(theme: ThemeId) {
+  const root = document.documentElement;
+  if (theme === "original") delete root.dataset.theme;
+  else root.dataset.theme = theme;
+}
+
+function initial(): ThemeId {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  return saved === "tokyo-night" || saved === "original" ? saved : "original";
+}
+
+interface ThemeState {
+  theme: ThemeId;
+  setTheme: (t: ThemeId) => void;
+}
+
+export const useTheme = create<ThemeState>((set) => ({
+  theme: initial(),
+  setTheme: (t) => {
+    localStorage.setItem(STORAGE_KEY, t);
+    apply(t);
+    set({ theme: t });
+  },
+}));
+
+/** Apply the persisted theme as early as possible (called from main). */
+export function bootTheme() {
+  apply(initial());
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2357,3 +2357,63 @@ body,
     scroll-behavior: auto !important;
   }
 }
+
+/* ============================================================
+   Theme: Tokyo Night (opt-in via <html data-theme="tokyo-night">)
+   Original theme stays the default under :root.
+   ============================================================ */
+:root[data-theme="tokyo-night"] {
+  --bg-main: #1a1b26;
+  --bg-sidebar: #16161e;
+  --bg-chat: #1a1b26;
+  --bg-surface: #1f2335;
+  --bg-surface-hover: #24283b;
+  --bg-active: #292e42;
+
+  --fg-primary: #c0caf5;
+  --fg-secondary: #a9b1d6;
+  --fg-muted: #565f89;
+
+  --accent: #7aa2f7;
+  --accent-hover: #9eb8f9;
+  --accent-light: rgba(122, 162, 247, 0.12);
+  --on-accent: #1a1b26;
+
+  --bg-popover: #24283b;
+  --bg-popover-hover: #2f334d;
+
+  --border: #2a2e42;
+  --border-popover: #3b4261;
+
+  --online: #9ece6a;
+  --danger: #f7768e;
+  --warning: #e0af68;
+}
+
+/* Theme picker (Settings › Appearance) */
+.theme-picker { display: flex; gap: var(--sp-2); }
+.theme-swatch {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 8px;
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  transition: border-color 0.12s;
+}
+.theme-swatch:hover { border-color: var(--accent-hover); }
+.theme-swatch.active { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+.theme-swatch-colors { display: flex; }
+.theme-swatch-colors i {
+  width: 16px;
+  height: 16px;
+  display: block;
+  border: 1px solid rgba(0, 0, 0, 0.35);
+}
+.theme-swatch-colors i:first-child { border-radius: var(--r-xs) 0 0 var(--r-xs); }
+.theme-swatch-colors i:last-child { border-radius: 0 var(--r-xs) var(--r-xs) 0; }
+.theme-swatch-label { font-size: var(--fs-caption); color: var(--fg-secondary); }
+.theme-swatch.active .theme-swatch-label { color: var(--fg-primary); }


### PR DESCRIPTION
This pulls the **Tokyo Night theme** out of #34 into its own small, self-contained PR, as suggested. No device code, no new dependencies — just an opt-in color scheme and a picker.

## What it adds
- An opt-in **Tokyo Night** color scheme alongside the existing **Original** theme.
- A small **theme picker** in **Settings › Appearance** (swatch buttons).
- The choice persists in `localStorage` and is applied before first paint (`bootTheme()` in `main.tsx`) to avoid a flash of the default theme.

## How it works
The whole thing rides on the CSS custom properties already defined under `:root`. A theme just overrides those tokens under `:root[data-theme="tokyo-night"]`; the store toggles the `data-theme` attribute on `<html>`. The original theme stays the default (no attribute), so nothing changes unless a user opts in.

## Changes
| File | +/- | What |
|---|---|---|
| `src/store/theme.ts` | +40 | tiny zustand store, persistence, `bootTheme()` |
| `src/main.tsx` | +4 | apply saved theme before first paint |
| `src/components/Settings/SettingsScreen.tsx` | +33 | swatch-based picker in a new Appearance section |
| `src/styles/globals.css` | +60 | `:root[data-theme="tokyo-night"]` token overrides + picker styles |

**137 lines total, no deletions, no new dependencies.** `tsc --noEmit` is clean.

Adding more themes later is just another entry in `THEMES` plus one token block in CSS.
