### PR TITLE
test(routing): cover the command paths behind the routing races

### DIFF
--- a/src-tauri/src/audio/mock.rs
+++ b/src-tauri/src/audio/mock.rs
@@ -1,0 +1,208 @@
+//! A recording [`AudioBackend`] for tests. Nothing here is compiled into a
+//! release build.
+//!
+//! Commands only ever reach the audio system through the trait, so a mock is
+//! enough to exercise a whole command path - including the order it does
+//! things in, which is what the routing races turned on.
+
+use std::sync::Mutex;
+
+use crate::audio::backend::AudioBackend;
+use crate::audio::types::{AppStream, EqConfig, MicConfig, OutputDevice};
+use crate::error::SinkError;
+
+/// One recorded backend call. Only the calls tests assert on are named;
+/// everything else lands as `Other`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Call {
+    MoveStream { index: u32, sink: String },
+    ListStreams,
+    Other(&'static str),
+}
+
+/// Called on every move, so a test can inspect the world mid-command.
+type MoveHook = Box<dyn Fn(u32, &str) + Send + Sync>;
+
+#[derive(Default)]
+pub struct MockBackend {
+    streams: Mutex<Vec<AppStream>>,
+    calls: Mutex<Vec<Call>>,
+    on_move: Mutex<Option<MoveHook>>,
+}
+
+impl MockBackend {
+    pub fn with_streams(streams: Vec<AppStream>) -> Self {
+        Self {
+            streams: Mutex::new(streams),
+            ..Default::default()
+        }
+    }
+
+    pub fn on_move(&self, f: impl Fn(u32, &str) + Send + Sync + 'static) {
+        *self.on_move.lock().expect("on_move") = Some(Box::new(f));
+    }
+
+    pub fn calls(&self) -> Vec<Call> {
+        self.calls.lock().expect("calls").clone()
+    }
+
+    pub fn moves(&self) -> Vec<(u32, String)> {
+        self.calls()
+            .into_iter()
+            .filter_map(|c| match c {
+                Call::MoveStream { index, sink } => Some((index, sink)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Simulate something outside Sink moving a stream (pavucontrol, or the
+    /// user dragging it in another mixer).
+    pub fn set_assigned(&self, index: u32, sink: Option<&str>) {
+        for s in self.streams.lock().expect("streams").iter_mut() {
+            if s.index == index {
+                s.assigned_sink = sink.map(str::to_string);
+            }
+        }
+    }
+
+    fn record(&self, call: Call) {
+        self.calls.lock().expect("calls").push(call);
+    }
+}
+
+/// Build an `AppStream` with the identity fields a test cares about.
+pub fn stream(index: u32, serial: u64, value: &str, on: Option<&str>) -> AppStream {
+    AppStream {
+        index,
+        serial,
+        app_name: value.to_string(),
+        match_prop: "application.name".into(),
+        match_value: value.into(),
+        alias: None,
+        icon_name: None,
+        icon_path: None,
+        pid: None,
+        assigned_sink: on.map(str::to_string),
+        volume_percent: 100,
+        muted: false,
+        active: true,
+    }
+}
+
+impl AudioBackend for MockBackend {
+    fn list_app_streams(&self) -> Result<Vec<AppStream>, SinkError> {
+        self.record(Call::ListStreams);
+        Ok(self.streams.lock().expect("streams").clone())
+    }
+
+    fn move_stream_to_sink(&self, stream_index: u32, sink_name: &str) -> Result<(), SinkError> {
+        self.record(Call::MoveStream {
+            index: stream_index,
+            sink: sink_name.to_string(),
+        });
+        if let Some(f) = self.on_move.lock().expect("on_move").as_ref() {
+            f(stream_index, sink_name);
+        }
+        // Reflect the move, so a later listing agrees with what happened.
+        for s in self.streams.lock().expect("streams").iter_mut() {
+            if s.index == stream_index {
+                s.assigned_sink = (!sink_name.is_empty()).then(|| sink_name.to_string());
+            }
+        }
+        Ok(())
+    }
+
+    fn create_virtual_sink(&self, _name: &str, _label: &str) -> Result<(), SinkError> {
+        self.record(Call::Other("create_virtual_sink"));
+        Ok(())
+    }
+
+    fn destroy_virtual_sink(&self, _name: &str) -> Result<(), SinkError> {
+        self.record(Call::Other("destroy_virtual_sink"));
+        Ok(())
+    }
+
+    fn list_output_devices(&self) -> Result<Vec<OutputDevice>, SinkError> {
+        Ok(Vec::new())
+    }
+
+    fn set_sink_volume(&self, _sink_name: &str, _volume_percent: u8) -> Result<(), SinkError> {
+        self.record(Call::Other("set_sink_volume"));
+        Ok(())
+    }
+
+    fn set_sink_mute(&self, _sink_name: &str, _muted: bool) -> Result<(), SinkError> {
+        self.record(Call::Other("set_sink_mute"));
+        Ok(())
+    }
+
+    fn set_app_volume(&self, _stream_index: u32, _volume_percent: u8) -> Result<(), SinkError> {
+        self.record(Call::Other("set_app_volume"));
+        Ok(())
+    }
+
+    fn set_channel_output(&self, _sink_name: &str, _device: Option<&str>) -> Result<(), SinkError> {
+        Ok(())
+    }
+
+    fn set_channel_eq(&self, _sink_name: &str, _config: &EqConfig) -> Result<(), SinkError> {
+        Ok(())
+    }
+
+    fn resolved_channel_outputs(
+        &self,
+    ) -> Result<std::collections::HashMap<String, Option<String>>, SinkError> {
+        Ok(std::collections::HashMap::new())
+    }
+
+    fn create_bus(&self, _name: &str, _label: &str) -> Result<(), SinkError> {
+        Ok(())
+    }
+
+    fn destroy_bus(&self, _name: &str) -> Result<(), SinkError> {
+        self.record(Call::Other("destroy_bus"));
+        Ok(())
+    }
+
+    fn set_bus_members(&self, _name: &str, _channels: &[String]) -> Result<(), SinkError> {
+        Ok(())
+    }
+
+    fn set_bus_mic(&self, _name: &str, _mic: bool) -> Result<(), SinkError> {
+        Ok(())
+    }
+
+    fn set_bus_member_gain(
+        &self,
+        _bus_name: &str,
+        _member: &str,
+        _percent: u8,
+    ) -> Result<(), SinkError> {
+        Ok(())
+    }
+
+    fn set_monitor(&self, _name: &str, _enabled: bool) -> Result<(), SinkError> {
+        Ok(())
+    }
+
+    fn list_input_devices(&self) -> Result<Vec<OutputDevice>, SinkError> {
+        Ok(Vec::new())
+    }
+
+    fn get_default_devices(&self) -> Result<(Option<String>, Option<String>), SinkError> {
+        Ok((None, None))
+    }
+
+    fn set_default_output(&self, _name: &str) -> Result<(), SinkError> {
+        Ok(())
+    }
+
+    fn set_default_input(&self, _name: &str) -> Result<(), SinkError> {
+        Ok(())
+    }
+
+    fn set_mic_config(&self, _config: &MicConfig) -> Result<(), SinkError> {
+        Ok(())
+    }
+}

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,6 +1,8 @@
 pub mod backend;
 pub mod eq_import;
 pub mod icons;
+#[cfg(test)]
+pub mod mock;
 pub mod pactl;
 pub mod presets;
 pub mod pw_native;

--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -369,3 +369,55 @@ pub fn teardown_virtual_devices(state: State<'_, AppState>) -> Result<(), String
         Err(errors.join("; "))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio::mock::{stream, MockBackend};
+    use crate::persistence::testing::TempConfig;
+    use std::sync::Arc;
+
+    #[test]
+    fn refresh_enforces_an_assignment_once() {
+        let _cfg = TempConfig::new("refresh-once");
+        let backend = Arc::new(MockBackend::with_streams(vec![stream(
+            7, 100, "Firefox", None,
+        )]));
+        let state = AppState::new(backend.clone(), true);
+        {
+            let mut mixer = state.lock_mixer().expect("mixer");
+            mixer.init_defaults();
+            mixer
+                .assignments
+                .set("application.name", "Firefox", "sink_game");
+        }
+
+        refresh_streams(&state).expect("first pass");
+        assert_eq!(backend.moves(), vec![(7, "sink_game".to_string())]);
+
+        // The user drags it elsewhere in pavucontrol. The ticker runs five
+        // times a second; it must leave that alone rather than dragging the
+        // stream back on the next pass.
+        backend.set_assigned(7, Some("sink_chat"));
+        refresh_streams(&state).expect("second pass");
+        assert_eq!(
+            backend.moves().len(),
+            1,
+            "a manual re-route must not be fought"
+        );
+    }
+
+    #[test]
+    fn refresh_leaves_unassigned_apps_alone() {
+        let _cfg = TempConfig::new("refresh-unassigned");
+        let backend = Arc::new(MockBackend::with_streams(vec![stream(
+            9, 300, "Spotify", None,
+        )]));
+        let state = AppState::new(backend.clone(), true);
+        state.lock_mixer().expect("mixer").init_defaults();
+
+        let streams = refresh_streams(&state).expect("pass");
+        assert!(backend.moves().is_empty());
+        assert_eq!(streams.len(), 1);
+    }
+}

--- a/src-tauri/src/commands/routing.rs
+++ b/src-tauri/src/commands/routing.rs
@@ -34,7 +34,11 @@ pub fn route_app_to_channel(
     stream_index: u32,
     sink_name: String,
 ) -> Result<(), String> {
-    if !sink_name.is_empty() && !is_virtual_sink(&sink_name) {
+    route_app(state.inner(), stream_index, &sink_name)
+}
+
+pub fn route_app(state: &AppState, stream_index: u32, sink_name: &str) -> Result<(), String> {
+    if !sink_name.is_empty() && !is_virtual_sink(sink_name) {
         return Err(format!("unknown channel: {sink_name}"));
     }
 
@@ -45,7 +49,7 @@ pub fn route_app_to_channel(
         // case the listing raced, with nothing to record against it.
         return state
             .backend
-            .move_stream_to_sink(stream_index, &sink_name)
+            .move_stream_to_sink(stream_index, sink_name)
             .map_err(|e| e.to_string());
     };
     let siblings: Vec<&crate::audio::types::AppStream> = siblings_of(&streams, stream);
@@ -60,7 +64,7 @@ pub fn route_app_to_channel(
         } else {
             mixer
                 .assignments
-                .set(&stream.match_prop, &stream.match_value, &sink_name);
+                .set(&stream.match_prop, &stream.match_value, sink_name);
         }
         // The user explicitly placed these streams; don't auto-route them again.
         mixer.auto_routed.insert(stream.serial);
@@ -71,10 +75,10 @@ pub fn route_app_to_channel(
 
     state
         .backend
-        .move_stream_to_sink(stream_index, &sink_name)
+        .move_stream_to_sink(stream_index, sink_name)
         .map_err(|e| e.to_string())?;
     for sibling in &siblings {
-        if let Err(e) = state.backend.move_stream_to_sink(sibling.index, &sink_name) {
+        if let Err(e) = state.backend.move_stream_to_sink(sibling.index, sink_name) {
             eprintln!(
                 "sink: moving {} (#{}) failed: {e}",
                 stream.app_name, sibling.index
@@ -205,7 +209,115 @@ pub fn set_app_volume(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::audio::mock::{stream as mock_stream, MockBackend};
     use crate::audio::types::AppStream;
+    use crate::persistence::testing::TempConfig;
+    use std::sync::Arc;
+
+    /// An AppState on a private config root, channels created, with one
+    /// saved assignment for Firefox.
+    fn app(backend: Arc<MockBackend>) -> AppState {
+        let state = AppState::new(backend, true);
+        {
+            let mut mixer = state.lock_mixer().expect("mixer");
+            mixer.init_defaults();
+            mixer
+                .assignments
+                .set("application.name", "Firefox", "sink_game");
+        }
+        state
+    }
+
+    #[test]
+    fn routing_records_the_assignment_before_it_moves_anything() {
+        let _cfg = TempConfig::new("route-order");
+        let backend = Arc::new(MockBackend::with_streams(vec![mock_stream(
+            7, 100, "Firefox", None,
+        )]));
+        let state = Arc::new(app(backend.clone()));
+
+        // Observe from inside the move: the enforcement ticker runs
+        // concurrently, so the assignment and the ledger must already say
+        // where this stream belongs, or a tick landing here corrects the
+        // move straight back.
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let (probe, probed_state) = (Arc::clone(&seen), Arc::clone(&state));
+        backend.on_move(move |_, _| {
+            let mixer = probed_state.lock_mixer().expect("mixer");
+            probe.lock().expect("probe").push((
+                mixer
+                    .assignments
+                    .sink_for("application.name", "Firefox")
+                    .map(str::to_string),
+                mixer.auto_routed.contains(&100),
+            ));
+        });
+
+        route_app(&state, 7, "sink_chat").expect("routes");
+
+        assert_eq!(
+            seen.lock().expect("probe").as_slice(),
+            [(Some("sink_chat".to_string()), true)],
+            "assignment and ledger must be recorded before the move"
+        );
+    }
+
+    #[test]
+    fn routing_moves_every_stream_of_the_app() {
+        let _cfg = TempConfig::new("route-siblings");
+        let backend = Arc::new(MockBackend::with_streams(vec![
+            mock_stream(7, 100, "Firefox", None),
+            mock_stream(8, 101, "Firefox", None),
+            mock_stream(9, 102, "Spotify", None),
+        ]));
+        let state = app(backend.clone());
+
+        route_app(&state, 7, "sink_chat").expect("routes");
+
+        let mut moved: Vec<u32> = backend.moves().into_iter().map(|(i, _)| i).collect();
+        moved.sort_unstable();
+        assert_eq!(moved, vec![7, 8], "siblings follow, other apps don't");
+        assert!(backend.moves().iter().all(|(_, s)| s == "sink_chat"));
+
+        // Every moved stream is ledgered, so the ticker leaves them alone.
+        let mixer = state.lock_mixer().expect("mixer");
+        assert!(mixer.auto_routed.contains(&100) && mixer.auto_routed.contains(&101));
+        assert!(!mixer.auto_routed.contains(&102));
+    }
+
+    #[test]
+    fn unrouting_clears_the_assignment() {
+        let _cfg = TempConfig::new("route-clear");
+        let backend = Arc::new(MockBackend::with_streams(vec![mock_stream(
+            7,
+            100,
+            "Firefox",
+            Some("sink_game"),
+        )]));
+        let state = app(backend.clone());
+
+        route_app(&state, 7, "").expect("unroutes");
+
+        assert_eq!(backend.moves(), vec![(7, String::new())]);
+        assert!(state
+            .lock_mixer()
+            .expect("mixer")
+            .assignments
+            .sink_for("application.name", "Firefox")
+            .is_none());
+    }
+
+    #[test]
+    fn routing_rejects_a_sink_that_is_not_one_of_ours() {
+        let _cfg = TempConfig::new("route-reject");
+        let backend = Arc::new(MockBackend::with_streams(vec![mock_stream(
+            7, 100, "Firefox", None,
+        )]));
+        let state = app(backend.clone());
+
+        assert!(route_app(&state, 7, "alsa_output.hw_0").is_err());
+        assert!(backend.moves().is_empty(), "nothing moves on a bad target");
+    }
 
     fn stream(index: u32, prop: &str, value: &str) -> AppStream {
         AppStream {

--- a/src-tauri/src/persistence/active.rs
+++ b/src-tauri/src/persistence/active.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use crate::error::SinkError;
 
 fn marker_path() -> Result<PathBuf, SinkError> {
-    let dir = dirs::config_dir()
+    let dir = crate::persistence::config_root()
         .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
     Ok(dir.join("sink").join("active_profile"))
 }

--- a/src-tauri/src/persistence/aliases.rs
+++ b/src-tauri/src/persistence/aliases.rs
@@ -23,7 +23,7 @@ pub struct Aliases {
 
 impl Aliases {
     pub fn config_path() -> Result<PathBuf, SinkError> {
-        let dir = dirs::config_dir()
+        let dir = crate::persistence::config_root()
             .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
         Ok(dir.join("sink").join("aliases.json"))
     }

--- a/src-tauri/src/persistence/assignments.rs
+++ b/src-tauri/src/persistence/assignments.rs
@@ -26,7 +26,7 @@ pub struct Assignments {
 
 impl Assignments {
     pub fn config_path() -> Result<PathBuf, SinkError> {
-        let dir = dirs::config_dir()
+        let dir = crate::persistence::config_root()
             .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
         Ok(dir.join("sink").join("assignments.json"))
     }

--- a/src-tauri/src/persistence/autostart.rs
+++ b/src-tauri/src/persistence/autostart.rs
@@ -13,7 +13,7 @@ use crate::error::SinkError;
 const UNIT_NAME: &str = "sink.service";
 
 fn unit_path() -> Result<PathBuf, SinkError> {
-    let dir = dirs::config_dir()
+    let dir = crate::persistence::config_root()
         .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
     Ok(dir.join("systemd").join("user").join(UNIT_NAME))
 }

--- a/src-tauri/src/persistence/buses.rs
+++ b/src-tauri/src/persistence/buses.rs
@@ -116,7 +116,7 @@ fn slugify(label: &str) -> String {
 
 impl Buses {
     pub fn config_path() -> Result<PathBuf, SinkError> {
-        let dir = dirs::config_dir()
+        let dir = crate::persistence::config_root()
             .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
         Ok(dir.join("sink").join("buses.json"))
     }

--- a/src-tauri/src/persistence/channels.rs
+++ b/src-tauri/src/persistence/channels.rs
@@ -87,7 +87,7 @@ fn slugify(label: &str) -> String {
 
 impl Channels {
     pub fn config_path() -> Result<PathBuf, SinkError> {
-        let dir = dirs::config_dir()
+        let dir = crate::persistence::config_root()
             .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
         Ok(dir.join("sink").join("channels.json"))
     }

--- a/src-tauri/src/persistence/eq.rs
+++ b/src-tauri/src/persistence/eq.rs
@@ -19,7 +19,7 @@ pub struct ChannelEq {
 
 impl ChannelEq {
     pub fn config_path() -> Result<PathBuf, SinkError> {
-        let dir = dirs::config_dir()
+        let dir = crate::persistence::config_root()
             .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
         Ok(dir.join("sink").join("eq.json"))
     }

--- a/src-tauri/src/persistence/eq_presets.rs
+++ b/src-tauri/src/persistence/eq_presets.rs
@@ -11,7 +11,7 @@ use crate::error::SinkError;
 use crate::persistence::profiles::sanitize_name;
 
 fn presets_dir() -> Result<PathBuf, SinkError> {
-    let dir = dirs::config_dir()
+    let dir = crate::persistence::config_root()
         .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
     Ok(dir.join("sink").join("eq_presets"))
 }

--- a/src-tauri/src/persistence/mic.rs
+++ b/src-tauri/src/persistence/mic.rs
@@ -7,7 +7,7 @@ use crate::error::SinkError;
 /// Mic chain configuration, stored as JSON at
 /// `$XDG_CONFIG_HOME/sink/mic.json`.
 pub fn config_path() -> Result<PathBuf, SinkError> {
-    let dir = dirs::config_dir()
+    let dir = crate::persistence::config_root()
         .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
     Ok(dir.join("sink").join("mic.json"))
 }

--- a/src-tauri/src/persistence/mod.rs
+++ b/src-tauri/src/persistence/mod.rs
@@ -21,6 +21,56 @@ pub fn unix_now() -> u64 {
         .unwrap_or(0)
 }
 
+/// Where Sink's own config directory lives. Release builds always resolve
+/// `$XDG_CONFIG_HOME`; the test override below does not exist in them.
+pub fn config_root() -> Option<std::path::PathBuf> {
+    #[cfg(test)]
+    if let Some(root) = testing::config_root_override() {
+        return Some(root);
+    }
+    dirs::config_dir()
+}
+
+/// Redirects [`config_root`] per thread, so a test can exercise a real save
+/// path without writing into the developer's own config.
+#[cfg(test)]
+pub mod testing {
+    use std::cell::RefCell;
+    use std::path::PathBuf;
+
+    thread_local! {
+        static ROOT: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+    }
+
+    pub fn config_root_override() -> Option<PathBuf> {
+        ROOT.with(|r| r.borrow().clone())
+    }
+
+    /// A private config root for this test, removed when the guard drops.
+    pub struct TempConfig(PathBuf);
+
+    impl TempConfig {
+        pub fn new(tag: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "sink-test-{tag}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).expect("temp config root");
+            ROOT.with(|r| *r.borrow_mut() = Some(dir.clone()));
+            Self(dir)
+        }
+    }
+
+    impl Drop for TempConfig {
+        fn drop(&mut self) {
+            ROOT.with(|r| *r.borrow_mut() = None);
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+}
+
 /// Create Sink's config directory (and parents) with owner-only access -
 /// routing rules and app history are nobody else's business. Used by every
 /// save path that writes under `$XDG_CONFIG_HOME/sink`.
@@ -66,7 +116,7 @@ pub fn write_atomic(path: &std::path::Path, contents: impl AsRef<[u8]>) -> std::
 /// directory (channels, mixes, profiles, assignments, history, prefs)
 /// and the WirePlumber routing rules.
 pub fn wipe_all() -> Result<(), crate::error::SinkError> {
-    if let Some(dir) = dirs::config_dir() {
+    if let Some(dir) = crate::persistence::config_root() {
         let sink_dir = dir.join("sink");
         if sink_dir.exists() {
             std::fs::remove_dir_all(&sink_dir)?;

--- a/src-tauri/src/persistence/outputs.rs
+++ b/src-tauri/src/persistence/outputs.rs
@@ -24,7 +24,7 @@ pub struct ChannelOutputs {
 
 impl ChannelOutputs {
     pub fn config_path() -> Result<PathBuf, SinkError> {
-        let dir = dirs::config_dir()
+        let dir = crate::persistence::config_root()
             .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
         Ok(dir.join("sink").join("outputs.json"))
     }

--- a/src-tauri/src/persistence/prefs.rs
+++ b/src-tauri/src/persistence/prefs.rs
@@ -60,7 +60,7 @@ impl Default for Prefs {
 
 impl Prefs {
     pub fn config_path() -> Result<PathBuf, SinkError> {
-        let dir = dirs::config_dir()
+        let dir = crate::persistence::config_root()
             .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
         Ok(dir.join("sink").join("prefs.json"))
     }

--- a/src-tauri/src/persistence/profiles.rs
+++ b/src-tauri/src/persistence/profiles.rs
@@ -38,7 +38,7 @@ pub struct ProfileInfo {
 }
 
 fn profiles_dir() -> Result<PathBuf, SinkError> {
-    let dir = dirs::config_dir()
+    let dir = crate::persistence::config_root()
         .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
     Ok(dir.join("sink").join("profiles"))
 }

--- a/src-tauri/src/persistence/seen.rs
+++ b/src-tauri/src/persistence/seen.rs
@@ -35,7 +35,7 @@ pub struct SeenApps {
 
 impl SeenApps {
     pub fn config_path() -> Result<PathBuf, SinkError> {
-        let dir = dirs::config_dir()
+        let dir = crate::persistence::config_root()
             .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
         Ok(dir.join("sink").join("seen_apps.json"))
     }

--- a/src-tauri/src/persistence/wireplumber.rs
+++ b/src-tauri/src/persistence/wireplumber.rs
@@ -15,7 +15,7 @@ use crate::error::SinkError;
 use crate::persistence::assignments::Assignments;
 
 pub fn conf_path() -> Result<PathBuf, SinkError> {
-    let dir = dirs::config_dir()
+    let dir = crate::persistence::config_root()
         .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
     Ok(dir
         .join("wireplumber")


### PR DESCRIPTION
The hardening added to the mixes PR - record intent before moving, and
enforce a stream once - was verified only by review and by manual runs
against a live PipeWire session. This covers those paths.

## Test infrastructure

Two additions, both invisible to a release build:

- `audio::mock::MockBackend`, a recording `AudioBackend`. Commands only
  ever reach the audio system through the trait, so a mock is enough to
  drive a whole command path, including the order it does things in. It
  can also run a hook on every move, which is how the ordering test
  observes the world mid-command rather than only afterwards.
- `persistence::testing::TempConfig`, a per-thread config-root override.
  Every persistence module now resolves through `persistence::config_root`,
  which in a non-test build is exactly `dirs::config_dir()` as before -
  the override is `#[cfg(test)]` and cannot exist in a release binary.
  Without it, no command that saves could be tested without writing into
  the developer's own config. Verified: the suite leaves
  `~/.config/sink` untouched, mtime unchanged.

`route_app_to_channel` gains a thin command wrapper over an inner fn
taking `&AppState`, the shape `get_app_streams` already uses.

## What is covered

- the assignment and the ledger are recorded *before* anything moves
- an app's other live streams follow, and other apps don't
- unrouting clears the saved assignment
- a target that is not one of our channels is refused before any move
- a stream is enforced once: after the user drags it elsewhere in
  pavucontrol, a later pass leaves it alone
- an app with no assignment is never moved

## Mutation checks

Every test was run against a mutant of the rule it claims to pin. The
ordering test fails when the move is put back in front of the record;
the enforce-once test fails when the ledger is cleared each pass.

One of these initially passed for the wrong reason - the mock reflected
the move, so the second pass was protected by the `assigned_sink` check
rather than by the ledger. The mutant exposed that, and the test now
simulates an external move so it exercises the ledger itself.

Still not covered: `ensure_all_links` (TD-010), which needs the planner
split, and the refresh gate's mutual exclusion, which is a structural
property a timing test would only flake on.
