### PR TITLE
fix(channels): persist volume/mute outside profiles

### DIFF
--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -161,15 +161,16 @@ pub fn init_virtual_devices(
             .backend
             .create_virtual_sink(&def.name, &prefs.decorate(&def.label))
             .map_err(|e| e.to_string())?;
-        // Known starting point - adopted sinks from a previous run may carry
-        // stale volume/mute.
+        // Restore the saved level explicitly - an adopted sink from a
+        // previous run may carry a stale volume/mute, so this is a set,
+        // not a "leave it alone".
         state
             .backend
-            .set_sink_volume(&def.name, 100)
+            .set_sink_volume(&def.name, def.volume_percent)
             .map_err(|e| e.to_string())?;
         state
             .backend
-            .set_sink_mute(&def.name, false)
+            .set_sink_mute(&def.name, def.muted)
             .map_err(|e| e.to_string())?;
     }
 

--- a/src-tauri/src/commands/profiles.rs
+++ b/src-tauri/src/commands/profiles.rs
@@ -193,6 +193,11 @@ pub fn load_profile(
                     label: c.label.clone(),
                     icon: c.icon.clone(),
                     stream_mix: c.stream_mix,
+                    // Carry the profile's levels into the persisted defs,
+                    // so channels.json stays the single source of truth
+                    // for what a channel comes back at.
+                    volume_percent: c.volume_percent,
+                    muted: c.muted,
                 })
                 .collect(),
         };

--- a/src-tauri/src/commands/routing.rs
+++ b/src-tauri/src/commands/routing.rs
@@ -74,12 +74,19 @@ pub fn set_channel_volume(
         .set_sink_volume(&sink_name, volume)
         .map_err(|e| e.to_string())?;
 
-    let mut mixer = state.lock_mixer()?;
-    if let Some(channel) = mixer.channel_mut(&sink_name) {
-        channel.volume_percent = volume;
-    }
-    crate::commands::profiles::autosave_active(&mixer);
-    Ok(())
+    let defs = {
+        let mut mixer = state.lock_mixer()?;
+        if let Some(channel) = mixer.channel_mut(&sink_name) {
+            channel.volume_percent = volume;
+        }
+        // Persist the level itself, not just into an active profile - a
+        // channel must come back at the volume you left it at even when
+        // no profile is bound.
+        mixer.channel_defs.set_volume(&sink_name, volume);
+        crate::commands::profiles::autosave_active(&mixer);
+        mixer.channel_defs.clone()
+    };
+    defs.save().map_err(|e| e.to_string())
 }
 
 /// Mute or unmute a channel.
@@ -97,12 +104,16 @@ pub fn toggle_channel_mute(
         .set_sink_mute(&sink_name, muted)
         .map_err(|e| e.to_string())?;
 
-    let mut mixer = state.lock_mixer()?;
-    if let Some(channel) = mixer.channel_mut(&sink_name) {
-        channel.muted = muted;
-    }
-    crate::commands::profiles::autosave_active(&mixer);
-    Ok(())
+    let defs = {
+        let mut mixer = state.lock_mixer()?;
+        if let Some(channel) = mixer.channel_mut(&sink_name) {
+            channel.muted = muted;
+        }
+        mixer.channel_defs.set_muted(&sink_name, muted);
+        crate::commands::profiles::autosave_active(&mixer);
+        mixer.channel_defs.clone()
+    };
+    defs.save().map_err(|e| e.to_string())
 }
 
 /// Listen to a channel/mix/mic on the default output (session scoped -

