### PR TITLE
test(routing): cover the auto-route ledger and sibling selection

### DIFF
--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -81,31 +81,7 @@ pub fn refresh_streams(state: &AppState) -> Result<Vec<AppStream>, String> {
         // Hide ignored identities (also exempts them from auto-routing).
         streams.retain(|s| !mixer.seen.is_ignored(&s.match_prop, &s.match_value));
 
-        // Only enforce once the virtual sinks exist; otherwise streams would be
-        // marked handled while their target sink can't be moved to yet.
-        let mut planned: Vec<(u32, String, String)> = Vec::new();
-        if mixer.initialized {
-            for stream in &streams {
-                if mixer.auto_routed.contains(&stream.serial) {
-                    continue;
-                }
-                if let Some(target) = mixer
-                    .assignments
-                    .sink_for(&stream.match_prop, &stream.match_value)
-                {
-                    if stream.assigned_sink.as_deref() != Some(target) {
-                        planned.push((stream.index, target.to_string(), stream.app_name.clone()));
-                    }
-                }
-                // Marked handled once (before the move, so a concurrent poll
-                // can't re-plan it); manual re-routing then isn't fought.
-                mixer.auto_routed.insert(stream.serial);
-            }
-            // Forget streams that have gone away, so the ledger can't grow
-            // without bound.
-            let live: std::collections::HashSet<u64> = streams.iter().map(|s| s.serial).collect();
-            mixer.auto_routed.retain(|serial| live.contains(serial));
-        }
+        let planned = mixer.plan_auto_routes(&streams);
 
         // User-chosen display names (in-memory read, cheap enough to keep here).
         for stream in &mut streams {

--- a/src-tauri/src/commands/routing.rs
+++ b/src-tauri/src/commands/routing.rs
@@ -6,6 +6,22 @@ use crate::state::AppState;
 
 pub(crate) const MAX_VOLUME: u8 = 150;
 
+/// An app's other live streams: same identity, different stream. Routing is
+/// per app, so these move with the one the user clicked.
+fn siblings_of<'a>(
+    streams: &'a [crate::audio::types::AppStream],
+    stream: &crate::audio::types::AppStream,
+) -> Vec<&'a crate::audio::types::AppStream> {
+    streams
+        .iter()
+        .filter(|s| {
+            s.index != stream.index
+                && s.match_prop == stream.match_prop
+                && s.match_value == stream.match_value
+        })
+        .collect()
+}
+
 /// Move an app stream onto a channel. An empty `sink_name` unassigns the
 /// stream (returns it to the system default sink).
 ///
@@ -32,14 +48,7 @@ pub fn route_app_to_channel(
             .move_stream_to_sink(stream_index, &sink_name)
             .map_err(|e| e.to_string());
     };
-    let siblings: Vec<&crate::audio::types::AppStream> = streams
-        .iter()
-        .filter(|s| {
-            s.index != stream_index
-                && s.match_prop == stream.match_prop
-                && s.match_value == stream.match_value
-        })
-        .collect();
+    let siblings: Vec<&crate::audio::types::AppStream> = siblings_of(&streams, stream);
 
     // Record intent before moving, or a concurrent tick undoes the move.
     let assignments = {
@@ -191,4 +200,44 @@ pub fn set_app_volume(
         .backend
         .set_app_volume(stream_index, volume.min(MAX_VOLUME))
         .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio::types::AppStream;
+
+    fn stream(index: u32, prop: &str, value: &str) -> AppStream {
+        AppStream {
+            index,
+            serial: u64::from(index) + 1000,
+            app_name: value.to_string(),
+            match_prop: prop.into(),
+            match_value: value.into(),
+            alias: None,
+            icon_name: None,
+            icon_path: None,
+            pid: None,
+            assigned_sink: None,
+            volume_percent: 100,
+            muted: false,
+            active: true,
+        }
+    }
+
+    #[test]
+    fn siblings_are_the_apps_other_streams() {
+        let streams = vec![
+            stream(1, "application.name", "Firefox"),
+            stream(2, "application.name", "Firefox"),
+            stream(3, "application.name", "Spotify"),
+            // Same value under a different property is a different identity.
+            stream(4, "application.process.binary", "Firefox"),
+        ];
+        let picked = siblings_of(&streams, &streams[0]);
+        let indices: Vec<u32> = picked.iter().map(|s| s.index).collect();
+        assert_eq!(indices, vec![2], "only same-identity streams, never itself");
+
+        assert!(siblings_of(&streams, &streams[2]).is_empty());
+    }
 }

--- a/src-tauri/src/mixer/state.rs
+++ b/src-tauri/src/mixer/state.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::audio::types::VirtualSink;
+use crate::audio::types::{AppStream, VirtualSink};
 use crate::persistence::aliases::Aliases;
 use crate::persistence::assignments::Assignments;
 use crate::persistence::channels::Channels;
@@ -93,6 +93,39 @@ impl MixerState {
         )
     }
 
