### PR TITLE
refactor(ui): share the strips' inline rename

### DIFF
--- a/src/components/MixerBoard/ChannelStrip.tsx
+++ b/src/components/MixerBoard/ChannelStrip.tsx
@@ -10,6 +10,7 @@ import { EqModal } from "../Eq/EqModal";
 import { ChannelApps } from "./ChannelApps";
 import { Fader } from "./Fader";
 import { OutputSelect } from "./OutputSelect";
+import { StripName } from "./StripName";
 import { VuMeter } from "./VuMeter";
 
 interface ChannelStripProps {
@@ -47,20 +48,10 @@ export function ChannelStrip({
 
   const eqEnabled = useMixerStore((s) => s.eqConfigs[channel.name]?.enabled ?? false);
 
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState("");
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [pickingIcon, setPickingIcon] = useState(false);
   const [managingApps, setManagingApps] = useState(false);
   const [editingEq, setEditingEq] = useState(false);
-
-  const commitRename = () => {
-    setEditing(false);
-    const label = draft.trim();
-    if (label && label !== channel.label) {
-      void renameChannel(channel.name, label);
-    }
-  };
 
   // Mono meter: show the louder of L/R.
   const amplitude = Math.max(level?.[0] ?? 0, level?.[1] ?? 0);
@@ -129,31 +120,10 @@ export function ChannelStrip({
             </div>
           </Popover>
         </div>
-        {editing ? (
-          <input
-            className="menu-input strip-name-input"
-            value={draft}
-            autoFocus
-            maxLength={24}
-            onChange={(e) => setDraft(e.target.value)}
-            onBlur={commitRename}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") commitRename();
-              if (e.key === "Escape") setEditing(false);
-            }}
-          />
-        ) : (
-          <div
-            className="strip-name strip-name-editable"
-            title="Double-click to rename"
-            onDoubleClick={() => {
-              setDraft(channel.label);
-              setEditing(true);
-            }}
-          >
-            {channel.label}
-          </div>
-        )}
+        <StripName
+          label={channel.label}
+          onRename={(label) => void renameChannel(channel.name, label)}
+        />
         <div style={{ position: "relative" }}>
           <button
             type="button"

--- a/src/components/MixerBoard/StreamMixStrip.tsx
+++ b/src/components/MixerBoard/StreamMixStrip.tsx
@@ -8,6 +8,7 @@ import { ConfirmModal } from "../ConfirmModal";
 import { MenuCheckItem, MenuItem } from "../MenuItem";
 import { Popover } from "../Popover";
 import { Fader } from "./Fader";
+import { StripName } from "./StripName";
 import { VuMeter } from "./VuMeter";
 
 /**
@@ -42,8 +43,6 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
   const openMixFaderWindow = useMixerStore((s) => s.openMixFaderWindow);
 
   const [managing, setManaging] = useState(false);
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState("");
   const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   // The master mix always exists and carries every channel.
@@ -58,11 +57,6 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
 
   const applyVolume = (v: number) => void setBusVolume(bus.name, v);
   const toggleMute = () => void setBusMute(bus.name, !muted);
-  const commitRename = () => {
-    setEditing(false);
-    const label = draft.trim();
-    if (label && label !== bus.label) void renameBus(bus.name, label);
-  };
   // What this mix actually carries (mode-aware).
   const allNames = channels.map((c) => c.name);
   const carried = busMembers(bus, allNames);
@@ -101,31 +95,7 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
         <div className="strip-icon strip-icon-bus">
           <Ms name="radio_button_checked" />
         </div>
-        {editing ? (
-          <input
-            className="menu-input strip-name-input"
-            value={draft}
-            autoFocus
-            maxLength={24}
-            onChange={(e) => setDraft(e.target.value)}
-            onBlur={commitRename}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") commitRename();
-              if (e.key === "Escape") setEditing(false);
-            }}
-          />
-        ) : (
-          <div
-            className="strip-name strip-name-editable"
-            title="Double-click to rename"
-            onDoubleClick={() => {
-              setDraft(bus.label);
-              setEditing(true);
-            }}
-          >
-            {bus.label}
-          </div>
-        )}
+        <StripName label={bus.label} onRename={(label) => void renameBus(bus.name, label)} />
         <div style={{ position: "relative" }}>
           <button
             type="button"

--- a/src/components/MixerBoard/StripName.tsx
+++ b/src/components/MixerBoard/StripName.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+
+interface StripNameProps {
+  label: string;
+  /** Given a trimmed, changed label. Not called for a no-op edit. */
+  onRename: (label: string) => void;
+}
+
+/** A strip's label, renamed in place on double-click. */
+export function StripName({ label, onRename }: Readonly<StripNameProps>) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  const commit = () => {
+    setEditing(false);
+    const next = draft.trim();
+    if (next && next !== label) onRename(next);
+  };
+
+  if (editing) {
+    return (
+      <input
+        className="menu-input strip-name-input"
+        value={draft}
+        autoFocus
+        maxLength={24}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          if (e.key === "Escape") setEditing(false);
+        }}
+      />
+    );
+  }
+
+  return (
+    <div
+      className="strip-name strip-name-editable"
+      title="Double-click to rename"
+      onDoubleClick={() => {
+        setDraft(label);
+        setEditing(true);
+      }}
+    >
+      {label}
+    </div>
+  );
+}


### PR DESCRIPTION
The channel and mix strips carried the same 18-line inline-rename widget
byte for byte, plus their own copies of the `editing`/`draft` state and
the commit rule. That block is the whole of the reported duplication:
19/238 and 19/243 lines is the 7.9%/7.8% that was flagged.

One `StripName` component, two props (`label`, `onRename`). The two
copies of `commitRename` had already drifted in style, which is the
usual first step before they drift in behaviour.

## Deliberately left alone

The same report picks up scraps of the toggle buttons (mute/monitor/eq),
the delete button and the popover trigger. Those are the same visual
shape, not the same behaviour:

- a shared toggle button would need `pressed`, `onToggle`, an icon per
  state, a title per state and an active class - and the EQ button does
  not toggle anything, it opens a modal, so two of those props would not
  apply to one of the three call sites
- the popover trigger opens completely different things: one inlines its
  menu, the other delegates to `ChannelApps`

Each would trade five to ten lines of obvious inline JSX for a component
you have to go read to know what a call site does. The fader, meter and
confirm modal that also look duplicated are simply two call sites of
components that are already shared.

Checked for accidental divergence between the two files (a guard, aria
attribute or handler present in one and missing in the other) and found
none - only a cosmetic `{" "}` vs literal-space difference in the volume
readout, which renders identically.

## Verified

`tsc`, 16 Vitest, and a real UI run against an isolated PipeWire
instance driving the actual widget: double-click opens the editor with
the current label focused, typing and Enter renames the channel and
persists it to `channels.json`, and Escape on a mix strip discards the
draft leaving both the UI and `buses.json` untouched.
