### PR TITLE
feat(audio): support comma as decimal separator in eq presets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -474,9 +474,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -494,9 +491,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -514,9 +508,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -534,9 +525,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -554,9 +542,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -574,9 +559,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2537,9 +2519,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2561,9 +2540,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2585,9 +2561,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2609,9 +2582,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -474,6 +474,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -491,6 +494,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -508,6 +514,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -525,6 +534,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -542,6 +554,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -559,6 +574,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2519,6 +2537,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2540,6 +2561,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2561,6 +2585,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2582,6 +2609,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src-tauri/src/audio/eq_import.rs
+++ b/src-tauri/src/audio/eq_import.rs
@@ -30,7 +30,7 @@ fn value_after(tokens: &[&str], label: &str) -> Option<f32> {
         .iter()
         .position(|t| t.eq_ignore_ascii_case(label))
         .and_then(|i| tokens.get(i + 1))
-        .and_then(|v| v.parse().ok())
+        .and_then(|v| v.replace(',', ".").parse().ok())
 }
 
 fn parse_filter_line(line: &str) -> Option<EqBand> {
@@ -71,7 +71,7 @@ pub fn parse_autoeq(text: &str) -> Result<EqConfig, SinkError> {
                 .split(':')
                 .nth(1)
                 .and_then(|rest| rest.split_whitespace().next())
-                .and_then(|v| v.parse::<f32>().ok())
+                .and_then(|v| v.replace(',', ".").parse::<f32>().ok())
             {
                 preamp_db = v;
             }
@@ -100,6 +100,21 @@ pub fn parse_autoeq(text: &str) -> Result<EqConfig, SinkError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_comma_separated_values() {
+        let config = parse_autoeq(
+            "Preamp: -3,7 dB\nFilter 1: ON PK Fc 195 Hz Gain -7,3 dB Q 0,5\n",
+        )
+        .expect("parses");
+        assert_eq!(config.preamp_db, -3.7);
+        assert_eq!(config.bands.len(), 1);
+        let b = &config.bands[0];
+        assert_eq!(b.kind, EqBandKind::Peaking);
+        assert_eq!(b.freq_hz, 195.0);
+        assert_eq!(b.gain_db, -7.3);
+        assert_eq!(b.q, 0.5);
+    }
 
     #[test]
     fn parses_preamp_and_peaking_filter() {


### PR DESCRIPTION
### Description
This PR adds support for parsing comma-separated decimal values (e.g., `-8,7`) when importing Equalizer APO presets.

### Why is this needed?
Some popular databases of equalizer profiles, such as the [Tal0na/Equalizer-Profiles](https://github.com/Tal0na/Equalizer-Profiles) repository, contain presets that use commas instead of dots as decimal separators, depending on the locale of the original export. 

Previously, importing these specific presets would fail or ignore the comma values. With this change, users can seamlessly import these profiles without having to manually replace commas with dots.

### How was this implemented?
- Updated `value_after` and `parse_autoeq` to use `.replace(',', ".")` right before parsing the string into an `f32`.
- This approach is entirely safe and backwards-compatible. It preserves the existing logic for standard profiles (with dots) and successfully converts European/Brazilian formatted numbers.
- Added a unit test `parses_comma_separated_values` to ensure both `Preamp` and `Filter` lines parse correctly when containing commas.