+    /// Decide which live streams to move onto their saved channel, and
+    /// record them as handled. Each stream is considered once, on first
+    /// sight, so a manual re-route (here or in pavucontrol) isn't fought;
+    /// streams that have gone away are forgotten so the ledger stays bounded.
+    ///
+    /// Returns `(stream index, target sink, app name)` for the caller to
+    /// execute once it has released the lock.
+    pub fn plan_auto_routes(&mut self, streams: &[AppStream]) -> Vec<(u32, String, String)> {
+        // Enforce only once the virtual sinks exist, or streams would be
+        // marked handled while their target can't be moved to yet.
+        if !self.initialized {
+            return Vec::new();
+        }
+        let mut planned = Vec::new();
+        for stream in streams {
+            if self.auto_routed.contains(&stream.serial) {
+                continue;
+            }
+            if let Some(target) = self
+                .assignments
+                .sink_for(&stream.match_prop, &stream.match_value)
+            {
+                if stream.assigned_sink.as_deref() != Some(target) {
+                    planned.push((stream.index, target.to_string(), stream.app_name.clone()));
+                }
+            }
+            self.auto_routed.insert(stream.serial);
+        }
+        let live: HashSet<u64> = streams.iter().map(|s| s.serial).collect();
+        self.auto_routed.retain(|serial| live.contains(serial));
+        planned
+    }
+
     pub fn reset(&mut self) {
         self.channels.clear();
         self.initialized = false;
@@ -132,6 +165,98 @@ mod tests {
         assert!(state.seen.get("application.name", "plain").is_none());
         assert!(state.seen.get("application.name", "assigned").is_some());
         assert!(state.seen.get("application.name", "aliased").is_some());
+    }
+
+    fn stream(index: u32, serial: u64, value: &str, on: Option<&str>) -> AppStream {
+        AppStream {
+            index,
+            serial,
+            app_name: value.to_string(),
+            match_prop: "application.name".into(),
+            match_value: value.into(),
+            alias: None,
+            icon_name: None,
+            icon_path: None,
+            pid: None,
+            assigned_sink: on.map(str::to_string),
+            volume_percent: 100,
+            muted: false,
+            active: true,
+        }
+    }
+
+    #[test]
+    fn auto_route_plans_once_and_respects_a_manual_move() {
+        let mut state = MixerState::default();
+        state.init_defaults();
+        state
+            .assignments
+            .set("application.name", "Firefox", "sink_game");
+
+        // First sight: planned, and marked handled.
+        let planned = state.plan_auto_routes(&[stream(7, 100, "Firefox", None)]);
+        assert_eq!(
+            planned,
+            vec![(7, "sink_game".to_string(), "Firefox".to_string())]
+        );
+
+        // Seen again, moved elsewhere by hand: not fought.
+        let planned = state.plan_auto_routes(&[stream(7, 100, "Firefox", Some("sink_chat"))]);
+        assert!(planned.is_empty());
+    }
+
+    #[test]
+    fn auto_route_skips_a_stream_already_on_target() {
+        let mut state = MixerState::default();
+        state.init_defaults();
+        state
+            .assignments
+            .set("application.name", "Firefox", "sink_game");
+        assert!(state
+            .plan_auto_routes(&[stream(7, 100, "Firefox", Some("sink_game"))])
+            .is_empty());
+    }
+
+    #[test]
+    fn auto_route_waits_for_the_sinks_to_exist() {
+        let mut state = MixerState::default();
+        state
+            .assignments
+            .set("application.name", "Firefox", "sink_game");
+        // Nothing planned, and nothing marked handled - marking here would
+        // strand the stream once the sinks arrive.
+        assert!(state
+            .plan_auto_routes(&[stream(7, 100, "Firefox", None)])
+            .is_empty());
+        assert!(state.auto_routed.is_empty());
+    }
+
+    #[test]
+    fn auto_route_reroutes_a_restarted_stream_on_a_recycled_node_id() {
+        let mut state = MixerState::default();
+        state.init_defaults();
+        state
+            .assignments
+            .set("application.name", "Firefox", "sink_game");
+        assert_eq!(
+            state.plan_auto_routes(&[stream(7, 100, "Firefox", None)]).len(),
+            1
+        );
+
+        // The app reopened its stream and PipeWire reused the node id;
+        // serials never repeat, so the new stream is still routed.
+        let planned = state.plan_auto_routes(&[stream(7, 101, "Firefox", None)]);
+        assert_eq!(planned.len(), 1);
+    }
+
+    #[test]
+    fn auto_route_ledger_forgets_dead_streams() {
+        let mut state = MixerState::default();
+        state.init_defaults();
+        state.plan_auto_routes(&[stream(1, 10, "A", None), stream(2, 11, "B", None)]);
+        assert_eq!(state.auto_routed.len(), 2);
+        state.plan_auto_routes(&[stream(1, 10, "A", None)]);
+        assert_eq!(state.auto_routed, HashSet::from([10]));
     }
 
     #[test]


### PR DESCRIPTION
The routing guarantees from 0.1.28 and 0.1.29 were pinned only by manual
runs against a live PipeWire session. This covers them:

- enforce a stream once, on first sight, so a manual re-route (here or in
  pavucontrol) is not fought
- key the ledger on `object.serial`, since node ids recycle fast enough
  that a restarted stream would inherit a dead entry and never be routed
- plan nothing before the sinks exist, or a stream is marked handled while
  its target cannot be moved to yet
- drop entries for streams that have gone away
- sibling selection: same identity, never the stream itself, and a
  different `match_prop` is a different app

The decision moved out of the `get_app_streams` body into
`MixerState::plan_auto_routes`. Every statement is byte-identical and in
the same order; the only difference is that the `if initialized` block
became an early return, which is equivalent because it wrapped the whole
body. The command layer kept no state of its own for it.

Each test was checked against a mutant of the behaviour it claims to pin
(ledger keyed on index, guard removed, prune removed, manual-move check
removed, sibling filter widened); every mutation failed the matching test
and nothing else. Verified end to end on an isolated PipeWire instance as
well: a pre-assigned app lands on its channel within 250ms, and a manual
move away holds for 40 enforcement ticks without being fought.

Not included: the `ensure_all_links` plan/apply split (TD-010), and
coverage of the refresh gate and the record-intent ordering from #44.
Both need to change production code or a new mock backend, so they belong
in their own PR.
