### PR TITLE
fix(audio): pin meters to their channels

### DIFF
--- a/src-tauri/src/audio/pw_native/meter.rs
+++ b/src-tauri/src/audio/pw_native/meter.rs
@@ -46,6 +46,12 @@ impl MeterHandle {
             "node.name" => format!("{METER_PREFIX}{sink_name}"),
             // For sinks: capture the monitor, don't keep the sink busy.
             "stream.capture.sink" => if capture_sink { "true" } else { "false" },
+            // Pin the meter to the channel it represents. Without an
+            // explicit target WirePlumber may move the first-created meter
+            // to a newly selected default device, making (for example) Game
+            // display the combined speaker output instead of Game itself.
+            "target.object" => sink_name,
+            "node.dont-reconnect" => "true",
             "node.passive" => "true",
         };
         let stream = pw::stream::StreamRc::new(core.clone(), "sink-meter", props)
@@ -98,7 +104,9 @@ impl MeterHandle {
             .connect(
                 spa::utils::Direction::Input,
                 Some(sink_id),
-                pw::stream::StreamFlags::AUTOCONNECT | pw::stream::StreamFlags::MAP_BUFFERS,
+                pw::stream::StreamFlags::AUTOCONNECT
+                    | pw::stream::StreamFlags::DONT_RECONNECT
+                    | pw::stream::StreamFlags::MAP_BUFFERS,
                 &mut params,
             )
             .map_err(|e| err("connect", e))?;


### PR DESCRIPTION
This is the meter fix from #49, pulled out on its own so it can land for everyone. The commit is still @Mocolax's, he found it and wrote the fix, I just split it out.

So each channel has a small capture stream that listens to the channel so the VU bar can move. Currently it's connected with a one time target hint and left as reconnectable, which wireplumber reads as "feel free to move this when the default output changes". Meaning when the default flips from one of our channels to a real device, say a dongle or an HDMI display showing up, wireplumber quietly moves the first meter onto the speakers. Game's bar then shows everything coming out of the speakers instead of Game. Nothing errors, the bar just lies.

The fix sets `target.object` to the channel by name and marks the stream `dont-reconnect`, which is basically the same pinning the mic and EQ inserts already use.

I reproduced it on an isolated pipewire instance before and after:

- default goes channel -> real device: main moves the Game meter, fixed stays put
- device disappears then comes back as default: same, main moves it, fixed stays put
- channel destroyed and healed, device vanishing: fine on both, since the loop already recreates meters when a node goes away, so dont-reconnect can't strand one

134 tests and clippy pass on the isolated commit.