--- a/src-tauri/src/mixer/state.rs
+++ b/src-tauri/src/mixer/state.rs
@@ -50,7 +50,8 @@ pub struct MixerState {
 
 impl MixerState {
     /// Populate the channel strips from the user's channel definitions,
-    /// each at 100% volume, unmuted.
+    /// each restored to its persisted volume/mute (100%/unmuted for a
+    /// channel that has never been touched).
     pub fn init_defaults(&mut self) {
         self.channels = self
             .channel_defs
@@ -60,8 +61,8 @@ impl MixerState {
                 name: def.name.clone(),
                 label: def.label.clone(),
                 icon: def.icon.clone(),
-                volume_percent: 100,
-                muted: false,
+                volume_percent: def.volume_percent,
+                muted: def.muted,
                 stream_mix: def.stream_mix,
             })
             .collect();

--- a/src-tauri/src/persistence/channels.rs
+++ b/src-tauri/src/persistence/channels.rs
@@ -23,10 +23,21 @@ pub struct ChannelDef {
     /// Whether the channel feeds the Stream Mix source (default: yes).
     #[serde(default = "default_true")]
     pub stream_mix: bool,
+    /// Fader position (0-150%). Persisted so a channel keeps its level
+    /// across restarts even when no profile is active.
+    #[serde(default = "default_volume")]
+    pub volume_percent: u8,
+    /// Muted state, persisted alongside the volume.
+    #[serde(default)]
+    pub muted: bool,
 }
 
 fn default_true() -> bool {
     true
+}
+
+fn default_volume() -> u8 {
+    100
 }
 
 /// The user's channel set, stored as JSON at
@@ -43,6 +54,8 @@ impl Default for Channels {
             label: label.to_string(),
             icon: Some(icon.to_string()),
             stream_mix: true,
+            volume_percent: default_volume(),
+            muted: false,
         };
         Self {
             channels: vec![
@@ -156,6 +169,23 @@ impl Channels {
         Ok(())
     }
 
+    /// Record a channel's fader position so it survives a restart. Unknown
+    /// channels are ignored rather than erroring: this runs on every fader
+    /// tick, and a channel deleted mid-drag shouldn't surface an error.
+    pub fn set_volume(&mut self, name: &str, volume_percent: u8) {
+        if let Some(def) = self.channels.iter_mut().find(|c| c.name == name) {
+            def.volume_percent = volume_percent;
+        }
+    }
+
+    /// Record a channel's mute state (see `set_volume` for the lenient
+    /// unknown-channel handling).
+    pub fn set_muted(&mut self, name: &str, muted: bool) {
+        if let Some(def) = self.channels.iter_mut().find(|c| c.name == name) {
+            def.muted = muted;
+        }
+    }
+
     /// Add a channel for `label`, generating a unique reserved-safe sink
     /// name. Returns the new definition.
     pub fn add(&mut self, label: &str, icon: Option<String>) -> Result<ChannelDef, SinkError> {
@@ -180,6 +210,8 @@ impl Channels {
             label: label.to_string(),
             icon,
             stream_mix: true,
+            volume_percent: default_volume(),
+            muted: false,
         };
         self.channels.push(def.clone());
         Ok(def)
@@ -318,6 +350,35 @@ mod tests {
         assert_eq!(c.channels[0].icon, None);
         assert!(c.channels[0].stream_mix, "missing stream_mix defaults true");
         assert!(!c.channels[1].stream_mix);
+    }
+
+    #[test]
+    fn volume_and_mute_persist_and_default_to_unity() {
+        let mut c = Channels::default();
+        assert_eq!(c.channels[0].volume_percent, 100);
+        assert!(!c.channels[0].muted);
+
+        c.set_volume("sink_game", 42);
+        c.set_muted("sink_game", true);
+        assert_eq!(c.get("sink_game").expect("channel").volume_percent, 42);
+        assert!(c.get("sink_game").expect("channel").muted);
+        // Other channels are untouched.
+        assert_eq!(c.get("sink_music").expect("channel").volume_percent, 100);
+        // A vanished channel is a no-op, not a panic (fader tick mid-delete).
+        c.set_volume("sink_gone", 10);
+        c.set_muted("sink_gone", true);
+
+        // A round trip through JSON keeps the levels…
+        let raw = serde_json::to_string(&c).expect("serializes");
+        let back = Channels::parse(&raw).expect("reparses");
+        assert_eq!(back.get("sink_game").expect("channel").volume_percent, 42);
+        assert!(back.get("sink_game").expect("channel").muted);
+
+        // …and channels.json written before these fields loads at unity.
+        let legacy = r#"{"channels":[{"name":"sink_game","label":"Game"}]}"#;
+        let old = Channels::parse(legacy).expect("legacy loads");
+        assert_eq!(old.channels[0].volume_percent, 100);
+        assert!(!old.channels[0].muted);
     }
 
     #[test]


### PR DESCRIPTION
Split out of #40, where @jdkx32-source found it while testing (the commit keeps their authorship).

Channel levels were only ever written into an active profile, so without one every channel came back at 100%/unmuted on restart - `init_virtual_devices` even reset them explicitly. `channels.json` now carries `volume_percent`/`muted`, every fader and mute change is written through, and startup restores the saved value instead of overwriting it. Profile loads write their levels back into the same file, so there's one source of truth. Configs written before these fields still load at unity.

Split rather than bundled because it changes startup behavior for every user, not just mix users: a channel you muted and forgot about now comes back muted instead of resetting to a clean 100%.

Checks: `cargo test` (117), clippy `-D warnings`, tsc, vitest - all clean.
