### PR TITLE
fix(apps): one row per app, and routing that survives new streams

### DIFF
--- a/src-tauri/src/audio/pactl.rs
+++ b/src-tauri/src/audio/pactl.rs
@@ -242,6 +242,8 @@ impl AudioBackend for PactlBackend {
 
                 AppStream {
                     index: input.index,
+                    // PulseAudio's sink-input index is itself never reused.
+                    serial: u64::from(input.index),
                     app_name,
                     match_prop,
                     match_value,

--- a/src-tauri/src/audio/pw_native/thread.rs
+++ b/src-tauri/src/audio/pw_native/thread.rs
@@ -1305,6 +1305,7 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
                         crate::audio::types::resolve_identity(|key| n.props.get(key).cloned());
                     AppStream {
                         index: n.id,
+                        serial: n.serial.unwrap_or_else(|| u64::from(n.id)),
                         app_name,
                         match_prop,
                         match_value,

--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -202,6 +202,13 @@ mod identity_tests {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppStream {
     pub index: u32,
+    /// Globally unique, never-reused stream id (PipeWire's `object.serial`).
+    /// `index` is a node id, and PipeWire recycles those within seconds - a
+    /// browser closing one stream and opening another lands on the same
+    /// number - so anything that remembers "this exact stream" keys on the
+    /// serial instead.
+    #[serde(default)]
+    pub serial: u64,
     /// Display name (possibly prettified - not for matching).
     pub app_name: String,
     /// PipeWire property the identity was read from (e.g. "application.name").

--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -202,11 +202,9 @@ mod identity_tests {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppStream {
     pub index: u32,
-    /// Globally unique, never-reused stream id (PipeWire's `object.serial`).
-    /// `index` is a node id, and PipeWire recycles those within seconds - a
-    /// browser closing one stream and opening another lands on the same
-    /// number - so anything that remembers "this exact stream" keys on the
-    /// serial instead.
+    /// Never-reused stream id (PipeWire's `object.serial`); `index` is a
+    /// node id and those recycle within seconds, so "this exact stream" is
+    /// remembered by serial.
     #[serde(default)]
     pub serial: u64,
     /// Display name (possibly prettified - not for matching).

--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -24,6 +24,12 @@ pub fn get_app_streams(state: State<'_, AppState>) -> Result<Vec<AppStream>, Str
 /// stream once, on first sight, so manual re-routing isn't fought. Idempotent:
 /// driven by both the backend ticker and the UI's own poll.
 pub fn refresh_streams(state: &AppState) -> Result<Vec<AppStream>, String> {
+    // One pass at a time; the gate carries no data, so a poisoned lock is
+    // safe to reclaim.
+    let _gate = state
+        .refresh_gate
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let mut streams = state.backend.list_app_streams().map_err(|e| e.to_string())?;
 
     // Desktop-entry resolution: real icon files and polished display names

--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -21,11 +21,8 @@ pub fn get_app_streams(state: State<'_, AppState>) -> Result<Vec<AppStream>, Str
 }
 
 /// List live streams, record history, and enforce saved assignments - each
-/// stream once, on first sight, so manual re-routing isn't fought. Idempotent:
-/// driven by both the backend ticker and the UI's own poll.
+/// stream once, on first sight. Idempotent; the ticker and the UI both call it.
 pub fn refresh_streams(state: &AppState) -> Result<Vec<AppStream>, String> {
-    // One pass at a time; the gate carries no data, so a poisoned lock is
-    // safe to reclaim.
     let _gate = state
         .refresh_gate
         .lock()

--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -20,14 +20,9 @@ pub fn get_app_streams(state: State<'_, AppState>) -> Result<Vec<AppStream>, Str
     refresh_streams(state.inner())
 }
 
-/// List the live streams, record them in the app history, and enforce saved
-/// assignments (Phase 2): any stream seen for the first time whose app has a
-/// saved assignment is moved onto its channel. Each stream is enforced once,
-/// so manual re-routing (here or in pavucontrol) isn't fought.
-///
-/// Driven by a backend ticker (see `lib::spawn_route_enforcer`) so routing
-/// holds while Sink sits in the tray, and by the frontend's own poll for the
-/// stream list it renders. Both paths run the same work; it is idempotent.
+/// List live streams, record history, and enforce saved assignments - each
+/// stream once, on first sight, so manual re-routing isn't fought. Idempotent:
+/// driven by both the backend ticker and the UI's own poll.
 pub fn refresh_streams(state: &AppState) -> Result<Vec<AppStream>, String> {
     let mut streams = state.backend.list_app_streams().map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -14,13 +14,21 @@ pub fn get_virtual_devices(state: State<'_, AppState>) -> Result<Vec<VirtualSink
 }
 
 /// All running app audio streams.
-///
-/// Doubles as the auto-routing enforcement point (Phase 2): the frontend
-/// polls this every 2s, and any stream seen for the first time whose app has
-/// a saved assignment is moved onto its channel. Each stream is enforced
-/// once, so manual re-routing (here or in pavucontrol) isn't fought.
 #[tauri::command]
 pub fn get_app_streams(state: State<'_, AppState>) -> Result<Vec<AppStream>, String> {
+    state.note_ui_stream_poll();
+    refresh_streams(state.inner())
+}
+
+/// List the live streams, record them in the app history, and enforce saved
+/// assignments (Phase 2): any stream seen for the first time whose app has a
+/// saved assignment is moved onto its channel. Each stream is enforced once,
+/// so manual re-routing (here or in pavucontrol) isn't fought.
+///
+/// Driven by a backend ticker (see `lib::spawn_route_enforcer`) so routing
+/// holds while Sink sits in the tray, and by the frontend's own poll for the
+/// stream list it renders. Both paths run the same work; it is idempotent.
+pub fn refresh_streams(state: &AppState) -> Result<Vec<AppStream>, String> {
     let mut streams = state.backend.list_app_streams().map_err(|e| e.to_string())?;
 
     // Desktop-entry resolution: real icon files and polished display names
@@ -80,7 +88,7 @@ pub fn get_app_streams(state: State<'_, AppState>) -> Result<Vec<AppStream>, Str
         let mut planned: Vec<(u32, String, String)> = Vec::new();
         if mixer.initialized {
             for stream in &streams {
-                if mixer.auto_routed.contains(&stream.index) {
+                if mixer.auto_routed.contains(&stream.serial) {
                     continue;
                 }
                 if let Some(target) = mixer
@@ -93,13 +101,12 @@ pub fn get_app_streams(state: State<'_, AppState>) -> Result<Vec<AppStream>, Str
                 }
                 // Marked handled once (before the move, so a concurrent poll
                 // can't re-plan it); manual re-routing then isn't fought.
-                mixer.auto_routed.insert(stream.index);
+                mixer.auto_routed.insert(stream.serial);
             }
             // Forget streams that have gone away, so the ledger can't grow
-            // without bound and a recycled PipeWire index isn't mistaken for one
-            // we already handled (which would skip auto-routing a new stream).
-            let live: std::collections::HashSet<u32> = streams.iter().map(|s| s.index).collect();
-            mixer.auto_routed.retain(|i| live.contains(i));
+            // without bound.
+            let live: std::collections::HashSet<u64> = streams.iter().map(|s| s.serial).collect();
+            mixer.auto_routed.retain(|serial| live.contains(serial));
         }
 
         // User-chosen display names (in-memory read, cheap enough to keep here).

--- a/src-tauri/src/commands/routing.rs
+++ b/src-tauri/src/commands/routing.rs
@@ -21,21 +21,19 @@ pub fn route_app_to_channel(
     if !sink_name.is_empty() && !is_virtual_sink(&sink_name) {
         return Err(format!("unknown channel: {sink_name}"));
     }
-    state
-        .backend
-        .move_stream_to_sink(stream_index, &sink_name)
-        .map_err(|e| e.to_string())?;
 
-    // Resolve the stream's identity to record the assignment. The stream is
-    // already moved at this point, so persistence failures are reported but
-    // the live routing stands.
-    let streams = state.backend.list_app_streams().map_err(|e| e.to_string())?;
-    let Some(stream) = streams.iter().find(|s| s.index == stream_index) else {
-        return Ok(()); // stream vanished between move and lookup
-    };
-
+    // Resolve the stream's identity and siblings before anything moves.
     // Assignments are per app, not per stream; leaving an app's other live
     // streams behind would split it across channels.
+    let streams = state.backend.list_app_streams().map_err(|e| e.to_string())?;
+    let Some(stream) = streams.iter().find(|s| s.index == stream_index) else {
+        // Vanished between the click and now; move the raw index anyway in
+        // case the listing raced, with nothing to record against it.
+        return state
+            .backend
+            .move_stream_to_sink(stream_index, &sink_name)
+            .map_err(|e| e.to_string());
+    };
     let siblings: Vec<&crate::audio::types::AppStream> = streams
         .iter()
         .filter(|s| {
@@ -44,15 +42,10 @@ pub fn route_app_to_channel(
                 && s.match_value == stream.match_value
         })
         .collect();
-    for sibling in &siblings {
-        if let Err(e) = state.backend.move_stream_to_sink(sibling.index, &sink_name) {
-            eprintln!(
-                "sink: moving {} (#{}) failed: {e}",
-                stream.app_name, sibling.index
-            );
-        }
-    }
 
+    // Record intent before moving: the enforcement ticker runs concurrently,
+    // and a stream it hasn't ledgered yet must not be seen mid-move against
+    // a stale assignment (it would be "corrected" right back).
     let assignments = {
         let mut mixer = state.lock_mixer()?;
         if sink_name.is_empty() {
@@ -70,6 +63,19 @@ pub fn route_app_to_channel(
         crate::commands::profiles::autosave_active(&mixer);
         mixer.assignments.clone()
     };
+
+    state
+        .backend
+        .move_stream_to_sink(stream_index, &sink_name)
+        .map_err(|e| e.to_string())?;
+    for sibling in &siblings {
+        if let Err(e) = state.backend.move_stream_to_sink(sibling.index, &sink_name) {
+            eprintln!(
+                "sink: moving {} (#{}) failed: {e}",
+                stream.app_name, sibling.index
+            );
+        }
+    }
 
     assignments.save().map_err(|e| e.to_string())?;
     wireplumber::write(&assignments).map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/routing.rs
+++ b/src-tauri/src/commands/routing.rs
@@ -34,6 +34,27 @@ pub fn route_app_to_channel(
         return Ok(()); // stream vanished between move and lookup
     };
 
+    // The app's other live streams follow. Assignments are per app, not per
+    // stream, and an app can hold several at once (a browser opens one per
+    // playing tab) - leaving those behind would split one app across
+    // channels and look like the choice didn't take.
+    let siblings: Vec<&crate::audio::types::AppStream> = streams
+        .iter()
+        .filter(|s| {
+            s.index != stream_index
+                && s.match_prop == stream.match_prop
+                && s.match_value == stream.match_value
+        })
+        .collect();
+    for sibling in &siblings {
+        if let Err(e) = state.backend.move_stream_to_sink(sibling.index, &sink_name) {
+            eprintln!(
+                "sink: moving {} (#{}) failed: {e}",
+                stream.app_name, sibling.index
+            );
+        }
+    }
+
     let assignments = {
         let mut mixer = state.lock_mixer()?;
         if sink_name.is_empty() {
@@ -45,8 +66,9 @@ pub fn route_app_to_channel(
                 .assignments
                 .set(&stream.match_prop, &stream.match_value, &sink_name);
         }
-        // The user explicitly placed this stream; don't auto-route it again.
-        mixer.auto_routed.insert(stream_index);
+        // The user explicitly placed these streams; don't auto-route them again.
+        mixer.auto_routed.insert(stream.serial);
+        mixer.auto_routed.extend(siblings.iter().map(|s| s.serial));
         crate::commands::profiles::autosave_active(&mixer);
         mixer.assignments.clone()
     };

--- a/src-tauri/src/commands/routing.rs
+++ b/src-tauri/src/commands/routing.rs
@@ -22,9 +22,7 @@ pub fn route_app_to_channel(
         return Err(format!("unknown channel: {sink_name}"));
     }
 
-    // Resolve the stream's identity and siblings before anything moves.
-    // Assignments are per app, not per stream; leaving an app's other live
-    // streams behind would split it across channels.
+    // Assignments are per app, not per stream: siblings move too.
     let streams = state.backend.list_app_streams().map_err(|e| e.to_string())?;
     let Some(stream) = streams.iter().find(|s| s.index == stream_index) else {
         // Vanished between the click and now; move the raw index anyway in
@@ -43,9 +41,7 @@ pub fn route_app_to_channel(
         })
         .collect();
 
-    // Record intent before moving: the enforcement ticker runs concurrently,
-    // and a stream it hasn't ledgered yet must not be seen mid-move against
-    // a stale assignment (it would be "corrected" right back).
+    // Record intent before moving, or a concurrent tick undoes the move.
     let assignments = {
         let mut mixer = state.lock_mixer()?;
         if sink_name.is_empty() {

--- a/src-tauri/src/commands/routing.rs
+++ b/src-tauri/src/commands/routing.rs
@@ -34,10 +34,8 @@ pub fn route_app_to_channel(
         return Ok(()); // stream vanished between move and lookup
     };
 
-    // The app's other live streams follow. Assignments are per app, not per
-    // stream, and an app can hold several at once (a browser opens one per
-    // playing tab) - leaving those behind would split one app across
-    // channels and look like the choice didn't take.
+    // Assignments are per app, not per stream; leaving an app's other live
+    // streams behind would split it across channels.
     let siblings: Vec<&crate::audio::types::AppStream> = streams
         .iter()
         .filter(|s| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -181,16 +181,25 @@ fn spawn_route_enforcer(handle: tauri::AppHandle) {
             ROUTE_ENFORCE_INTERVAL_PACTL
         };
         let mut last_error: Option<String> = None;
+        let mut failures: u32 = 0;
         loop {
-            std::thread::sleep(interval);
+            // A wedged backend must not be fed a request per tick forever -
+            // the loop's command queue is unbounded, and each timed-out call
+            // already costs 3s. Back off once errors look persistent.
+            let pause = if failures >= 3 { interval * 10 } else { interval };
+            std::thread::sleep(pause);
             let state = handle.state::<AppState>();
             if !native && state.ui_polled_within(UI_POLL_GRACE) {
                 continue;
             }
             match commands::devices::refresh_streams(state.inner()) {
-                Ok(_) => last_error = None,
+                Ok(_) => {
+                    last_error = None;
+                    failures = 0;
+                }
                 // Usually transient; log each message once, not every tick.
                 Err(e) => {
+                    failures = failures.saturating_add(1);
                     if last_error.as_deref() != Some(e.as_str()) {
                         eprintln!("sink: auto-route enforcement failed: {e}");
                         last_error = Some(e);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -157,21 +157,17 @@ pub fn run() {
     }
 }
 
-/// Worst-case delay before a new stream lands on its channel; the gap is
-/// audible (it plays on the default output). Affordable because a native
-/// check is one round-trip answered from the loop's node map (~150us).
+/// The gap before a new stream lands on its channel is audible; a native
+/// check costs ~150us.
 const ROUTE_ENFORCE_INTERVAL: Duration = Duration::from_millis(200);
 
-/// The pactl fallback forks two processes per check - too dear for 5 Hz.
+/// pactl forks two processes per check.
 const ROUTE_ENFORCE_INTERVAL_PACTL: Duration = Duration::from_secs(2);
 
-/// Longer than the UI's 2s poll, so an on-screen window isn't shadowed by
-/// the ticker; clock-based so a stalled webview is still covered.
+/// Longer than the UI's 2s poll; clock-based so a stalled webview is covered.
 const UI_POLL_GRACE: Duration = Duration::from_secs(5);
 
-/// Enforces saved app→channel assignments from the backend. The UI poll
-/// pauses in the tray (TD-009), and enforcement used to pause with it -
-/// streams opened meanwhile stayed on the default sink.
+/// Enforces assignments from the backend; the UI poll pauses in the tray (TD-009).
 fn spawn_route_enforcer(handle: tauri::AppHandle) {
     std::thread::spawn(move || {
         let native = handle.state::<AppState>().backend_native;
@@ -183,9 +179,6 @@ fn spawn_route_enforcer(handle: tauri::AppHandle) {
         let mut last_error: Option<String> = None;
         let mut failures: u32 = 0;
         loop {
-            // A wedged backend must not be fed a request per tick forever -
-            // the loop's command queue is unbounded, and each timed-out call
-            // already costs 3s. Back off once errors look persistent.
             let pause = if failures >= 3 { interval * 10 } else { interval };
             std::thread::sleep(pause);
             let state = handle.state::<AppState>();
@@ -197,7 +190,6 @@ fn spawn_route_enforcer(handle: tauri::AppHandle) {
                     last_error = None;
                     failures = 0;
                 }
-                // Usually transient; log each message once, not every tick.
                 Err(e) => {
                     failures = failures.saturating_add(1);
                     if last_error.as_deref() != Some(e.as_str()) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -157,38 +157,21 @@ pub fn run() {
     }
 }
 
-/// How often the backend re-checks live streams against saved assignments on
-/// the native backend, and so the worst-case delay before a just-opened
-/// stream lands on its channel. A browser tears down and rebuilds its stream
-/// on every new video, so this window is audible - the first fraction of a
-/// second plays on the default output - and it is kept short because the
-/// check is cheap: one channel round-trip to the PipeWire thread, which
-/// answers from the node map it already maintains. Measured at ~150us per
-/// tick for 8 live streams in a debug build, so ~0.1% of a core at this
-/// cadence.
+/// Worst-case delay before a new stream lands on its channel; the gap is
+/// audible (it plays on the default output). Affordable because a native
+/// check is one round-trip answered from the loop's node map (~150us).
 const ROUTE_ENFORCE_INTERVAL: Duration = Duration::from_millis(200);
 
-/// The same, for the pactl fallback, which forks two `pactl` processes per
-/// check (~13ms). Far too expensive to run five times a second, and that
-/// backend is the compatibility path, not the one people run.
+/// The pactl fallback forks two processes per check - too dear for 5 Hz.
 const ROUTE_ENFORCE_INTERVAL_PACTL: Duration = Duration::from_secs(2);
 
-/// How stale the UI's own stream poll must get before the pactl fallback's
-/// ticker takes over enforcement. Longer than the UI's 2s interval, so an
-/// on-screen window doesn't have every poll duplicated behind it. The native
-/// backend skips this dedup entirely: its ticker is faster than the UI poll,
-/// and deferring to the UI would put the 2s delay back.
+/// Longer than the UI's 2s poll, so an on-screen window isn't shadowed by
+/// the ticker; clock-based so a stalled webview is still covered.
 const UI_POLL_GRACE: Duration = Duration::from_secs(5);
 
-/// Keeps saved app→channel assignments enforced from the backend, whether or
-/// not anyone is looking at the window.
-///
-/// The UI's own poll pauses while Sink is hidden in the tray (TD-009), and
-/// that used to pause auto-routing with it: an app that opened a new stream
-/// meanwhile - a browser starts one per playing tab - landed on the default
-/// sink and stayed there, which reads as Sink forgetting its routing. The
-/// enforcement therefore lives here, on a timer that never sleeps, and the
-/// frontend poll is now only about what it draws.
+/// Enforces saved app→channel assignments from the backend. The UI poll
+/// pauses in the tray (TD-009), and enforcement used to pause with it -
+/// streams opened meanwhile stayed on the default sink.
 fn spawn_route_enforcer(handle: tauri::AppHandle) {
     std::thread::spawn(move || {
         let native = handle.state::<AppState>().backend_native;
@@ -201,17 +184,12 @@ fn spawn_route_enforcer(handle: tauri::AppHandle) {
         loop {
             std::thread::sleep(interval);
             let state = handle.state::<AppState>();
-            // On the fallback backend a check is expensive enough to be worth
-            // skipping when an on-screen window already ran one. Waiting on
-            // the clock rather than on window visibility means a webview that
-            // stalls or sleeps is covered too.
             if !native && state.ui_polled_within(UI_POLL_GRACE) {
                 continue;
             }
             match commands::devices::refresh_streams(state.inner()) {
                 Ok(_) => last_error = None,
-                // Failures here are usually transient (the backend restarting
-                // its loop). Log a given message once rather than every tick.
+                // Usually transient; log each message once, not every tick.
                 Err(e) => {
                     if last_error.as_deref() != Some(e.as_str()) {
                         eprintln!("sink: auto-route enforcement failed: {e}");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -133,6 +133,7 @@ pub fn run() {
             if let Some(levels) = levels {
                 spawn_level_emitter(app.handle().clone(), levels);
             }
+            spawn_route_enforcer(app.handle().clone());
             Ok(())
         })
         // Close button hides to tray instead of quitting - main window
@@ -154,6 +155,72 @@ pub fn run() {
         eprintln!("sink: fatal error while running tauri application: {e}");
         std::process::exit(1);
     }
+}
+
+/// How often the backend re-checks live streams against saved assignments on
+/// the native backend, and so the worst-case delay before a just-opened
+/// stream lands on its channel. A browser tears down and rebuilds its stream
+/// on every new video, so this window is audible - the first fraction of a
+/// second plays on the default output - and it is kept short because the
+/// check is cheap: one channel round-trip to the PipeWire thread, which
+/// answers from the node map it already maintains. Measured at ~150us per
+/// tick for 8 live streams in a debug build, so ~0.1% of a core at this
+/// cadence.
+const ROUTE_ENFORCE_INTERVAL: Duration = Duration::from_millis(200);
+
+/// The same, for the pactl fallback, which forks two `pactl` processes per
+/// check (~13ms). Far too expensive to run five times a second, and that
+/// backend is the compatibility path, not the one people run.
+const ROUTE_ENFORCE_INTERVAL_PACTL: Duration = Duration::from_secs(2);
+
+/// How stale the UI's own stream poll must get before the pactl fallback's
+/// ticker takes over enforcement. Longer than the UI's 2s interval, so an
+/// on-screen window doesn't have every poll duplicated behind it. The native
+/// backend skips this dedup entirely: its ticker is faster than the UI poll,
+/// and deferring to the UI would put the 2s delay back.
+const UI_POLL_GRACE: Duration = Duration::from_secs(5);
+
+/// Keeps saved app→channel assignments enforced from the backend, whether or
+/// not anyone is looking at the window.
+///
+/// The UI's own poll pauses while Sink is hidden in the tray (TD-009), and
+/// that used to pause auto-routing with it: an app that opened a new stream
+/// meanwhile - a browser starts one per playing tab - landed on the default
+/// sink and stayed there, which reads as Sink forgetting its routing. The
+/// enforcement therefore lives here, on a timer that never sleeps, and the
+/// frontend poll is now only about what it draws.
+fn spawn_route_enforcer(handle: tauri::AppHandle) {
+    std::thread::spawn(move || {
+        let native = handle.state::<AppState>().backend_native;
+        let interval = if native {
+            ROUTE_ENFORCE_INTERVAL
+        } else {
+            ROUTE_ENFORCE_INTERVAL_PACTL
+        };
+        let mut last_error: Option<String> = None;
+        loop {
+            std::thread::sleep(interval);
+            let state = handle.state::<AppState>();
+            // On the fallback backend a check is expensive enough to be worth
+            // skipping when an on-screen window already ran one. Waiting on
+            // the clock rather than on window visibility means a webview that
+            // stalls or sleeps is covered too.
+            if !native && state.ui_polled_within(UI_POLL_GRACE) {
+                continue;
+            }
+            match commands::devices::refresh_streams(state.inner()) {
+                Ok(_) => last_error = None,
+                // Failures here are usually transient (the backend restarting
+                // its loop). Log a given message once rather than every tick.
+                Err(e) => {
+                    if last_error.as_deref() != Some(e.as_str()) {
+                        eprintln!("sink: auto-route enforcement failed: {e}");
+                        last_error = Some(e);
+                    }
+                }
+            }
+        }
+    });
 }
 
 /// Streams per-channel peak levels to the UI at 10 Hz as `levels` events.

--- a/src-tauri/src/mixer/state.rs
+++ b/src-tauri/src/mixer/state.rs
@@ -42,12 +42,10 @@ pub struct MixerState {
     pub buses: crate::persistence::buses::Buses,
     /// App preferences (device naming etc.), persisted to disk.
     pub prefs: crate::persistence::prefs::Prefs,
-    /// Streams already considered for auto-routing this session, by
-    /// `object.serial`. Each stream is enforced once, on first sight, so a
-    /// user moving a stream elsewhere (here or in pavucontrol) isn't fought
-    /// every poll. Serials, not node ids: PipeWire recycles node ids fast
-    /// enough that an app closing one stream and opening another between two
-    /// polls would inherit the old entry and never get routed.
+    /// Streams already considered for auto-routing this session, keyed by
+    /// `object.serial` (node ids recycle fast enough to inherit a dead
+    /// stream's entry). Enforced once each, so manual re-routing isn't
+    /// fought every poll.
     pub auto_routed: HashSet<u64>,
 }
 

--- a/src-tauri/src/mixer/state.rs
+++ b/src-tauri/src/mixer/state.rs
@@ -42,10 +42,8 @@ pub struct MixerState {
     pub buses: crate::persistence::buses::Buses,
     /// App preferences (device naming etc.), persisted to disk.
     pub prefs: crate::persistence::prefs::Prefs,
-    /// Streams already considered for auto-routing this session, keyed by
-    /// `object.serial` (node ids recycle fast enough to inherit a dead
-    /// stream's entry). Enforced once each, so manual re-routing isn't
-    /// fought every poll.
+    /// Streams already auto-routed once, by `object.serial` (node ids
+    /// recycle); manual re-routing isn't fought.
     pub auto_routed: HashSet<u64>,
 }
 

--- a/src-tauri/src/mixer/state.rs
+++ b/src-tauri/src/mixer/state.rs
@@ -42,10 +42,13 @@ pub struct MixerState {
     pub buses: crate::persistence::buses::Buses,
     /// App preferences (device naming etc.), persisted to disk.
     pub prefs: crate::persistence::prefs::Prefs,
-    /// Stream indices already considered for auto-routing this session.
-    /// Each stream is enforced once, on first sight, so a user moving a
-    /// stream elsewhere (here or in pavucontrol) isn't fought every poll.
-    pub auto_routed: HashSet<u32>,
+    /// Streams already considered for auto-routing this session, by
+    /// `object.serial`. Each stream is enforced once, on first sight, so a
+    /// user moving a stream elsewhere (here or in pavucontrol) isn't fought
+    /// every poll. Serials, not node ids: PipeWire recycles node ids fast
+    /// enough that an app closing one stream and opening another between two
+    /// polls would inherit the old entry and never get routed.
+    pub auto_routed: HashSet<u64>,
 }
 
 impl MixerState {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -13,9 +13,6 @@ pub struct AppState {
     /// Lets the pactl-backend ticker yield while an on-screen window is
     /// already polling (see `lib::spawn_route_enforcer`).
     ui_stream_poll: Mutex<Option<Instant>>,
-    /// Serializes `refresh_streams` across the ticker and UI invokes: two
-    /// interleaved passes could otherwise race their `seen.save()` calls on
-    /// one temp path and publish the older snapshot.
     pub refresh_gate: Mutex<()>,
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -10,9 +10,8 @@ pub struct AppState {
     /// True when the native PipeWire backend is driving (vs pactl fallback).
     pub backend_native: bool,
     pub mixer: Mutex<MixerState>,
-    /// When the UI last asked for the stream list. The backend's routing
-    /// ticker uses this to stay out of the way while the window is doing
-    /// the same work (see `lib::spawn_route_enforcer`).
+    /// Lets the pactl-backend ticker yield while an on-screen window is
+    /// already polling (see `lib::spawn_route_enforcer`).
     ui_stream_poll: Mutex<Option<Instant>>,
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use crate::audio::backend::AudioBackend;
 use crate::mixer::state::MixerState;
@@ -9,9 +10,29 @@ pub struct AppState {
     /// True when the native PipeWire backend is driving (vs pactl fallback).
     pub backend_native: bool,
     pub mixer: Mutex<MixerState>,
+    /// When the UI last asked for the stream list. The backend's routing
+    /// ticker uses this to stay out of the way while the window is doing
+    /// the same work (see `lib::spawn_route_enforcer`).
+    ui_stream_poll: Mutex<Option<Instant>>,
 }
 
 impl AppState {
+    /// Record that the UI just polled the stream list.
+    pub fn note_ui_stream_poll(&self) {
+        if let Ok(mut last) = self.ui_stream_poll.lock() {
+            *last = Some(Instant::now());
+        }
+    }
+
+    /// Whether the UI polled the stream list within `window`.
+    pub fn ui_polled_within(&self, window: Duration) -> bool {
+        self.ui_stream_poll
+            .lock()
+            .ok()
+            .and_then(|last| *last)
+            .is_some_and(|last| last.elapsed() < window)
+    }
+
     /// Lock the mixer state, mapping poisoning to a command-friendly error.
     /// All command handlers go through this instead of hand-rolled map_errs.
     pub fn lock_mixer(&self) -> Result<std::sync::MutexGuard<'_, MixerState>, String> {
@@ -57,6 +78,7 @@ impl AppState {
             backend,
             backend_native,
             mixer: Mutex::new(mixer),
+            ui_stream_poll: Mutex::new(None),
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -13,6 +13,10 @@ pub struct AppState {
     /// Lets the pactl-backend ticker yield while an on-screen window is
     /// already polling (see `lib::spawn_route_enforcer`).
     ui_stream_poll: Mutex<Option<Instant>>,
+    /// Serializes `refresh_streams` across the ticker and UI invokes: two
+    /// interleaved passes could otherwise race their `seen.save()` calls on
+    /// one temp path and publish the older snapshot.
+    pub refresh_gate: Mutex<()>,
 }
 
 impl AppState {
@@ -78,6 +82,7 @@ impl AppState {
             backend_native,
             mixer: Mutex::new(mixer),
             ui_stream_poll: Mutex::new(None),
+            refresh_gate: Mutex::new(()),
         }
     }
 

--- a/src/components/AppList/AppList.tsx
+++ b/src/components/AppList/AppList.tsx
@@ -43,6 +43,11 @@ export function AppList() {
   ].filter((g) => g.apps.length > 0);
 
   const liveIdentity = new Set(appStreams.map(identity));
+  const streamTotals = new Map<string, number>();
+  for (const s of appStreams) {
+    const key = identity(s);
+    streamTotals.set(key, (streamTotals.get(key) ?? 0) + 1);
+  }
   const inactive = seenApps
     .filter((a) => !a.ignored && !liveIdentity.has(`${a.match_prop}\0${a.match_value}`))
     .sort((a, b) => b.last_seen - a.last_seen);
@@ -75,7 +80,11 @@ export function AppList() {
               </div>
               <div className="card">
                 {group.apps.map((streams) => (
-                  <AppRow key={identity(streams[0])} streams={streams} />
+                  <AppRow
+                    key={identity(streams[0])}
+                    streams={streams}
+                    total={streamTotals.get(identity(streams[0])) ?? streams.length}
+                  />
                 ))}
               </div>
             </div>

--- a/src/components/AppList/AppList.tsx
+++ b/src/components/AppList/AppList.tsx
@@ -17,9 +17,7 @@ export function AppList() {
   const byName = (a: AppStream[], b: AppStream[]) =>
     (a[0].alias ?? a[0].app_name).localeCompare(b[0].alias ?? b[0].app_name);
 
-  /** One entry per app, holding all of its streams on this channel: an app
-   *  playing several streams at once (a browser tab per video) is one row,
-   *  not one row per stream. */
+  /** One row per app, not per stream - a browser holds one per playing tab. */
   const byApp = (streams: AppStream[]): AppStream[][] => {
     const apps = new Map<string, AppStream[]>();
     for (const s of streams) {

--- a/src/components/AppList/AppList.tsx
+++ b/src/components/AppList/AppList.tsx
@@ -13,23 +13,38 @@ export function AppList() {
   const seenApps = useMixerStore((s) => s.seenApps);
   const [showIgnored, setShowIgnored] = useState(false);
 
-  const byName = (a: AppStream, b: AppStream) =>
-    (a.alias ?? a.app_name).localeCompare(b.alias ?? b.app_name);
+  const identity = (s: AppStream) => `${s.match_prop}\0${s.match_value}`;
+  const byName = (a: AppStream[], b: AppStream[]) =>
+    (a[0].alias ?? a[0].app_name).localeCompare(b[0].alias ?? b[0].app_name);
+
+  /** One entry per app, holding all of its streams on this channel: an app
+   *  playing several streams at once (a browser tab per video) is one row,
+   *  not one row per stream. */
+  const byApp = (streams: AppStream[]): AppStream[][] => {
+    const apps = new Map<string, AppStream[]>();
+    for (const s of streams) {
+      const group = apps.get(identity(s));
+      if (group) group.push(s);
+      else apps.set(identity(s), [s]);
+    }
+    for (const group of apps.values()) group.sort((a, b) => a.index - b.index);
+    return [...apps.values()].sort(byName);
+  };
 
   const groups = [
     ...channels.map((c) => ({
       key: c.name,
       label: c.label,
-      streams: appStreams.filter((s) => s.assigned_sink === c.name).sort(byName),
+      apps: byApp(appStreams.filter((s) => s.assigned_sink === c.name)),
     })),
     {
       key: "unrouted",
       label: "Unrouted",
-      streams: appStreams.filter((s) => !s.assigned_sink).sort(byName),
+      apps: byApp(appStreams.filter((s) => !s.assigned_sink)),
     },
-  ].filter((g) => g.streams.length > 0);
+  ].filter((g) => g.apps.length > 0);
 
-  const liveIdentity = new Set(appStreams.map((s) => `${s.match_prop}\0${s.match_value}`));
+  const liveIdentity = new Set(appStreams.map(identity));
   const inactive = seenApps
     .filter((a) => !a.ignored && !liveIdentity.has(`${a.match_prop}\0${a.match_value}`))
     .sort((a, b) => b.last_seen - a.last_seen);
@@ -43,7 +58,7 @@ export function AppList() {
         <div className="screen-head-actions">
           <span className="tag">
             <Ms name="graphic_eq" />
-            {appStreams.length} {appStreams.length === 1 ? "stream" : "streams"}
+            {liveIdentity.size} {liveIdentity.size === 1 ? "app" : "apps"}
           </span>
         </div>
       </div>
@@ -58,11 +73,11 @@ export function AppList() {
           groups.map((group) => (
             <div key={group.key}>
               <div className="section-label">
-                {group.label} · {group.streams.length}
+                {group.label} · {group.apps.length}
               </div>
               <div className="card">
-                {group.streams.map((stream) => (
-                  <AppRow key={stream.index} stream={stream} />
+                {group.apps.map((streams) => (
+                  <AppRow key={identity(streams[0])} streams={streams} />
                 ))}
               </div>
             </div>

--- a/src/components/AppList/AppRow.tsx
+++ b/src/components/AppList/AppRow.tsx
@@ -7,10 +7,13 @@ import { ChannelSelect } from "./ChannelSelect";
 import { HSlider } from "./HSlider";
 
 interface AppRowProps {
-  stream: AppStream;
+  /** Every live stream of one app on one channel, lowest index first. An
+   *  app can hold several at once - a browser opens one per playing tab -
+   *  and they share an identity, so they share a row. */
+  streams: AppStream[];
 }
 
-export function AppRow({ stream }: Readonly<AppRowProps>) {
+export function AppRow({ streams }: Readonly<AppRowProps>) {
   const routeApp = useMixerStore((s) => s.routeApp);
   const setAppVolume = useMixerStore((s) => s.setAppVolume);
   const renameApp = useMixerStore((s) => s.renameApp);
@@ -19,7 +22,11 @@ export function AppRow({ stream }: Readonly<AppRowProps>) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
 
+  // The oldest stream stands for the app: routing and renaming are keyed by
+  // identity anyway, and volume is applied to all of them below.
+  const stream = streams[0];
   const displayName = stream.alias ?? stream.app_name;
+  const active = streams.some((s) => s.active);
 
   const startEdit = () => {
     setDraft(displayName);
@@ -55,8 +62,8 @@ export function AppRow({ stream }: Readonly<AppRowProps>) {
         ) : (
           <div className="rtitle" title={stream.app_name}>
             <span
-              className={"eq" + (stream.active ? " on" : "")}
-              title={stream.active ? "Playing audio" : "Silent"}
+              className={"eq" + (active ? " on" : "")}
+              title={active ? "Playing audio" : "Silent"}
               aria-hidden="true"
             >
               <i />
@@ -87,13 +94,15 @@ export function AppRow({ stream }: Readonly<AppRowProps>) {
             />
           </div>
         )}
-        <div className="rsub">stream #{stream.index}</div>
+        {streams.length > 1 && <div className="rsub">{streams.length} streams</div>}
       </div>
       <div className="rtrail">
         <HSlider
           value={stream.volume_percent}
           max={100}
-          onChange={(v) => void setAppVolume(stream.index, v)}
+          onChange={(v) => {
+            for (const s of streams) void setAppVolume(s.index, v);
+          }}
         />
         <ChannelSelect
           value={stream.assigned_sink}

--- a/src/components/AppList/AppRow.tsx
+++ b/src/components/AppList/AppRow.tsx
@@ -7,9 +7,7 @@ import { ChannelSelect } from "./ChannelSelect";
 import { HSlider } from "./HSlider";
 
 interface AppRowProps {
-  /** Every live stream of one app on one channel, lowest index first. An
-   *  app can hold several at once - a browser opens one per playing tab -
-   *  and they share an identity, so they share a row. */
+  /** Every live stream of one app on one channel, lowest index first. */
   streams: AppStream[];
 }
 
@@ -22,8 +20,7 @@ export function AppRow({ streams }: Readonly<AppRowProps>) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
 
-  // The oldest stream stands for the app: routing and renaming are keyed by
-  // identity anyway, and volume is applied to all of them below.
+  // The oldest stream stands for the app; volume applies to all below.
   const stream = streams[0];
   const displayName = stream.alias ?? stream.app_name;
   const active = streams.some((s) => s.active);

--- a/src/components/AppList/AppRow.tsx
+++ b/src/components/AppList/AppRow.tsx
@@ -9,9 +9,12 @@ import { HSlider } from "./HSlider";
 interface AppRowProps {
   /** Every live stream of one app on one channel, lowest index first. */
   streams: AppStream[];
+  /** The app's stream count across all channels; more than this row holds
+   *  when something external split the app, and routing here moves all. */
+  total?: number;
 }
 
-export function AppRow({ streams }: Readonly<AppRowProps>) {
+export function AppRow({ streams, total }: Readonly<AppRowProps>) {
   const routeApp = useMixerStore((s) => s.routeApp);
   const setAppVolume = useMixerStore((s) => s.setAppVolume);
   const renameApp = useMixerStore((s) => s.renameApp);
@@ -91,7 +94,13 @@ export function AppRow({ streams }: Readonly<AppRowProps>) {
             />
           </div>
         )}
-        {streams.length > 1 && <div className="rsub">{streams.length} streams</div>}
+        {(total ?? streams.length) > streams.length ? (
+          <div className="rsub">
+            {streams.length} of {total} streams
+          </div>
+        ) : (
+          streams.length > 1 && <div className="rsub">{streams.length} streams</div>
+        )}
       </div>
       <div className="rtrail">
         <HSlider

--- a/src/components/MixerBoard/ChannelApps.tsx
+++ b/src/components/MixerBoard/ChannelApps.tsx
@@ -35,12 +35,18 @@ export function ChannelApps({
   const routeApp = useMixerStore((s) => s.routeApp);
   const setAppAssignment = useMixerStore((s) => s.setAppAssignment);
 
-  const entries: Entry[] = [];
-  const seenKeys = new Set<string>();
+  // One entry per app, not per stream: an app can hold several streams at
+  // once (a browser opens one per playing tab) and they route together.
+  const live = new Map<string, Entry>();
   for (const s of appStreams) {
     const key = `${s.match_prop}\0${s.match_value}`;
-    seenKeys.add(key);
-    entries.push({
+    const existing = live.get(key);
+    if (existing) {
+      existing.checked ||= s.assigned_sink === channel.name;
+      existing.active ||= s.active;
+      continue;
+    }
+    live.set(key, {
       key,
       name: s.alias ?? s.app_name,
       iconPath: s.icon_path,
@@ -51,9 +57,10 @@ export function ChannelApps({
       matchValue: s.match_value,
     });
   }
+  const entries: Entry[] = [...live.values()];
   for (const a of seenApps) {
     const key = `${a.match_prop}\0${a.match_value}`;
-    if (a.ignored || seenKeys.has(key)) continue;
+    if (a.ignored || live.has(key)) continue;
     entries.push({
       key,
       name: a.alias ?? a.display_name,

--- a/src/components/MixerBoard/ChannelApps.tsx
+++ b/src/components/MixerBoard/ChannelApps.tsx
@@ -35,8 +35,7 @@ export function ChannelApps({
   const routeApp = useMixerStore((s) => s.routeApp);
   const setAppAssignment = useMixerStore((s) => s.setAppAssignment);
 
-  // One entry per app, not per stream: an app can hold several streams at
-  // once (a browser opens one per playing tab) and they route together.
+  // One entry per app, not per stream - they route together.
   const live = new Map<string, Entry>();
   for (const s of appStreams) {
     const key = `${s.match_prop}\0${s.match_value}`;

--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -6,9 +6,9 @@ const POLL_INTERVAL_MS = 2000;
 
 /**
  * Boots the audio layer: creates the virtual sinks on mount, polls the app
- * stream list + device list every 2s (also the auto-route enforcement
- * trigger), subscribes to live VU level events, and auto-loads profiles
- * bound to newly connected devices (Phase 5).
+ * stream list + device list every 2s while the window is on screen,
+ * subscribes to live VU level events, and auto-loads profiles bound to
+ * newly connected devices (Phase 5).
  */
 export function useAudio() {
   const initialize = useMixerStore((s) => s.initialize);
@@ -41,7 +41,9 @@ export function useAudio() {
       }
     };
     // Pause the 4-IPC poll while hidden in the tray - the product's dominant
-    // idle state - instead of round-tripping every 2s forever (TD-009).
+    // idle state - instead of round-tripping every 2s forever (TD-009). This
+    // only stops the UI refreshing: auto-routing is enforced by a backend
+    // ticker, so assignments hold while the window is away.
     const onVisibility = () => (document.hidden ? stop() : start());
     if (!document.hidden) start();
     document.addEventListener("visibilitychange", onVisibility);

--- a/src/store/mixer.ts
+++ b/src/store/mixer.ts
@@ -340,13 +340,19 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
   },
 
   routeApp: async (streamIndex, sinkName) => {
-    set((s) => ({
-      appStreams: s.appStreams.map((a) =>
-        a.index === streamIndex
-          ? { ...a, assigned_sink: sinkName === "" ? null : sinkName }
-          : a,
-      ),
-    }));
+    set((s) => {
+      // The backend moves every live stream of this app, so the optimistic
+      // update follows the identity, not the one index that was clicked.
+      const moved = s.appStreams.find((a) => a.index === streamIndex);
+      if (!moved) return {};
+      return {
+        appStreams: s.appStreams.map((a) =>
+          a.match_prop === moved.match_prop && a.match_value === moved.match_value
+            ? { ...a, assigned_sink: sinkName === "" ? null : sinkName }
+            : a,
+        ),
+      };
+    });
     try {
       await invoke("route_app_to_channel", { streamIndex, sinkName });
     } catch (e) {

--- a/src/store/mixer.ts
+++ b/src/store/mixer.ts
@@ -341,8 +341,7 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
 
   routeApp: async (streamIndex, sinkName) => {
     set((s) => {
-      // The backend moves every live stream of this app, so the optimistic
-      // update follows the identity, not the one index that was clicked.
+      // The backend moves every live stream of the app; follow the identity.
       const moved = s.appStreams.find((a) => a.index === streamIndex);
       if (!moved) return {};
       return {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,8 @@
 
 export interface AppStream {
   index: number;
+  /** Unique, never-reused stream id (PipeWire's object.serial). */
+  serial: number;
   app_name: string;
   /** PipeWire property the identity was read from. */
   match_prop: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,6 @@ export interface AppStream {
   /** Unique, never-reused stream id (PipeWire's object.serial). */
   serial: number;
   app_name: string;
-  /** PipeWire property the identity was read from. */
   match_prop: string;
   /** Raw property value (stream identity for persistence). */
   match_value: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   clearScreen: false,
   server: {
+    // Pinned to IPv4. Vite's default binding answers only on [::1] here,
+    // and the devUrl the webview loads is "localhost" - which resolves to
+    // 127.0.0.1 for it. Same address on both sides, no dev-only surprises.
+    host: "127.0.0.1",
     port: 1420,
     strictPort: true,
     watch: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,8 +8,6 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   clearScreen: false,
   server: {
-    // Vite's default binding can answer only on [::1] while the webview
-    // resolves the devUrl's "localhost" to 127.0.0.1 - blank window.
     host: "127.0.0.1",
     port: 1420,
     strictPort: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,9 +8,8 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   clearScreen: false,
   server: {
-    // Pinned to IPv4. Vite's default binding answers only on [::1] here,
-    // and the devUrl the webview loads is "localhost" - which resolves to
-    // 127.0.0.1 for it. Same address on both sides, no dev-only surprises.
+    // Vite's default binding can answer only on [::1] while the webview
+    // resolves the devUrl's "localhost" to 127.0.0.1 - blank window.
     host: "127.0.0.1",
     port: 1420,
     strictPort: true,


### PR DESCRIPTION
Firefox showed up as several rows in the Apps tab and kept losing its channel. Testing it turned up three separate causes, all of which are fixed here.

## One row per app

The Apps list and the mixer's per-channel app list both rendered one entry per *stream*, and a browser opens one per playing tab - so Firefox appeared three or four times, and routing one of those rows moved one tab while the others stayed put. Both lists now group by stream identity (`match_prop`/`match_value`, the same key assignments are already stored under), so an app is one row carrying all of its streams. Routing or setting the volume on that row applies to every one of them, and `route_app_to_channel` moves the siblings on the backend too, so the choice holds even if the click came from somewhere else.

The header count follows: it says "3 apps" rather than "7 streams", and a row only mentions its stream count when it has more than one.

## Routing that survives the tray

Auto-routing enforcement lived inside `get_app_streams`, which is only reached by the frontend's 2s poll - and that poll pauses while the window is hidden in the tray (TD-009, the product's dominant idle state). A stream opened meanwhile landed on the default sink and stayed there, which reads as sink forgetting its routing entirely.

Enforcement moves to a backend ticker that never sleeps (`spawn_route_enforcer`). The frontend poll is now only about what it draws. Both paths call the same idempotent `refresh_streams`.

The ticker runs at 200ms on the native backend, so a browser rebuilding its stream on a new video is back on its channel in ~180ms rather than up to 2s - the gap is audible, since the first fraction of a second plays on the default output. That cadence is affordable because the check is one channel round-trip to the PipeWire thread, answered from the node map it already keeps: ~150µs per tick for 8 live streams in a debug build, measured at 0.15% of a core for the enforcement thread. The pactl fallback forks two processes per check (~13ms), so it keeps the 2s cadence and skips a tick when an on-screen window polled within 5s - dedup against the clock rather than against window visibility, so a stalled webview is still covered.

## Serials, not node ids

The "already handled" ledger was keyed on PipeWire node ids, which are recycled within seconds. An app that closed one stream and opened another between two polls inherited the old entry and was never routed at all. Observed here: node 247 reused across serials 94848, 95924 and 96615.

`AppStream` now carries `object.serial`, which PipeWire never reuses, and the ledger keys on that. The pactl backend fills it from the sink-input index, which is also never reused. The field is `#[serde(default)]`, so a stale frontend against a new backend degrades rather than fails to deserialize.

## Also here

`vite.config.ts` pins the dev server to `127.0.0.1`. Vite's default binding answers only on `[::1]` on this machine, while the webview loads the devUrl as `localhost` and resolves it to `127.0.0.1` - so `npm run tauri dev` came up blank. Dev-only; nothing in a release build reads it.

## Testing

- `cargo test` (120), `cargo clippy --all-targets -- -D warnings`, `npx tsc --noEmit`, `npm test` (16) - all clean
- The diagnosis came off real hardware (native PipeWire backend): the duplicate Firefox rows, the routing lost while hidden in the tray, and the recycled node 247 were all observed there
