### PR TITLE
feat: add SteelSeries Arctis Nova 7 ChatMix support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3238,6 +3238,7 @@ name = "sink"
 version = "0.1.0"
 dependencies = [
  "dirs",
+ "libc",
  "pipewire",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ npm run tauri build    # package
 
 Config lives in `~/.config/sink` as plain JSON.
 
+Optional SteelSeries Arctis Nova 7 Gen 1 (`1038:2202`) hardware ChatMix and
+wireless-state auto-switch support is available in Settings. Both are disabled
+by default. Debian packages include a device-scoped udev rule; see
+[`docs/STEELSERIES_CHATMIX.md`](docs/STEELSERIES_CHATMIX.md) for permissions,
+protocol attribution, and Easy Effects routing guidance.
+
 ## License
 
 [GPL-3.0](LICENSE)

--- a/docs/STEELSERIES_CHATMIX.md
+++ b/docs/STEELSERIES_CHATMIX.md
@@ -1,0 +1,50 @@
+# SteelSeries Arctis Nova 7 hardware ChatMix
+
+Sink can read the physical ChatMix wheel and the real wireless headset state
+from an Arctis Nova 7 Gen 1 dongle (`1038:2202`). Both features are disabled by
+default. They run in Sink's existing backend process, including while the main
+window is hidden in the tray; no root daemon is used.
+
+## Protocol and attribution
+
+The HID report framing, Nova 7 command interface 3, additional dial listener
+interface 5, session/query commands, and field offsets in
+`src-tauri/src/hardware/mod.rs` are adapted from
+[`rdamron/rust-arctis-chatmix`](https://github.com/rdamron/rust-arctis-chatmix),
+GPL-3.0-only. That project attributes the reverse-engineered device definitions
+to [`elegos/Linux-Arctis-Manager`](https://github.com/elegos/Linux-Arctis-Manager),
+also GPL-3.0. Sink remains GPL-3.0-only.
+
+The implementation writes only the documented session/query sequence needed to
+receive ChatMix and power-status reports. It does not write EQ, sidetone, gain,
+microphone, auto-off, wireless-mode, or other stored headset preferences.
+
+## Permissions
+
+The Debian package includes
+`/usr/lib/udev/rules.d/70-sink-arctis-nova7.rules`. The rule is deliberately
+limited to hidraw nodes belonging to USB `1038:2202` and uses `TAG+="uaccess"`
+for the active local seat. It does not use a global hidraw mode or grant access
+to unrelated SteelSeries devices.
+
+Installing the package needs administrator authorization. After installation,
+reload udev and reconnect the dongle (or reboot) before enabling hardware
+ChatMix. Do not copy a broader rule into `/etc/udev/rules.d`.
+
+## Easy Effects
+
+The hardware settings list the same physical outputs exposed by Sink's channel
+output selectors, including Easy Effects Sink when it is running. Selecting
+Easy Effects sends the two Balance channels into its input sink. Easy Effects'
+own output must remain a physical device; routing it back to a Sink channel
+would form a processing loop. Sink does not modify Easy Effects configuration.
+
+## Auto-switch safety
+
+Auto-switch reacts only after the first confirmed wireless state sample. Merely
+starting or quitting the GUI does not claim or restore an output. On a real
+disconnected-to-connected transition, Sink remembers the prior system default,
+activates the configured destination for Balance A/B, and makes Game the system
+default. On disconnect it restores the remembered output only if the current
+default is still one of Sink's channels, preserving an intervening manual
+selection of a physical or processing output.

--- a/docs/STEELSERIES_CHATMIX.md
+++ b/docs/STEELSERIES_CHATMIX.md
@@ -45,6 +45,8 @@ Auto-switch reacts only after the first confirmed wireless state sample. Merely
 starting or quitting the GUI does not claim or restore an output. On a real
 disconnected-to-connected transition, Sink remembers the prior system default,
 activates the configured destination for Balance A/B, and makes Game the system
-default. On disconnect it restores the remembered output only if the current
-default is still one of Sink's channels, preserving an intervening manual
-selection of a physical or processing output.
+default. On disconnect it releases that temporary Balance A/B destination and
+restores each channel's saved output choice. It restores the remembered system
+default only if the current default is still one of Sink's channels, preserving
+an intervening manual selection of a physical or processing output. Application
+assignments remain on Sink's channels throughout both transitions.

--- a/packaging/70-sink-arctis-nova7.rules
+++ b/packaging/70-sink-arctis-nova7.rules
@@ -1,0 +1,4 @@
+# Sink hardware ChatMix access for the SteelSeries Arctis Nova 7 Gen 1 only.
+# uaccess grants the active local desktop session access; it does not make all
+# HID devices or all local users writable.
+SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="2202", TAG+="uaccess"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 dirs = "6"
+libc = "0.2"
 # 0.8.0 on crates.io predates PipeWire 1.6 headers (libspa bindgen breaks);
 # git main carries the header fixes. v0_3_49 gates Buffer::requested().
 pipewire = { git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs", rev = "v0.10.0", features = ["v0_3_49"] }

--- a/src-tauri/src/audio/pw_native/meter.rs
+++ b/src-tauri/src/audio/pw_native/meter.rs
@@ -46,6 +46,12 @@ impl MeterHandle {
             "node.name" => format!("{METER_PREFIX}{sink_name}"),
             // For sinks: capture the monitor, don't keep the sink busy.
             "stream.capture.sink" => if capture_sink { "true" } else { "false" },
+            // Pin the meter to the channel it represents. Without an
+            // explicit target WirePlumber may move the first-created meter
+            // to a newly selected default device, making (for example) Game
+            // display the combined speaker output instead of Game itself.
+            "target.object" => sink_name,
+            "node.dont-reconnect" => "true",
             "node.passive" => "true",
         };
         let stream = pw::stream::StreamRc::new(core.clone(), "sink-meter", props)
@@ -98,7 +104,9 @@ impl MeterHandle {
             .connect(
                 spa::utils::Direction::Input,
                 Some(sink_id),
-                pw::stream::StreamFlags::AUTOCONNECT | pw::stream::StreamFlags::MAP_BUFFERS,
+                pw::stream::StreamFlags::AUTOCONNECT
+                    | pw::stream::StreamFlags::DONT_RECONNECT
+                    | pw::stream::StreamFlags::MAP_BUFFERS,
                 &mut params,
             )
             .map_err(|e| err("connect", e))?;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -99,6 +99,66 @@ pub fn set_balance_channels(
     prefs.save().map_err(|e| e.to_string())
 }
 
+/// Enable or disable the Nova 7 hidraw worker. The worker is part of Sink's
+/// backend process, so hiding the window to the tray does not stop it.
+#[tauri::command]
+pub fn set_hardware_chatmix_enabled(
+    state: State<'_, AppState>,
+    enabled: bool,
+) -> Result<(), String> {
+    let prefs = {
+        let mut mixer = state.lock_mixer()?;
+        mixer.prefs.hardware_chatmix_enabled = enabled;
+        mixer.prefs.clone()
+    };
+    prefs.save().map_err(|e| e.to_string())?;
+    state.hardware.notify_settings_changed();
+    Ok(())
+}
+
+/// Enable or disable wireless-state-driven default output switching.
+#[tauri::command]
+pub fn set_headset_auto_switch(state: State<'_, AppState>, enabled: bool) -> Result<(), String> {
+    let prefs = {
+        let mut mixer = state.lock_mixer()?;
+        mixer.prefs.headset_auto_switch = enabled;
+        mixer.prefs.clone()
+    };
+    prefs.save().map_err(|e| e.to_string())?;
+    state.hardware.notify_settings_changed();
+    Ok(())
+}
+
+/// Pick a common physical/processing destination for the two Balance
+/// channels. None means keep their individual output selections.
+#[tauri::command]
+pub fn set_arctis_output(state: State<'_, AppState>, output: Option<String>) -> Result<(), String> {
+    if let Some(name) = output.as_deref() {
+        let available = state
+            .backend
+            .list_output_devices()
+            .map_err(|e| e.to_string())?
+            .into_iter()
+            .any(|device| device.name == name);
+        if !available {
+            return Err(format!("unknown output device: {name}"));
+        }
+    }
+    let prefs = {
+        let mut mixer = state.lock_mixer()?;
+        mixer.prefs.arctis_output = output;
+        mixer.prefs.clone()
+    };
+    prefs.save().map_err(|e| e.to_string())?;
+    state.hardware.notify_settings_changed();
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_arctis_status(state: State<'_, AppState>) -> crate::hardware::ArctisStatus {
+    state.hardware.status()
+}
+
 /// Mark the first-run tutorial as completed (never shown again, until a
 /// factory reset).
 #[tauri::command]

--- a/src-tauri/src/hardware/mod.rs
+++ b/src-tauri/src/hardware/mod.rs
@@ -1,0 +1,856 @@
+//! SteelSeries Arctis Nova 7 Gen 1 hardware ChatMix support.
+//!
+//! Protocol framing and byte offsets are adapted from the GPL-3.0-only
+//! `rust-arctis-chatmix` project by rdamron, which in turn documents its
+//! source as Linux-Arctis-Manager. See `docs/STEELSERIES_CHATMIX.md`.
+//! This module intentionally sends only the session/query commands required
+//! to receive dial and wireless-status reports. It never writes EQ, sidetone,
+//! gain, auto-off, microphone, or other persistent headset settings.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::os::fd::AsRawFd;
+use std::path::PathBuf;
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use tauri::{Emitter, Manager};
+
+use crate::state::AppState;
+
+const HID_ID: &str = "0003:00001038:00002202";
+const COMMAND_INTERFACE_SUFFIX: &str = "/input3";
+const DIAL_INTERFACE_SUFFIX: &str = "/input5";
+const REPORT_LEN: usize = 64;
+const STATUS_INTERVAL: Duration = Duration::from_secs(10);
+const PERSIST_DEBOUNCE: Duration = Duration::from_millis(350);
+const SESSION_POLL_MS: i32 = 250;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArctisConnectionState {
+    Disabled,
+    Connected,
+    Disconnected,
+    PermissionDenied,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ArctisStatus {
+    pub state: ArctisConnectionState,
+    pub detail: Option<String>,
+}
+
+impl Default for ArctisStatus {
+    fn default() -> Self {
+        Self {
+            state: ArctisConnectionState::Disabled,
+            detail: None,
+        }
+    }
+}
+
+/// Shared status plus a condition variable so settings changes wake a worker
+/// that may currently be in reconnect backoff.
+pub struct HardwareRuntime {
+    status: Mutex<ArctisStatus>,
+    wake_generation: Mutex<u64>,
+    wake: Condvar,
+}
+
+impl Default for HardwareRuntime {
+    fn default() -> Self {
+        Self {
+            status: Mutex::new(ArctisStatus::default()),
+            wake_generation: Mutex::new(0),
+            wake: Condvar::new(),
+        }
+    }
+}
+
+impl HardwareRuntime {
+    pub fn status(&self) -> ArctisStatus {
+        self.status.lock().map(|s| s.clone()).unwrap_or_default()
+    }
+
+    pub fn notify_settings_changed(&self) {
+        if let Ok(mut generation) = self.wake_generation.lock() {
+            *generation = generation.wrapping_add(1);
+            self.wake.notify_all();
+        }
+    }
+
+    fn wait(&self, duration: Duration) {
+        let Ok(generation) = self.wake_generation.lock() else {
+            std::thread::sleep(duration);
+            return;
+        };
+        let observed = *generation;
+        let _ = self
+            .wake
+            .wait_timeout_while(generation, duration, |current| *current == observed);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ChatMixEvent {
+    a: String,
+    b: String,
+    a_volume: u8,
+    b_volume: u8,
+}
+
+#[derive(Debug, Clone)]
+struct WorkerPrefs {
+    enabled: bool,
+    auto_switch: bool,
+    output: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AutoSwitchAction {
+    None,
+    Claim,
+    Restore(String),
+}
+
+/// Pure transition state: no first-sample action and no shutdown action.
+/// Those two rules prevent launching or quitting the GUI from changing the
+/// user's default output.
+#[derive(Debug, Default)]
+struct AutoSwitchState {
+    observed_online: Option<bool>,
+    previous_default: Option<String>,
+}
+
+impl AutoSwitchState {
+    fn reset_observation(&mut self) {
+        self.observed_online = None;
+        self.previous_default = None;
+    }
+
+    fn observe(
+        &mut self,
+        online: bool,
+        enabled: bool,
+        current_default: Option<&str>,
+        controlled: &[String],
+    ) -> AutoSwitchAction {
+        let Some(previous_online) = self.observed_online.replace(online) else {
+            return AutoSwitchAction::None;
+        };
+        if previous_online == online {
+            return AutoSwitchAction::None;
+        }
+        if !enabled {
+            self.previous_default = None;
+            return AutoSwitchAction::None;
+        }
+        if online {
+            self.previous_default = current_default
+                .filter(|name| !controlled.iter().any(|candidate| candidate == name))
+                .map(str::to_string);
+            AutoSwitchAction::Claim
+        } else {
+            let restore = current_default
+                .filter(|name| controlled.iter().any(|candidate| candidate == name))
+                .and_then(|_| self.previous_default.take());
+            restore
+                .map(AutoSwitchAction::Restore)
+                .unwrap_or(AutoSwitchAction::None)
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Discovery {
+    Found(DevicePaths),
+    Missing,
+    Unsupported(String),
+}
+
+#[derive(Debug)]
+struct DevicePaths {
+    command: PathBuf,
+    listeners: Vec<PathBuf>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ParsedReport {
+    mix: Option<(u8, u8)>,
+    online: Option<bool>,
+}
+
+/// Nova 7 Gen 1 reports are unnumbered. Dial reports are
+/// `45 <game> <chat>`; status reports are
+/// `b0 <power> <battery> <charging> <game> <chat> ...`.
+fn parse_report(report: &[u8]) -> ParsedReport {
+    match report.first().copied() {
+        Some(0x45) if report.len() >= 3 => ParsedReport {
+            mix: Some((report[1].min(100), report[2].min(100))),
+            online: None,
+        },
+        Some(0xb0) if report.len() >= 6 => ParsedReport {
+            mix: Some((report[4].min(100), report[5].min(100))),
+            online: match report[1] {
+                0x02 => Some(false),
+                0x03 => Some(true),
+                _ => None,
+            },
+        },
+        _ => ParsedReport::default(),
+    }
+}
+
+fn uevent_matches(content: &str) -> bool {
+    let id = content
+        .lines()
+        .find_map(|line| line.strip_prefix("HID_ID="));
+    let phys = content
+        .lines()
+        .find_map(|line| line.strip_prefix("HID_PHYS="));
+    id == Some(HID_ID) && phys.is_some_and(|path| path.ends_with(COMMAND_INTERFACE_SUFFIX))
+}
+
+fn hid_phys(content: &str) -> Option<&str> {
+    content
+        .lines()
+        .find_map(|line| line.strip_prefix("HID_PHYS="))
+}
+
+fn listener_matches(content: &str, expected_phys: &str) -> bool {
+    content
+        .lines()
+        .any(|line| line.strip_prefix("HID_ID=") == Some(HID_ID))
+        && hid_phys(content) == Some(expected_phys)
+}
+
+fn discover() -> Discovery {
+    let entries = match fs::read_dir("/sys/class/hidraw") {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            return Discovery::Unsupported("hidraw is not available on this system".into())
+        }
+        Err(e) => return Discovery::Unsupported(format!("cannot inspect hidraw: {e}")),
+    };
+
+    let entries: Vec<(String, String)> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let content = fs::read_to_string(entry.path().join("device/uevent")).ok()?;
+            Some((name, content))
+        })
+        .collect();
+
+    for (name, content) in &entries {
+        if uevent_matches(content) {
+            let phys_base = hid_phys(content)
+                .and_then(|path| path.rsplit_once("/input"))
+                .map(|(base, _)| base);
+            let listeners = phys_base
+                .into_iter()
+                .flat_map(|base| {
+                    let expected = format!("{base}{DIAL_INTERFACE_SUFFIX}");
+                    entries
+                        .iter()
+                        .filter(move |&(candidate, uevent)| {
+                            candidate != name && listener_matches(uevent, &expected)
+                        })
+                        .map(|(candidate, _)| PathBuf::from("/dev").join(candidate))
+                })
+                .collect();
+            return Discovery::Found(DevicePaths {
+                command: PathBuf::from("/dev").join(name),
+                listeners,
+            });
+        }
+    }
+    Discovery::Missing
+}
+
+fn frame_command(command: &[u8]) -> Vec<u8> {
+    let mut report = vec![0; REPORT_LEN + 1];
+    let copy_len = command.len().min(REPORT_LEN);
+    report[1..1 + copy_len].copy_from_slice(&command[..copy_len]);
+    report
+}
+
+fn write_command(device: &mut File, command: &[u8]) -> io::Result<()> {
+    let report = frame_command(command);
+    let written = device.write(&report)?;
+    if written == report.len() {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            format!("short hidraw write: {written}/{} bytes", report.len()),
+        ))
+    }
+}
+
+fn poll_readable(fd: i32, timeout_ms: i32) -> io::Result<bool> {
+    let mut pollfd = libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let result = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
+    if result < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if result == 0 {
+        return Ok(false);
+    }
+    if pollfd.revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "hidraw device disconnected",
+        ));
+    }
+    Ok(pollfd.revents & libc::POLLIN != 0)
+}
+
+fn poll_any(fds: &[i32], timeout_ms: i32) -> io::Result<bool> {
+    let mut pollfds: Vec<libc::pollfd> = fds
+        .iter()
+        .map(|fd| libc::pollfd {
+            fd: *fd,
+            events: libc::POLLIN,
+            revents: 0,
+        })
+        .collect();
+    let result = unsafe {
+        libc::poll(
+            pollfds.as_mut_ptr(),
+            pollfds.len() as libc::nfds_t,
+            timeout_ms,
+        )
+    };
+    if result < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if result == 0 {
+        return Ok(false);
+    }
+    if pollfds
+        .iter()
+        .any(|fd| fd.revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "hidraw device disconnected",
+        ));
+    }
+    Ok(pollfds.iter().any(|fd| fd.revents & libc::POLLIN != 0))
+}
+
+fn worker_prefs(app: &tauri::AppHandle) -> Option<WorkerPrefs> {
+    let state = app.state::<AppState>();
+    let mixer = state.lock_mixer().ok()?;
+    Some(WorkerPrefs {
+        enabled: mixer.prefs.hardware_chatmix_enabled,
+        auto_switch: mixer.prefs.headset_auto_switch,
+        output: mixer.prefs.arctis_output.clone(),
+    })
+}
+
+fn balance_pair(app: &tauri::AppHandle) -> Option<(String, String)> {
+    let state = app.state::<AppState>();
+    let mixer = state.lock_mixer().ok()?;
+    let names: Vec<&str> = mixer
+        .channel_defs
+        .channels
+        .iter()
+        .map(|channel| channel.name.as_str())
+        .collect();
+    if names.len() < 2 {
+        return None;
+    }
+
+    let valid = |candidate: Option<&String>| {
+        candidate
+            .filter(|name| names.contains(&name.as_str()))
+            .cloned()
+    };
+    let mut a = valid(mixer.prefs.balance_a.as_ref());
+    let mut b = valid(mixer.prefs.balance_b.as_ref());
+    if a.is_none() {
+        a = names
+            .contains(&"sink_game")
+            .then(|| "sink_game".to_string());
+    }
+    if b.is_none() {
+        b = names
+            .contains(&"sink_chat")
+            .then(|| "sink_chat".to_string());
+    }
+    let a = a.unwrap_or_else(|| names[0].to_string());
+    let b = match b {
+        Some(candidate) if candidate != a => candidate,
+        _ => names
+            .iter()
+            .copied()
+            .find(|candidate| *candidate != a.as_str())?
+            .to_string(),
+    };
+    Some((a, b))
+}
+
+fn set_status(
+    app: &tauri::AppHandle,
+    runtime: &HardwareRuntime,
+    state: ArctisConnectionState,
+    detail: Option<String>,
+) {
+    let next = ArctisStatus { state, detail };
+    let changed = runtime
+        .status
+        .lock()
+        .map(|mut status| {
+            if *status == next {
+                false
+            } else {
+                *status = next.clone();
+                true
+            }
+        })
+        .unwrap_or(false);
+    if changed {
+        let _ = app.emit("arctis-status", next);
+    }
+}
+
+fn apply_mix(app: &tauri::AppHandle, game: u8, chat: u8) -> Result<ChatMixEvent, String> {
+    let (a, b) = balance_pair(app).ok_or_else(|| "ChatMix requires two channels".to_string())?;
+    let state = app.state::<AppState>();
+    state
+        .backend
+        .set_sink_volume(&a, game)
+        .map_err(|e| e.to_string())?;
+    state
+        .backend
+        .set_sink_volume(&b, chat)
+        .map_err(|e| e.to_string())?;
+
+    {
+        let mut mixer = state.lock_mixer()?;
+        if let Some(channel) = mixer.channel_mut(&a) {
+            channel.volume_percent = game;
+        }
+        if let Some(channel) = mixer.channel_mut(&b) {
+            channel.volume_percent = chat;
+        }
+        mixer.channel_defs.set_volume(&a, game);
+        mixer.channel_defs.set_volume(&b, chat);
+    }
+
+    let event = ChatMixEvent {
+        a,
+        b,
+        a_volume: game,
+        b_volume: chat,
+    };
+    let _ = app.emit("arctis-chatmix", &event);
+    Ok(event)
+}
+
+fn persist_mix(app: &tauri::AppHandle) {
+    let state = app.state::<AppState>();
+    let Ok(mixer) = state.lock_mixer() else {
+        return;
+    };
+    let channels = mixer.channel_defs.clone();
+    crate::commands::profiles::autosave_active(&mixer);
+    drop(mixer);
+    if let Err(e) = channels.save() {
+        eprintln!("sink: persisting hardware ChatMix volumes failed: {e}");
+    }
+}
+
+struct DebouncedPersistence<'a> {
+    app: &'a tauri::AppHandle,
+    due: Option<Instant>,
+}
+
+impl<'a> DebouncedPersistence<'a> {
+    fn new(app: &'a tauri::AppHandle) -> Self {
+        Self { app, due: None }
+    }
+
+    fn mark_dirty(&mut self) {
+        self.due = Some(Instant::now());
+    }
+
+    fn flush_if_due(&mut self) {
+        if self
+            .due
+            .is_some_and(|due| due.elapsed() >= PERSIST_DEBOUNCE)
+        {
+            persist_mix(self.app);
+            self.due = None;
+        }
+    }
+}
+
+impl Drop for DebouncedPersistence<'_> {
+    fn drop(&mut self) {
+        if self.due.is_some() {
+            persist_mix(self.app);
+        }
+    }
+}
+
+fn controlled_channels(app: &tauri::AppHandle) -> Vec<String> {
+    app.state::<AppState>()
+        .lock_mixer()
+        .map(|mixer| {
+            mixer
+                .channel_defs
+                .channels
+                .iter()
+                .map(|channel| channel.name.clone())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn apply_auto_switch(app: &tauri::AppHandle, machine: &mut AutoSwitchState, online: bool) {
+    let Some(prefs) = worker_prefs(app) else {
+        return;
+    };
+    let state = app.state::<AppState>();
+    let controlled = controlled_channels(app);
+    let current = state
+        .backend
+        .get_default_devices()
+        .ok()
+        .and_then(|(output, _)| output);
+    match machine.observe(online, prefs.auto_switch, current.as_deref(), &controlled) {
+        AutoSwitchAction::None => {}
+        AutoSwitchAction::Restore(previous) => {
+            if let Err(e) = state.backend.set_default_output(&previous) {
+                eprintln!("sink: restoring the pre-headset output failed: {e}");
+            }
+        }
+        AutoSwitchAction::Claim => {
+            let Some((a, b)) = balance_pair(app) else {
+                return;
+            };
+            let (a_output, b_output, game_channel) = {
+                let Ok(mixer) = state.lock_mixer() else {
+                    return;
+                };
+                let target = prefs.output.as_deref();
+                (
+                    target.or_else(|| mixer.outputs.get(&a)).map(str::to_string),
+                    target.or_else(|| mixer.outputs.get(&b)).map(str::to_string),
+                    mixer
+                        .channel_defs
+                        .get("sink_game")
+                        .map(|_| "sink_game".to_string())
+                        .unwrap_or_else(|| a.clone()),
+                )
+            };
+            if let Err(e) = state.backend.set_channel_output(&a, a_output.as_deref()) {
+                eprintln!("sink: activating ChatMix output for {a} failed: {e}");
+            }
+            if let Err(e) = state.backend.set_channel_output(&b, b_output.as_deref()) {
+                eprintln!("sink: activating ChatMix output for {b} failed: {e}");
+            }
+            if let Err(e) = state.backend.set_default_output(&game_channel) {
+                eprintln!("sink: setting the Game channel as default failed: {e}");
+            }
+        }
+    }
+}
+
+fn run_device_session(
+    app: &tauri::AppHandle,
+    runtime: &HardwareRuntime,
+    machine: &mut AutoSwitchState,
+    paths: &DevicePaths,
+) -> io::Result<()> {
+    let mut device = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&paths.command)?;
+    let mut listeners: Vec<File> = paths
+        .listeners
+        .iter()
+        .map(File::open)
+        .collect::<io::Result<_>>()?;
+
+    // Session/query sequence from rust-arctis-chatmix's Nova 7 definition.
+    for command in [&[0x10][..], &[0x09][..], &[0xb0][..]] {
+        write_command(&mut device, command)?;
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    set_status(
+        app,
+        runtime,
+        ArctisConnectionState::Disconnected,
+        Some("Waiting for the wireless headset status".into()),
+    );
+
+    let mut last_status = Instant::now();
+    let mut last_applied: Option<ChatMixEvent> = None;
+    let mut persistence = DebouncedPersistence::new(app);
+
+    loop {
+        let prefs = worker_prefs(app).unwrap_or(WorkerPrefs {
+            enabled: false,
+            auto_switch: false,
+            output: None,
+        });
+        if !prefs.enabled {
+            return Ok(());
+        }
+
+        if last_status.elapsed() >= STATUS_INTERVAL {
+            write_command(&mut device, &[0xb0])?;
+            last_status = Instant::now();
+        }
+        persistence.flush_if_due();
+        let fds: Vec<i32> = std::iter::once(device.as_raw_fd())
+            .chain(listeners.iter().map(AsRawFd::as_raw_fd))
+            .collect();
+        if !poll_any(&fds, SESSION_POLL_MS)? {
+            continue;
+        }
+
+        let mut newest = ParsedReport::default();
+        for reader in std::iter::once(&mut device).chain(listeners.iter_mut()) {
+            while poll_readable(reader.as_raw_fd(), 0)? {
+                let mut report = [0u8; REPORT_LEN + 1];
+                let count = reader.read(&mut report)?;
+                if count == 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "hidraw device returned EOF",
+                    ));
+                }
+                let parsed = parse_report(&report[..count]);
+                if parsed.mix.is_some() {
+                    newest.mix = parsed.mix;
+                }
+                if parsed.online.is_some() {
+                    newest.online = parsed.online;
+                }
+            }
+        }
+
+        if let Some(online) = newest.online {
+            set_status(
+                app,
+                runtime,
+                if online {
+                    ArctisConnectionState::Connected
+                } else {
+                    ArctisConnectionState::Disconnected
+                },
+                Some(if online {
+                    "Arctis Nova 7 wireless link is active".into()
+                } else {
+                    "Dongle detected; headset is powered off or out of range".into()
+                }),
+            );
+            apply_auto_switch(app, machine, online);
+        }
+
+        if let Some((game, chat)) = newest.mix {
+            let pair_changed = balance_pair(app).is_some_and(|(a, b)| {
+                last_applied
+                    .as_ref()
+                    .map_or(true, |event| event.a != a || event.b != b)
+            });
+            let values_changed = last_applied.as_ref().map_or(true, |event| {
+                event.a_volume != game || event.b_volume != chat
+            });
+            if pair_changed || values_changed {
+                match apply_mix(app, game, chat) {
+                    Ok(event) => {
+                        last_applied = Some(event);
+                        persistence.mark_dirty();
+                    }
+                    Err(e) => eprintln!("sink: applying hardware ChatMix failed: {e}"),
+                }
+            }
+        }
+    }
+}
+
+fn worker_loop(app: tauri::AppHandle, runtime: Arc<HardwareRuntime>) {
+    let mut backoff = Duration::from_secs(1);
+    let mut auto_switch = AutoSwitchState::default();
+    loop {
+        let prefs = worker_prefs(&app).unwrap_or(WorkerPrefs {
+            enabled: false,
+            auto_switch: false,
+            output: None,
+        });
+        if !prefs.enabled {
+            auto_switch.reset_observation();
+            set_status(&app, &runtime, ArctisConnectionState::Disabled, None);
+            runtime.wait(Duration::from_secs(30));
+            backoff = Duration::from_secs(1);
+            continue;
+        }
+
+        let paths = match discover() {
+            Discovery::Found(paths) => paths,
+            Discovery::Missing => {
+                apply_auto_switch(&app, &mut auto_switch, false);
+                set_status(
+                    &app,
+                    &runtime,
+                    ArctisConnectionState::Disconnected,
+                    Some("Arctis Nova 7 dongle not found".into()),
+                );
+                runtime.wait(backoff);
+                backoff = (backoff * 2).min(Duration::from_secs(30));
+                continue;
+            }
+            Discovery::Unsupported(detail) => {
+                set_status(
+                    &app,
+                    &runtime,
+                    ArctisConnectionState::Unsupported,
+                    Some(detail),
+                );
+                runtime.wait(Duration::from_secs(30));
+                continue;
+            }
+        };
+
+        match run_device_session(&app, &runtime, &mut auto_switch, &paths) {
+            Ok(()) => {
+                backoff = Duration::from_secs(1);
+            }
+            Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {
+                set_status(
+                    &app,
+                    &runtime,
+                    ArctisConnectionState::PermissionDenied,
+                    Some(format!("Cannot open {}: {e}", paths.command.display())),
+                );
+                runtime.wait(backoff);
+                backoff = (backoff * 2).min(Duration::from_secs(30));
+            }
+            Err(e) => {
+                apply_auto_switch(&app, &mut auto_switch, false);
+                set_status(
+                    &app,
+                    &runtime,
+                    ArctisConnectionState::Disconnected,
+                    Some(format!("{}: {e}", paths.command.display())),
+                );
+                runtime.wait(backoff);
+                backoff = (backoff * 2).min(Duration::from_secs(30));
+            }
+        }
+    }
+}
+
+pub fn spawn(app: tauri::AppHandle) {
+    let runtime = app.state::<AppState>().hardware.clone();
+    if let Err(e) = std::thread::Builder::new()
+        .name("arctis-chatmix".into())
+        .spawn(move || worker_loop(app, runtime))
+    {
+        eprintln!("sink: failed to start the Arctis ChatMix worker: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dial_report_maps_center_to_full_volume() {
+        assert_eq!(parse_report(&[0x45, 100, 100]).mix, Some((100, 100)));
+    }
+
+    #[test]
+    fn dial_report_maps_both_extremes() {
+        assert_eq!(parse_report(&[0x45, 100, 0]).mix, Some((100, 0)));
+        assert_eq!(parse_report(&[0x45, 0, 100]).mix, Some((0, 100)));
+    }
+
+    #[test]
+    fn status_report_carries_wireless_state_and_mix() {
+        let online = parse_report(&[0xb0, 0x03, 4, 0, 72, 100]);
+        assert_eq!(online.online, Some(true));
+        assert_eq!(online.mix, Some((72, 100)));
+        assert_eq!(
+            parse_report(&[0xb0, 0x02, 4, 0, 100, 100]).online,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn values_are_bounded_to_sink_fader_range() {
+        assert_eq!(parse_report(&[0x45, 255, 101]).mix, Some((100, 100)));
+    }
+
+    #[test]
+    fn discovery_match_is_limited_to_product_and_interface() {
+        let event = "HID_ID=0003:00001038:00002202\nHID_PHYS=usb-x/input3\n";
+        assert!(uevent_matches(event));
+        assert!(!uevent_matches(&event.replace("2202", "2206")));
+        assert!(!uevent_matches(&event.replace("input3", "input4")));
+
+        let dial = event.replace("input3", "input5");
+        assert!(listener_matches(&dial, "usb-x/input5"));
+        assert!(!listener_matches(&dial, "usb-other/input5"));
+    }
+
+    #[test]
+    fn first_observation_never_switches_outputs() {
+        let mut state = AutoSwitchState::default();
+        let controlled = vec!["sink_game".to_string(), "sink_chat".to_string()];
+        assert_eq!(
+            state.observe(true, true, Some("speakers"), &controlled),
+            AutoSwitchAction::None
+        );
+        assert_eq!(state.previous_default, None);
+    }
+
+    #[test]
+    fn disconnect_and_reconnect_claim_and_restore() {
+        let mut state = AutoSwitchState::default();
+        let controlled = vec!["sink_game".to_string(), "sink_chat".to_string()];
+        assert_eq!(
+            state.observe(false, true, Some("speakers"), &controlled),
+            AutoSwitchAction::None
+        );
+        assert_eq!(
+            state.observe(true, true, Some("speakers"), &controlled),
+            AutoSwitchAction::Claim
+        );
+        assert_eq!(state.previous_default.as_deref(), Some("speakers"));
+        assert_eq!(
+            state.observe(false, true, Some("sink_game"), &controlled),
+            AutoSwitchAction::Restore("speakers".into())
+        );
+        assert_eq!(
+            state.observe(true, true, Some("speakers"), &controlled),
+            AutoSwitchAction::Claim
+        );
+    }
+
+    #[test]
+    fn disconnect_does_not_undo_a_manual_default_change() {
+        let mut state = AutoSwitchState::default();
+        let controlled = vec!["sink_game".to_string(), "sink_chat".to_string()];
+        state.observe(false, true, Some("speakers"), &controlled);
+        state.observe(true, true, Some("speakers"), &controlled);
+        assert_eq!(
+            state.observe(false, true, Some("usb_dac"), &controlled),
+            AutoSwitchAction::None
+        );
+    }
+}

--- a/src-tauri/src/hardware/mod.rs
+++ b/src-tauri/src/hardware/mod.rs
@@ -23,7 +23,7 @@ const HID_ID: &str = "0003:00001038:00002202";
 const COMMAND_INTERFACE_SUFFIX: &str = "/input3";
 const DIAL_INTERFACE_SUFFIX: &str = "/input5";
 const REPORT_LEN: usize = 64;
-const STATUS_INTERVAL: Duration = Duration::from_secs(10);
+const STATUS_INTERVAL: Duration = Duration::from_secs(2);
 const PERSIST_DEBOUNCE: Duration = Duration::from_millis(350);
 const SESSION_POLL_MS: i32 = 250;
 
@@ -535,21 +535,19 @@ fn apply_auto_switch(app: &tauri::AppHandle, machine: &mut AutoSwitchState, onli
         AutoSwitchAction::Release(previous) => {
             // Hardware claims are deliberately transient: `Claim` changes
             // the live PipeWire links without replacing the user's saved
-            // per-channel choices. Restore those choices when the wireless
-            // link goes away, so applications stay assigned to Sink while
-            // their channels return to speakers/default routing.
-            if let Some((a, b)) = balance_pair(app) {
-                if let Ok(mixer) = state.lock_mixer() {
-                    let (a_output, b_output) = (
-                        mixer.outputs.get(&a).map(str::to_string),
-                        mixer.outputs.get(&b).map(str::to_string),
-                    );
-                    drop(mixer);
-                    if let Err(e) = state.backend.set_channel_output(&a, a_output.as_deref()) {
-                        eprintln!("sink: releasing ChatMix output for {a} failed: {e}");
-                    }
-                    if let Err(e) = state.backend.set_channel_output(&b, b_output.as_deref()) {
-                        eprintln!("sink: releasing ChatMix output for {b} failed: {e}");
+            // per-channel choices. Restore every channel on disconnect, not
+            // just the current Balance pair: a channel that used to be A/B
+            // must not retain a stale headset target after the pair changes.
+            let saved_outputs = state.lock_mixer().map(|mixer| {
+                controlled
+                    .iter()
+                    .map(|name| (name.clone(), mixer.outputs.get(name).map(str::to_string)))
+                    .collect::<Vec<_>>()
+            });
+            if let Ok(saved_outputs) = saved_outputs {
+                for (name, output) in saved_outputs {
+                    if let Err(e) = state.backend.set_channel_output(&name, output.as_deref()) {
+                        eprintln!("sink: releasing ChatMix output for {name} failed: {e}");
                     }
                 }
             }

--- a/src-tauri/src/hardware/mod.rs
+++ b/src-tauri/src/hardware/mod.rs
@@ -113,7 +113,7 @@ struct WorkerPrefs {
 enum AutoSwitchAction {
     None,
     Claim,
-    Restore(String),
+    Release(Option<String>),
 }
 
 /// Pure transition state: no first-sample action and no shutdown action.
@@ -157,9 +157,11 @@ impl AutoSwitchState {
             let restore = current_default
                 .filter(|name| controlled.iter().any(|candidate| candidate == name))
                 .and_then(|_| self.previous_default.take());
-            restore
-                .map(AutoSwitchAction::Restore)
-                .unwrap_or(AutoSwitchAction::None)
+            // Always release the temporary Balance A/B output claim. The
+            // previous system default is optional because a manual default
+            // change must still be preserved.
+            self.previous_default = None;
+            AutoSwitchAction::Release(restore)
         }
     }
 }
@@ -530,9 +532,31 @@ fn apply_auto_switch(app: &tauri::AppHandle, machine: &mut AutoSwitchState, onli
         .and_then(|(output, _)| output);
     match machine.observe(online, prefs.auto_switch, current.as_deref(), &controlled) {
         AutoSwitchAction::None => {}
-        AutoSwitchAction::Restore(previous) => {
-            if let Err(e) = state.backend.set_default_output(&previous) {
-                eprintln!("sink: restoring the pre-headset output failed: {e}");
+        AutoSwitchAction::Release(previous) => {
+            // Hardware claims are deliberately transient: `Claim` changes
+            // the live PipeWire links without replacing the user's saved
+            // per-channel choices. Restore those choices when the wireless
+            // link goes away, so applications stay assigned to Sink while
+            // their channels return to speakers/default routing.
+            if let Some((a, b)) = balance_pair(app) {
+                if let Ok(mixer) = state.lock_mixer() {
+                    let (a_output, b_output) = (
+                        mixer.outputs.get(&a).map(str::to_string),
+                        mixer.outputs.get(&b).map(str::to_string),
+                    );
+                    drop(mixer);
+                    if let Err(e) = state.backend.set_channel_output(&a, a_output.as_deref()) {
+                        eprintln!("sink: releasing ChatMix output for {a} failed: {e}");
+                    }
+                    if let Err(e) = state.backend.set_channel_output(&b, b_output.as_deref()) {
+                        eprintln!("sink: releasing ChatMix output for {b} failed: {e}");
+                    }
+                }
+            }
+            if let Some(previous) = previous {
+                if let Err(e) = state.backend.set_default_output(&previous) {
+                    eprintln!("sink: restoring the pre-headset output failed: {e}");
+                }
             }
         }
         AutoSwitchAction::Claim => {
@@ -820,7 +844,7 @@ mod tests {
     }
 
     #[test]
-    fn disconnect_and_reconnect_claim_and_restore() {
+    fn disconnect_and_reconnect_claim_and_release() {
         let mut state = AutoSwitchState::default();
         let controlled = vec!["sink_game".to_string(), "sink_chat".to_string()];
         assert_eq!(
@@ -834,7 +858,7 @@ mod tests {
         assert_eq!(state.previous_default.as_deref(), Some("speakers"));
         assert_eq!(
             state.observe(false, true, Some("sink_game"), &controlled),
-            AutoSwitchAction::Restore("speakers".into())
+            AutoSwitchAction::Release(Some("speakers".into()))
         );
         assert_eq!(
             state.observe(true, true, Some("speakers"), &controlled),
@@ -843,14 +867,14 @@ mod tests {
     }
 
     #[test]
-    fn disconnect_does_not_undo_a_manual_default_change() {
+    fn disconnect_releases_channels_without_undoing_a_manual_default_change() {
         let mut state = AutoSwitchState::default();
         let controlled = vec!["sink_game".to_string(), "sink_chat".to_string()];
         state.observe(false, true, Some("speakers"), &controlled);
         state.observe(true, true, Some("speakers"), &controlled);
         assert_eq!(
             state.observe(false, true, Some("usb_dac"), &controlled),
-            AutoSwitchAction::None
+            AutoSwitchAction::Release(None)
         );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod audio;
 mod commands;
 mod error;
+mod hardware;
 mod mixer;
 mod persistence;
 mod state;
@@ -118,6 +119,10 @@ pub fn run() {
             commands::settings::set_balance_channels,
             commands::settings::set_balance_visible,
             commands::settings::set_start_minimized,
+            commands::settings::set_hardware_chatmix_enabled,
+            commands::settings::set_headset_auto_switch,
+            commands::settings::set_arctis_output,
+            commands::settings::get_arctis_status,
             commands::settings::reset_app,
         ])
         .setup(move |app| {
@@ -134,6 +139,7 @@ pub fn run() {
                 spawn_level_emitter(app.handle().clone(), levels);
             }
             spawn_route_enforcer(app.handle().clone());
+            hardware::spawn(app.handle().clone());
             Ok(())
         })
         // Close button hides to tray instead of quitting - main window

--- a/src-tauri/src/persistence/prefs.rs
+++ b/src-tauri/src/persistence/prefs.rs
@@ -39,6 +39,18 @@ pub struct Prefs {
     /// showing the window (only meaningful with autostart enabled).
     #[serde(default)]
     pub start_minimized: bool,
+    /// Read the physical ChatMix dial from a SteelSeries Arctis Nova 7 Gen 1.
+    /// Off by default because hidraw access requires an explicitly installed
+    /// device-scoped udev rule.
+    #[serde(default)]
+    pub hardware_chatmix_enabled: bool,
+    /// Switch the system default only on confirmed wireless state changes.
+    #[serde(default)]
+    pub headset_auto_switch: bool,
+    /// Optional shared destination for the two Balance channels. None keeps
+    /// each channel's existing output selection.
+    #[serde(default)]
+    pub arctis_output: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -54,6 +66,9 @@ impl Default for Prefs {
             balance_b: None,
             show_balance: true,
             start_minimized: false,
+            hardware_chatmix_enabled: false,
+            headset_auto_switch: false,
+            arctis_output: None,
         }
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -14,6 +14,9 @@ pub struct AppState {
     /// already polling (see `lib::spawn_route_enforcer`).
     ui_stream_poll: Mutex<Option<Instant>>,
     pub refresh_gate: Mutex<()>,
+    /// Long-lived hardware worker state. The worker itself is spawned during
+    /// Tauri setup and remains active while the app is hidden in the tray.
+    pub hardware: Arc<crate::hardware::HardwareRuntime>,
 }
 
 impl AppState {
@@ -80,6 +83,7 @@ impl AppState {
             mixer: Mutex::new(mixer),
             ui_stream_poll: Mutex::new(None),
             refresh_gate: Mutex::new(()),
+            hardware: Arc::new(crate::hardware::HardwareRuntime::default()),
         }
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -48,7 +48,10 @@
           "pulseaudio-utils",
           "pipewire-pulse",
           "wireplumber"
-        ]
+        ],
+        "files": {
+          "/usr/lib/udev/rules.d/70-sink-arctis-nova7.rules": "../packaging/70-sink-arctis-nova7.rules"
+        }
       },
       "rpm": {
         "depends": [

--- a/src/components/Settings/SettingsScreen.tsx
+++ b/src/components/Settings/SettingsScreen.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getVersion } from "@tauri-apps/api/app";
+import { listen } from "@tauri-apps/api/event";
 import { useMixerStore } from "../../store/mixer";
 import { useTheme, THEMES } from "../../store/theme";
-import type { OutputDevice } from "../../types";
+import type { OutputDevice, VirtualSink } from "../../types";
 import { Ms } from "../Icons";
 import { ConfirmModal } from "../ConfirmModal";
 import { MenuItem } from "../MenuItem";
@@ -16,6 +17,17 @@ interface DefaultDevices {
 }
 
 type LabelStyle = "plain" | "suffix" | "prefix";
+type ArctisConnectionState =
+  | "disabled"
+  | "connected"
+  | "disconnected"
+  | "permission_denied"
+  | "unsupported";
+
+interface ArctisStatus {
+  state: ArctisConnectionState;
+  detail: string | null;
+}
 
 const LABEL_STYLES: { value: LabelStyle; label: string; example: string }[] = [
   { value: "plain", label: "Plain", example: "Game" },
@@ -78,6 +90,133 @@ function DeviceRow({
   );
 }
 
+function ArctisOutputRow({
+  devices,
+  current,
+  onPick,
+}: Readonly<{
+  devices: OutputDevice[];
+  current: string | null;
+  onPick: (name: string | null) => void;
+}>) {
+  const [open, setOpen] = useState(false);
+  const label = current
+    ? devices.find((device) => device.name === current)?.description ?? current
+    : "Use each channel's output";
+  return (
+    <div className="row row-sub">
+      <div className="ricon"><Ms name="speaker_group" /></div>
+      <div className="rmain">
+        <div className="rtitle">Headset output</div>
+        <div className="rsub">Physical Arctis or Easy Effects; keep Easy Effects' output physical to avoid a loop</div>
+      </div>
+      <div style={{ position: "relative" }}>
+        <button type="button" className="select device-select" onClick={() => setOpen((value) => !value)}>
+          <span className="device-select-name">{label}</span>
+          <Ms name="expand_more" />
+        </button>
+        <Popover open={open} onClose={() => setOpen(false)} side="bottom" align="end">
+          <MenuItem
+            icon="alt_route"
+            selected={current === null}
+            showCheck
+            onClick={() => {
+              onPick(null);
+              setOpen(false);
+            }}
+          >
+            Use each channel's output
+          </MenuItem>
+          {devices.map((device) => (
+            <MenuItem
+              key={device.name}
+              icon="speaker"
+              selected={device.name === current}
+              showCheck
+              onClick={() => {
+                onPick(device.name);
+                setOpen(false);
+              }}
+            >
+              {device.description}
+            </MenuItem>
+          ))}
+        </Popover>
+      </div>
+    </div>
+  );
+}
+
+function BalanceChannelsRow({
+  channels,
+  aName,
+  bName,
+  onPick,
+}: Readonly<{
+  channels: VirtualSink[];
+  aName: string | null;
+  bName: string | null;
+  onPick: (a: string, b: string) => void;
+}>) {
+  const [open, setOpen] = useState<"a" | "b" | null>(null);
+  const find = (name: string | null) => channels.find((channel) => channel.name === name);
+  const a = find(aName) ?? find("sink_game") ?? channels[0];
+  const b = find(bName) ?? find("sink_chat") ?? channels.find((channel) => channel.name !== a?.name);
+  if (!a || !b) return null;
+
+  const picker = (side: "a" | "b", selected: VirtualSink, other: VirtualSink) => (
+    <div style={{ position: "relative" }}>
+      <button type="button" className="select" onClick={() => setOpen(open === side ? null : side)}>
+        <span>{selected.label}</span>
+        <Ms name="expand_more" />
+      </button>
+      <Popover open={open === side} onClose={() => setOpen(null)} side="bottom" align="end">
+        {channels.filter((channel) => channel.name !== other.name).map((channel) => (
+          <MenuItem
+            key={channel.name}
+            icon={channel.icon ?? "graphic_eq"}
+            selected={channel.name === selected.name}
+            showCheck
+            onClick={() => {
+              onPick(
+                side === "a" ? channel.name : a.name,
+                side === "b" ? channel.name : b.name,
+              );
+              setOpen(null);
+            }}
+          >
+            {channel.label}
+          </MenuItem>
+        ))}
+      </Popover>
+    </div>
+  );
+
+  return (
+    <div className="row row-sub">
+      <div className="ricon"><Ms name="balance" /></div>
+      <div className="rmain">
+        <div className="rtitle">Wheel channels</div>
+        <div className="rsub">The same Balance A/B pair used by the title-bar slider</div>
+      </div>
+      <div style={{ display: "flex", gap: "var(--sp-2)" }}>
+        {picker("a", a, b)}
+        {picker("b", b, a)}
+      </div>
+    </div>
+  );
+}
+
+function arctisStateLabel(state: ArctisConnectionState): string {
+  switch (state) {
+    case "connected": return "Connected";
+    case "disconnected": return "Disconnected";
+    case "permission_denied": return "Permission denied";
+    case "unsupported": return "Unsupported";
+    default: return "Disabled";
+  }
+}
+
 function engineDesc(native: boolean | null): string {
   if (native === null) return "…";
   return native
@@ -96,24 +235,75 @@ export function SettingsScreen() {
   const [labelStyleOpen, setLabelStyleOpen] = useState(false);
   const [confirmingReset, setConfirmingReset] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [hardwareChatMix, setHardwareChatMix] = useState(false);
+  const [headsetAutoSwitch, setHeadsetAutoSwitch] = useState(false);
+  const [arctisOutput, setArctisOutput] = useState<string | null>(null);
+  const [arctisStatus, setArctisStatus] = useState<ArctisStatus>({
+    state: "disabled",
+    detail: null,
+  });
+  const channels = useMixerStore((s) => s.channels);
   const outputDevices = useMixerStore((s) => s.outputDevices);
   const inputDevices = useMixerStore((s) => s.inputDevices);
   const replayOnboarding = useMixerStore((s) => s.replayOnboarding);
   const showBalance = useMixerStore((s) => s.showBalance);
   const setBalanceVisible = useMixerStore((s) => s.setBalanceVisible);
+  const balanceA = useMixerStore((s) => s.balanceA);
+  const balanceB = useMixerStore((s) => s.balanceB);
+  const setBalanceChannels = useMixerStore((s) => s.setBalanceChannels);
 
   useEffect(() => {
     void invoke<boolean>("get_autostart").then(setAutostart);
     void invoke<{ native: boolean }>("get_backend_info").then((i) => setBackendNative(i.native));
     void invoke<DefaultDevices>("get_default_devices").then(setDefaults).catch(() => {});
-    void invoke<{ device_label_style: LabelStyle; start_minimized: boolean }>("get_prefs")
+    void invoke<{
+      device_label_style: LabelStyle;
+      start_minimized: boolean;
+      hardware_chatmix_enabled: boolean;
+      headset_auto_switch: boolean;
+      arctis_output: string | null;
+    }>("get_prefs")
       .then((p) => {
         setLabelStyle(p.device_label_style);
         setStartMinimized(p.start_minimized);
+        setHardwareChatMix(p.hardware_chatmix_enabled);
+        setHeadsetAutoSwitch(p.headset_auto_switch);
+        setArctisOutput(p.arctis_output);
       })
       .catch(() => {});
+    void invoke<ArctisStatus>("get_arctis_status").then(setArctisStatus).catch(() => {});
+    const unlisten = listen<ArctisStatus>("arctis-status", (event) => {
+      setArctisStatus(event.payload);
+    });
     void getVersion().then(setVersion);
+    return () => {
+      void unlisten.then((fn) => fn());
+    };
   }, []);
+
+  const setHardwarePreference = async (
+    command: "set_hardware_chatmix_enabled" | "set_headset_auto_switch",
+    enabled: boolean,
+  ) => {
+    try {
+      await invoke(command, { enabled });
+      if (command === "set_hardware_chatmix_enabled") setHardwareChatMix(enabled);
+      else setHeadsetAutoSwitch(enabled);
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const pickArctisOutput = async (output: string | null) => {
+    try {
+      await invoke("set_arctis_output", { output });
+      setArctisOutput(output);
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    }
+  };
 
   const pickDefault = async (kind: "output" | "input", name: string) => {
     try {
@@ -280,6 +470,53 @@ export function SettingsScreen() {
               />
             </div>
           )}
+        </div>
+
+        <div className="section-label">SteelSeries Arctis Nova 7</div>
+        <div className="card" style={{ padding: "var(--sp-2)" }}>
+          <div className="row">
+            <div className="ricon"><Ms name="headphones" /></div>
+            <div className="rmain">
+              <div className="rtitle">Hardware ChatMix</div>
+              <div className="rsub">Read the physical wheel through the scoped hidraw interface</div>
+            </div>
+            <Toggle
+              on={hardwareChatMix}
+              onClick={() => void setHardwarePreference("set_hardware_chatmix_enabled", !hardwareChatMix)}
+            />
+          </div>
+          <div className="row row-sub">
+            <div className="ricon"><Ms name="sensors" /></div>
+            <div className="rmain">
+              <div className="rtitle">Headset status</div>
+              <div className="rsub">{arctisStatus.detail ?? "Hardware monitoring is off"}</div>
+            </div>
+            <span className={"tag" + (arctisStatus.state === "connected" ? " live" : "")}>
+              {arctisStateLabel(arctisStatus.state)}
+            </span>
+          </div>
+          <BalanceChannelsRow
+            channels={channels}
+            aName={balanceA}
+            bName={balanceB}
+            onPick={(a, b) => void setBalanceChannels(a, b)}
+          />
+          <ArctisOutputRow
+            devices={outputDevices}
+            current={arctisOutput}
+            onPick={(output) => void pickArctisOutput(output)}
+          />
+          <div className="row row-sub">
+            <div className="ricon"><Ms name="swap_horiz" /></div>
+            <div className="rmain">
+              <div className="rtitle">Headset auto-switch</div>
+              <div className="rsub">On wireless connect, use Game; on disconnect, restore only if Sink still owns the default</div>
+            </div>
+            <Toggle
+              on={headsetAutoSwitch}
+              onClick={() => void setHardwarePreference("set_headset_auto_switch", !headsetAutoSwitch)}
+            />
+          </div>
         </div>
 
         <div className="section-label">About</div>

--- a/src/components/Settings/SettingsScreen.tsx
+++ b/src/components/Settings/SettingsScreen.tsx
@@ -510,7 +510,7 @@ export function SettingsScreen() {
             <div className="ricon"><Ms name="swap_horiz" /></div>
             <div className="rmain">
               <div className="rtitle">Headset auto-switch</div>
-              <div className="rsub">On wireless connect, use Game; on disconnect, restore only if Sink still owns the default</div>
+              <div className="rsub">On connect, route Balance A/B to the headset; on disconnect, return them to their saved outputs</div>
             </div>
             <Toggle
               on={headsetAutoSwitch}

--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
-import { useMixerStore, type Levels } from "../store/mixer";
+import {
+  useMixerStore,
+  type HardwareChatMixEvent,
+  type Levels,
+} from "../store/mixer";
 
 const POLL_INTERVAL_MS = 2000;
 
@@ -16,6 +20,7 @@ export function useAudio() {
   const fetchOutputs = useMixerStore((s) => s.fetchOutputs);
   const fetchSeenApps = useMixerStore((s) => s.fetchSeenApps);
   const setLevels = useMixerStore((s) => s.setLevels);
+  const applyHardwareChatMix = useMixerStore((s) => s.applyHardwareChatMix);
   const outputDevices = useMixerStore((s) => s.outputDevices);
   const profiles = useMixerStore((s) => s.profiles);
   const loadProfile = useMixerStore((s) => s.loadProfile);
@@ -59,6 +64,18 @@ export function useAudio() {
       void unlisten.then((fn) => fn());
     };
   }, [setLevels]);
+
+  // Hardware reports already changed PipeWire and Rust's in-memory model.
+  // Mirror them locally without calling setChannelVolume, which would send
+  // the same update back through IPC and create redundant work.
+  useEffect(() => {
+    const unlisten = listen<HardwareChatMixEvent>("arctis-chatmix", (event) => {
+      applyHardwareChatMix(event.payload);
+    });
+    return () => {
+      void unlisten.then((fn) => fn());
+    };
+  }, [applyHardwareChatMix]);
 
   // Profile switched from the tray menu - sync the whole UI.
   const onProfileChanged = useMixerStore((s) => s.onProfileChanged);

--- a/src/store/mixer.ts
+++ b/src/store/mixer.ts
@@ -30,6 +30,13 @@ function debouncedInvoke(key: string, cmd: string, args: Record<string, unknown>
 /** Per-sink [left, right] peak amplitudes (0-1), streamed from the native backend. */
 export type Levels = Record<string, [number, number]>;
 
+export interface HardwareChatMixEvent {
+  a: string;
+  b: string;
+  a_volume: number;
+  b_volume: number;
+}
+
 interface MixerStore {
   channels: VirtualSink[];
   appStreams: AppStream[];
@@ -139,6 +146,8 @@ interface MixerStore {
   setBalanceChannels: (a: string | null, b: string | null) => Promise<void>;
   showBalance: boolean;
   setBalanceVisible: (visible: boolean) => Promise<void>;
+  /** Reflect a backend-originated dial event without invoking Rust again. */
+  applyHardwareChatMix: (event: HardwareChatMixEvent) => void;
 
   /** Create the virtual sinks and load initial state. */
   initialize: () => Promise<void>;
@@ -216,6 +225,16 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
     } catch (e) {
       set({ error: String(e) });
     }
+  },
+
+  applyHardwareChatMix: (event) => {
+    set((s) => ({
+      channels: s.channels.map((channel) => {
+        if (channel.name === event.a) return { ...channel, volume_percent: event.a_volume };
+        if (channel.name === event.b) return { ...channel, volume_percent: event.b_volume };
+        return channel;
+      }),
+    }));
   },
 
   finishOnboarding: async (blank) => {


### PR DESCRIPTION
## Summary

- add opt-in HID/hidraw support for the SteelSeries Arctis Nova 7 Gen 1 (`1038:2202`)
- drive Sink's existing Balance A/B volumes from the physical ChatMix wheel, with debounced persistence
- detect the real wireless headset state and optionally switch the selected Balance channels between a configured headset destination and their saved outputs
- preserve manual default-output changes and avoid switching on the worker's initial state observation
- expose hardware enablement, auto-switch, destination, and connection status in Settings
- Package a udev rule limited to the Nova 7 (1038:2202) so the active desktop user can access its hidraw interfaces without running Sink as root, and document the protocol sources and safe Easy Effects routing.
- keep native PipeWire meters pinned to their own channels so WirePlumber cannot reconnect a meter to the current default output (little fix on the original code)

Both hardware ChatMix and headset auto-switch are disabled by default. The implementation runs in Sink's existing backend process and does not require a root daemon or modify stored headset settings.

## Automated validation

- `npm test`: 16 passed
- `npm run build`: passed
- `cargo test --manifest-path src-tauri/Cargo.toml`: 142 passed
- `cargo check --manifest-path src-tauri/Cargo.toml`: passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: passed
- `npm run tauri build -- --bundles deb`: passed; produced `sink_0.1.0_amd64.deb`

The Rust tests cover wheel center and both extremes, report clamping, device/interface matching, initial-observation safety, disconnect/reconnect, and preservation of a manual default-output change.

## Physical validation

Tested on:

- SteelSeries Arctis Nova 7 Gen 1, USB `1038:2202`
- Ubuntu 26.04.1, KDE Plasma 6.6.6 Wayland
- PipeWire/WirePlumber 1.6.2

Verified:

- the physical wheel updates the configured Balance channels and the UI
- application-to-channel assignments work after restarting Sink
- wireless on/off transitions switch between the Arctis and the laptop speakers
- all saved channel destinations are restored on headset disconnect
- a manual physical default-output change is not overwritten

## Scope and attribution

Protocol framing and device offsets are adapted from GPL-3.0-only `rdamron/rust-arctis-chatmix`, with attribution in `docs/STEELSERIES_CHATMIX.md`. Support is intentionally scoped to the tested Nova 7 Gen 1 VID:PID and does not add unrelated SteelSeries Sonar features.
