### PR TITLE
feat(hotkeys): global hotkeys for profiles and the balance slider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3290,6 +3290,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-single-instance",
  "thiserror 2.0.20",
+ "tokio",
 ]
 
 [[package]]
@@ -3974,8 +3975,20 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "ashpd"
+version = "0.13.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8421aaa9644a5faf26735f258b669b15f063313ef8f8e2bdb28912a1a6f111"
+dependencies = [
+ "enumflags2",
+ "futures-util",
+ "getrandom 0.4.3",
+ "serde",
+ "tokio",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,6 +1308,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1435,23 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "thiserror 2.0.20",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -3237,7 +3278,10 @@ checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 name = "sink"
 version = "0.1.0"
 dependencies = [
+ "ashpd",
  "dirs",
+ "futures-util",
+ "global-hotkey",
  "pipewire",
  "serde",
  "serde_json",
@@ -3928,7 +3972,9 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -5067,6 +5113,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5114,6 +5183,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",

--- a/packaging/linux/us.echo.Sink.desktop
+++ b/packaging/linux/us.echo.Sink.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=Sink
+Comment=Linux-native audio routing and mixing for PipeWire
+Exec=sink
+Icon=sink
+StartupWMClass=sink
+NoDisplay=true

--- a/packaging/linux/us.echo.Sink.desktop
+++ b/packaging/linux/us.echo.Sink.desktop
@@ -4,5 +4,4 @@ Name=Sink
 Comment=Linux-native audio routing and mixing for PipeWire
 Exec=sink
 Icon=sink
-StartupWMClass=sink
 NoDisplay=true

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,3 +30,4 @@ pipewire = { git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs", rev = 
 ashpd = { version = "0.13", default-features = false, features = ["tokio", "global_shortcuts"] }
 global-hotkey = "0.8"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
+tokio = { version = "1", default-features = false, features = ["macros", "time"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,3 +26,7 @@ dirs = "6"
 # 0.8.0 on crates.io predates PipeWire 1.6 headers (libspa bindgen breaks);
 # git main carries the header fixes. v0_3_49 gates Buffer::requested().
 pipewire = { git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs", rev = "v0.10.0", features = ["v0_3_49"] }
+# Global hotkeys: the XDG portal on Wayland, direct X11 grabs as the fallback.
+ashpd = { version = "0.13", default-features = false, features = ["tokio", "global_shortcuts"] }
+global-hotkey = "0.8"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }

--- a/src-tauri/src/commands/hotkeys.rs
+++ b/src-tauri/src/commands/hotkeys.rs
@@ -1,0 +1,68 @@
+use tauri::{AppHandle, Manager};
+
+use crate::hotkeys::{Action, Backend, HotkeyStatus, Hotkeys, ShortcutInfo};
+use crate::persistence::hotkeys::BALANCE_STEPS;
+
+#[tauri::command]
+pub async fn get_hotkeys(app: AppHandle) -> Result<HotkeyStatus, String> {
+    let hotkeys = app.state::<Hotkeys>();
+    let config = hotkeys.config();
+    let backend = hotkeys.backend();
+    let shortcuts: Vec<ShortcutInfo> = match &backend {
+        Backend::Portal(handle) => crate::hotkeys::portal::shortcuts(handle).await?,
+        Backend::X11(handle) => handle.shortcuts(&config),
+        Backend::None => Vec::new(),
+    };
+    Ok(HotkeyStatus {
+        backend: backend.name(),
+        shortcuts,
+        balance_step: config.balance_step,
+        steps: BALANCE_STEPS,
+    })
+}
+
+/// Portal: the desktop's binding dialog. X11 binds through set_hotkey_binding.
+#[tauri::command]
+pub async fn configure_hotkeys(app: AppHandle) -> Result<(), String> {
+    match app.state::<Hotkeys>().backend() {
+        Backend::Portal(handle) => crate::hotkeys::portal::configure(&handle).await,
+        Backend::X11(_) => Err("bindings are edited per shortcut on X11".into()),
+        Backend::None => Err("global hotkeys are not available on this desktop".into()),
+    }
+}
+
+#[tauri::command]
+pub fn set_hotkey_binding(app: AppHandle, id: String, trigger: String) -> Result<(), String> {
+    let action = Action::from_id(&id).ok_or_else(|| format!("unknown hotkey: {id}"))?;
+    let hotkeys = app.state::<Hotkeys>();
+    let Backend::X11(handle) = hotkeys.backend() else {
+        return Err("bindings are edited in the desktop's settings here".into());
+    };
+    handle.bind(action, &trigger)?;
+    let config = {
+        let mut config = hotkeys
+            .config
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        config.bindings.insert(id, trigger);
+        config.clone()
+    };
+    config.save().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn set_balance_step(app: AppHandle, step: u8) -> Result<(), String> {
+    if !BALANCE_STEPS.contains(&step) {
+        return Err(format!("unsupported balance step: {step}"));
+    }
+    let hotkeys = app.state::<Hotkeys>();
+    let config = {
+        let mut config = hotkeys
+            .config
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        config.balance_step = step;
+        config.clone()
+    };
+    config.save().map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/hotkeys.rs
+++ b/src-tauri/src/commands/hotkeys.rs
@@ -10,7 +10,7 @@ pub async fn get_hotkeys(app: AppHandle) -> Result<HotkeyStatus, String> {
     let backend = hotkeys.backend();
     let shortcuts: Vec<ShortcutInfo> = match &backend {
         Backend::Portal(handle) => crate::hotkeys::portal::shortcuts(handle).await?,
-        Backend::X11(handle) => handle.shortcuts(&config),
+        Backend::X11(handle) => handle.shortcuts(),
         Backend::None => Vec::new(),
     };
     Ok(HotkeyStatus {
@@ -39,15 +39,12 @@ pub fn set_hotkey_binding(app: AppHandle, id: String, trigger: String) -> Result
         return Err("bindings are edited in the desktop's settings here".into());
     };
     handle.bind(action, &trigger)?;
-    let config = {
-        let mut config = hotkeys
-            .config
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        config.bindings.insert(id, trigger);
-        config.clone()
-    };
-    config.save().map_err(|e| e.to_string())
+    hotkeys
+        .update_config(|c| {
+            c.bindings.insert(id, trigger);
+        })
+        .save()
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -55,14 +52,8 @@ pub fn set_balance_step(app: AppHandle, step: u8) -> Result<(), String> {
     if !BALANCE_STEPS.contains(&step) {
         return Err(format!("unsupported balance step: {step}"));
     }
-    let hotkeys = app.state::<Hotkeys>();
-    let config = {
-        let mut config = hotkeys
-            .config
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        config.balance_step = step;
-        config.clone()
-    };
-    config.save().map_err(|e| e.to_string())
+    app.state::<Hotkeys>()
+        .update_config(|c| c.balance_step = step)
+        .save()
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod buses;
 pub mod channels;
 pub mod devices;
 pub mod eq;
+pub mod hotkeys;
 pub mod mic;
 pub mod profiles;
 pub mod routing;

--- a/src-tauri/src/commands/profiles.rs
+++ b/src-tauri/src/commands/profiles.rs
@@ -81,6 +81,12 @@ pub fn load_profile(
     state: State<'_, AppState>,
     name: String,
 ) -> Result<(), String> {
+    // A tray click, a hotkey and the UI can all land here at once; the
+    // reconcile below reads and writes the mixer in several steps.
+    let _switching = state
+        .profile_switch
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let profile = profiles::load(&name).map_err(|e| e.to_string())?;
     if profile.channels.is_empty() {
         return Err(format!("profile {name} has no channels"));

--- a/src-tauri/src/hotkeys/mod.rs
+++ b/src-tauri/src/hotkeys/mod.rs
@@ -12,7 +12,7 @@ use tauri::{AppHandle, Emitter, Manager};
 use crate::persistence::hotkeys::HotkeyConfig;
 use crate::state::AppState;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Action {
     ProfileNext,
     ProfilePrev,
@@ -119,12 +119,21 @@ pub struct Hotkeys {
     config: Mutex<HotkeyConfig>,
     /// Held while an action runs, so key repeat can't queue up profile loads.
     running: Mutex<()>,
-    /// Desktops re-send an activation on key auto-repeat; one press is one action.
-    last_press: Mutex<Option<std::time::Instant>>,
+    /// Keys currently held: a desktop re-sends the activation at the key
+    /// repeat rate, and one press must be one action.
+    held: Mutex<std::collections::HashSet<Action>>,
 }
 
-/// Auto-repeat starts after ~250ms on most desktops; anything faster is a repeat.
-const REPEAT_GAP: std::time::Duration = std::time::Duration::from_millis(250);
+impl Hotkeys {
+    /// True once per press: the first activation until the key is released.
+    pub fn press(&self, action: Action) -> bool {
+        lock(&self.held).insert(action)
+    }
+
+    pub fn release(&self, action: Action) {
+        lock(&self.held).remove(&action);
+    }
+}
 
 impl Hotkeys {
     pub fn backend(&self) -> Backend {
@@ -209,14 +218,6 @@ pub fn perform(app: &AppHandle, action: Action) {
     let app = app.clone();
     tauri::async_runtime::spawn_blocking(move || {
         let hotkeys = app.state::<Hotkeys>();
-        {
-            let now = std::time::Instant::now();
-            let mut last = lock(&hotkeys.last_press);
-            if last.is_some_and(|t| now.duration_since(t) < REPEAT_GAP) {
-                return;
-            }
-            *last = Some(now);
-        }
         let Ok(_running) = hotkeys.running.try_lock() else {
             return;
         };
@@ -370,6 +371,19 @@ mod tests {
             (a, b) = next;
         }
         assert_eq!((a, b), (97, 100));
+    }
+
+    #[test]
+    fn a_held_key_is_one_press_until_released() {
+        let hotkeys = Hotkeys::default();
+        assert!(hotkeys.press(Action::ProfileNext));
+        assert!(!hotkeys.press(Action::ProfileNext), "auto-repeat");
+        assert!(
+            hotkeys.press(Action::BalanceA),
+            "another key is independent"
+        );
+        hotkeys.release(Action::ProfileNext);
+        assert!(hotkeys.press(Action::ProfileNext));
     }
 
     #[test]

--- a/src-tauri/src/hotkeys/mod.rs
+++ b/src-tauri/src/hotkeys/mod.rs
@@ -119,7 +119,12 @@ pub struct Hotkeys {
     config: Mutex<HotkeyConfig>,
     /// Held while an action runs, so key repeat can't queue up profile loads.
     running: Mutex<()>,
+    /// Desktops re-send an activation on key auto-repeat; one press is one action.
+    last_press: Mutex<Option<std::time::Instant>>,
 }
+
+/// Auto-repeat starts after ~250ms on most desktops; anything faster is a repeat.
+const REPEAT_GAP: std::time::Duration = std::time::Duration::from_millis(250);
 
 impl Hotkeys {
     pub fn backend(&self) -> Backend {
@@ -204,6 +209,14 @@ pub fn perform(app: &AppHandle, action: Action) {
     let app = app.clone();
     tauri::async_runtime::spawn_blocking(move || {
         let hotkeys = app.state::<Hotkeys>();
+        {
+            let now = std::time::Instant::now();
+            let mut last = lock(&hotkeys.last_press);
+            if last.is_some_and(|t| now.duration_since(t) < REPEAT_GAP) {
+                return;
+            }
+            *last = Some(now);
+        }
         let Ok(_running) = hotkeys.running.try_lock() else {
             return;
         };

--- a/src-tauri/src/hotkeys/mod.rs
+++ b/src-tauri/src/hotkeys/mod.rs
@@ -192,7 +192,12 @@ pub fn start(app: AppHandle) {
 
 /// Without a portal, X11 can still grab keys; Wayland cannot.
 fn fallback(config: &HotkeyConfig, app: &AppHandle, portal_err: &str) -> Backend {
-    let x11 = std::env::var("XDG_SESSION_TYPE").is_ok_and(|t| t == "x11");
+    let env = |k| std::env::var(k).ok().filter(|v| !v.is_empty());
+    let x11 = session_is_x11(
+        env("XDG_SESSION_TYPE").as_deref(),
+        env("DISPLAY").is_some(),
+        env("WAYLAND_DISPLAY").is_some(),
+    );
     match x11.then(|| x11::connect(config, app.clone())) {
         Some(Ok(handle)) => Backend::X11(Arc::new(handle)),
         Some(Err(e)) => {
@@ -330,6 +335,16 @@ fn set_balance(app: &AppHandle, position: f32) -> Result<(), String> {
     Ok(())
 }
 
+/// Launchers don't always pass the session type on; a bare X display is
+/// still X11, while XWayland leaves both displays set and keys ungrabbable.
+fn session_is_x11(session_type: Option<&str>, display: bool, wayland_display: bool) -> bool {
+    match session_type {
+        Some("x11") => true,
+        Some("wayland") => false,
+        _ => display && !wayland_display,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -371,6 +386,25 @@ mod tests {
             (a, b) = next;
         }
         assert_eq!((a, b), (97, 100));
+    }
+
+    #[test]
+    fn x11_is_detected_from_the_session_or_a_bare_display() {
+        assert!(session_is_x11(Some("x11"), true, false));
+        assert!(
+            session_is_x11(None, true, false),
+            "launched without a session type"
+        );
+        assert!(
+            session_is_x11(Some("tty"), true, false),
+            "started from a console login"
+        );
+        assert!(!session_is_x11(Some("wayland"), true, false));
+        assert!(
+            !session_is_x11(None, true, true),
+            "xwayland is not a grab target"
+        );
+        assert!(!session_is_x11(None, false, false));
     }
 
     #[test]

--- a/src-tauri/src/hotkeys/mod.rs
+++ b/src-tauri/src/hotkeys/mod.rs
@@ -1,0 +1,335 @@
+//! Global hotkeys for profile switching and the balance slider. Under
+//! Wayland the desktop portal is the only way to see a key while another
+//! app is focused; an X11 session without the portal grabs keys directly.
+
+pub mod portal;
+pub mod x11;
+
+use std::sync::{Arc, Mutex};
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::persistence::hotkeys::HotkeyConfig;
+use crate::state::AppState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    ProfileNext,
+    ProfilePrev,
+    BalanceA,
+    BalanceB,
+    BalanceCenter,
+}
+
+impl Action {
+    pub const ALL: [Action; 5] = [
+        Action::ProfileNext,
+        Action::ProfilePrev,
+        Action::BalanceA,
+        Action::BalanceB,
+        Action::BalanceCenter,
+    ];
+
+    pub fn id(self) -> &'static str {
+        match self {
+            Action::ProfileNext => "profile.next",
+            Action::ProfilePrev => "profile.prev",
+            Action::BalanceA => "balance.a",
+            Action::BalanceB => "balance.b",
+            Action::BalanceCenter => "balance.center",
+        }
+    }
+
+    pub fn from_id(id: &str) -> Option<Action> {
+        Action::ALL.into_iter().find(|a| a.id() == id)
+    }
+
+    pub fn description(self) -> &'static str {
+        match self {
+            Action::ProfileNext => "Next profile",
+            Action::ProfilePrev => "Previous profile",
+            Action::BalanceA => "Balance toward A",
+            Action::BalanceB => "Balance toward B",
+            Action::BalanceCenter => "Center the balance",
+        }
+    }
+
+    /// The portal spells triggers with xkb keysym names.
+    pub fn portal_trigger(self) -> &'static str {
+        match self {
+            Action::ProfileNext => "CTRL+ALT+bracketright",
+            Action::ProfilePrev => "CTRL+ALT+bracketleft",
+            Action::BalanceA => "CTRL+ALT+Left",
+            Action::BalanceB => "CTRL+ALT+Right",
+            Action::BalanceCenter => "CTRL+ALT+Down",
+        }
+    }
+
+    /// X11 grabs spell them with key codes.
+    pub fn x11_trigger(self) -> &'static str {
+        match self {
+            Action::ProfileNext => "Ctrl+Alt+BracketRight",
+            Action::ProfilePrev => "Ctrl+Alt+BracketLeft",
+            Action::BalanceA => "Ctrl+Alt+ArrowLeft",
+            Action::BalanceB => "Ctrl+Alt+ArrowRight",
+            Action::BalanceCenter => "Ctrl+Alt+ArrowDown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ShortcutInfo {
+    pub id: String,
+    pub description: String,
+    /// Human-readable key, empty when the desktop has none bound yet.
+    pub trigger: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HotkeyStatus {
+    /// "portal", "x11" or "none".
+    pub backend: &'static str,
+    pub shortcuts: Vec<ShortcutInfo>,
+    pub balance_step: u8,
+    pub steps: [u8; 4],
+}
+
+#[derive(Default)]
+pub enum Backend {
+    Portal(Arc<portal::Handle>),
+    X11(Arc<x11::Handle>),
+    #[default]
+    None,
+}
+
+impl Backend {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Backend::Portal(_) => "portal",
+            Backend::X11(_) => "x11",
+            Backend::None => "none",
+        }
+    }
+}
+
+/// Managed by Tauri; the backend is picked once at start.
+#[derive(Default)]
+pub struct Hotkeys {
+    pub backend: Mutex<Backend>,
+    pub config: Mutex<HotkeyConfig>,
+}
+
+impl Hotkeys {
+    pub fn backend(&self) -> Backend {
+        match &*self
+            .backend
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+        {
+            Backend::Portal(h) => Backend::Portal(h.clone()),
+            Backend::X11(h) => Backend::X11(h.clone()),
+            Backend::None => Backend::None,
+        }
+    }
+
+    pub fn config(&self) -> HotkeyConfig {
+        self.config
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+}
+
+/// Connect the best available backend; never blocks startup.
+pub fn start(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let hotkeys = app.state::<Hotkeys>();
+        let config = HotkeyConfig::load();
+        *hotkeys
+            .config
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = config.clone();
+        let backend = match portal::connect().await {
+            Ok(handle) => {
+                let handle = Arc::new(handle);
+                portal::listen(handle.clone(), app.clone());
+                Backend::Portal(handle)
+            }
+            Err(portal_err) => {
+                let x11 = std::env::var("XDG_SESSION_TYPE").is_ok_and(|t| t == "x11");
+                match x11.then(|| x11::connect(&config, app.clone())) {
+                    Some(Ok(handle)) => Backend::X11(Arc::new(handle)),
+                    Some(Err(e)) => {
+                        eprintln!(
+                            "sink: global hotkeys unavailable (portal: {portal_err}; x11: {e})"
+                        );
+                        Backend::None
+                    }
+                    None => {
+                        eprintln!("sink: global hotkeys unavailable ({portal_err})");
+                        Backend::None
+                    }
+                }
+            }
+        };
+        eprintln!("sink: hotkeys via {}", backend.name());
+        *hotkeys
+            .backend
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = backend;
+    });
+}
+
+pub fn perform(app: &AppHandle, action: Action) {
+    let result = match action {
+        Action::ProfileNext => switch_profile(app, 1),
+        Action::ProfilePrev => switch_profile(app, -1),
+        Action::BalanceA => nudge_balance(app, -1),
+        Action::BalanceB => nudge_balance(app, 1),
+        Action::BalanceCenter => set_balance(app, 0.0),
+    };
+    if let Err(e) = result {
+        eprintln!("sink: hotkey {} failed: {e}", action.id());
+    }
+}
+
+fn switch_profile(app: &AppHandle, direction: i32) -> Result<(), String> {
+    let profiles = crate::persistence::profiles::list().map_err(|e| e.to_string())?;
+    if profiles.is_empty() {
+        return Ok(());
+    }
+    let state = app.state::<AppState>();
+    let active = state.lock_mixer()?.active_profile.clone();
+    let name = next_profile(
+        &profiles.iter().map(|p| p.name.as_str()).collect::<Vec<_>>(),
+        active.as_deref(),
+        direction,
+    )
+    .to_string();
+    crate::commands::profiles::load_profile(app.clone(), app.state(), name.clone())?;
+    let _ = app.emit("profile-changed", name);
+    Ok(())
+}
+
+/// The profile after (or before) the active one, wrapping; the first when
+/// none is active.
+pub fn next_profile<'a>(names: &[&'a str], active: Option<&str>, direction: i32) -> &'a str {
+    let n = names.len() as i32;
+    let current = active.and_then(|a| names.iter().position(|n| *n == a));
+    let index = match current {
+        Some(i) => (i as i32 + direction).rem_euclid(n),
+        None => 0,
+    };
+    names[index as usize]
+}
+
+/// The slider position for a pair of volumes: + favours B, - favours A.
+pub fn balance_position(a: u8, b: u8) -> f32 {
+    (f32::from(b) - f32::from(a)) / 100.0
+}
+
+/// Volumes for a position, snapping to centre near the middle like the
+/// slider does.
+pub fn balance_volumes(position: f32) -> (u8, u8) {
+    let p = position.clamp(-1.0, 1.0);
+    let p = if p.abs() < 0.04 { 0.0 } else { p };
+    let a = (100.0 * (1.0 - p).min(1.0)).round() as u8;
+    let b = (100.0 * (1.0 + p).min(1.0)).round() as u8;
+    (a, b)
+}
+
+/// A channel name with its current volume.
+type Level = (String, u8);
+
+/// The pair the balance slider works on: the preference, else Game and
+/// Chat, else the first two channels.
+fn balance_pair(state: &AppState) -> Result<Option<(Level, Level)>, String> {
+    let mixer = state.lock_mixer()?;
+    let channels = &mixer.channel_defs.channels;
+    let find = |name: &str| {
+        channels
+            .iter()
+            .find(|c| c.name == name)
+            .map(|c| (c.name.clone(), c.volume_percent))
+    };
+    let nth = |i: usize| channels.get(i).map(|c| (c.name.clone(), c.volume_percent));
+    let a = mixer
+        .prefs
+        .balance_a
+        .as_deref()
+        .and_then(find)
+        .or_else(|| find("sink_game"))
+        .or_else(|| nth(0));
+    let b = mixer
+        .prefs
+        .balance_b
+        .as_deref()
+        .and_then(find)
+        .or_else(|| find("sink_chat"))
+        .or_else(|| nth(1));
+    Ok(a.zip(b).filter(|(a, b)| a.0 != b.0))
+}
+
+fn nudge_balance(app: &AppHandle, direction: i32) -> Result<(), String> {
+    let step = f32::from(app.state::<Hotkeys>().config().balance_step) / 100.0;
+    let state = app.state::<AppState>();
+    let Some((a, b)) = balance_pair(&state)? else {
+        return Ok(());
+    };
+    set_balance(app, balance_position(a.1, b.1) + direction as f32 * step)
+}
+
+fn set_balance(app: &AppHandle, position: f32) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    let Some((a, b)) = balance_pair(&state)? else {
+        return Ok(());
+    };
+    let (va, vb) = balance_volumes(position);
+    crate::commands::routing::set_channel_volume(app.state(), a.0, va)?;
+    crate::commands::routing::set_channel_volume(app.state(), b.0, vb)?;
+    let _ = app.emit("channels-changed", ());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profiles_cycle_in_both_directions() {
+        let names = ["Default", "Stream", "Night"];
+        assert_eq!(next_profile(&names, Some("Default"), 1), "Stream");
+        assert_eq!(next_profile(&names, Some("Night"), 1), "Default");
+        assert_eq!(next_profile(&names, Some("Default"), -1), "Night");
+        assert_eq!(next_profile(&names, None, 1), "Default");
+        assert_eq!(next_profile(&names, Some("gone"), -1), "Default");
+    }
+
+    #[test]
+    fn balance_maths_matches_the_slider() {
+        assert_eq!(balance_volumes(0.0), (100, 100));
+        assert_eq!(balance_volumes(0.5), (50, 100));
+        assert_eq!(balance_volumes(-0.25), (100, 75));
+        assert_eq!(balance_volumes(0.03), (100, 100), "snaps to centre");
+        assert_eq!(balance_volumes(2.0), (0, 100), "clamped");
+        assert_eq!(balance_position(50, 100), 0.5);
+        assert_eq!(balance_position(100, 75), -0.25);
+    }
+
+    #[test]
+    fn a_step_moves_the_position_by_the_step() {
+        let (a, b) = balance_volumes(balance_position(100, 100) + 0.10);
+        assert_eq!((a, b), (90, 100));
+        let (a, b) = balance_volumes(balance_position(90, 100) - 0.25);
+        assert_eq!((a, b), (100, 85));
+    }
+
+    #[test]
+    fn every_action_round_trips_its_id() {
+        for action in Action::ALL {
+            assert_eq!(Action::from_id(action.id()), Some(action));
+        }
+        assert_eq!(Action::from_id("nope"), None);
+    }
+}

--- a/src-tauri/src/hotkeys/mod.rs
+++ b/src-tauri/src/hotkeys/mod.rs
@@ -1,6 +1,5 @@
-//! Global hotkeys for profile switching and the balance slider. Under
-//! Wayland the desktop portal is the only way to see a key while another
-//! app is focused; an X11 session without the portal grabs keys directly.
+//! Global hotkeys for profile switching and the balance slider: the desktop
+//! portal under Wayland, direct key grabs on a portal-less X11 session.
 
 pub mod portal;
 pub mod x11;
@@ -60,9 +59,9 @@ impl Action {
         match self {
             Action::ProfileNext => "CTRL+ALT+bracketright",
             Action::ProfilePrev => "CTRL+ALT+bracketleft",
-            Action::BalanceA => "CTRL+ALT+Left",
-            Action::BalanceB => "CTRL+ALT+Right",
-            Action::BalanceCenter => "CTRL+ALT+Down",
+            Action::BalanceA => "CTRL+ALT+comma",
+            Action::BalanceB => "CTRL+ALT+period",
+            Action::BalanceCenter => "CTRL+ALT+slash",
         }
     }
 
@@ -71,9 +70,9 @@ impl Action {
         match self {
             Action::ProfileNext => "Ctrl+Alt+BracketRight",
             Action::ProfilePrev => "Ctrl+Alt+BracketLeft",
-            Action::BalanceA => "Ctrl+Alt+ArrowLeft",
-            Action::BalanceB => "Ctrl+Alt+ArrowRight",
-            Action::BalanceCenter => "Ctrl+Alt+ArrowDown",
+            Action::BalanceA => "Ctrl+Alt+Comma",
+            Action::BalanceB => "Ctrl+Alt+Period",
+            Action::BalanceCenter => "Ctrl+Alt+Slash",
         }
     }
 }
@@ -113,20 +112,18 @@ impl Backend {
     }
 }
 
-/// Managed by Tauri; the backend is picked once at start.
+/// Managed by Tauri.
 #[derive(Default)]
 pub struct Hotkeys {
-    pub backend: Mutex<Backend>,
-    pub config: Mutex<HotkeyConfig>,
+    backend: Mutex<Backend>,
+    config: Mutex<HotkeyConfig>,
+    /// Held while an action runs, so key repeat can't queue up profile loads.
+    running: Mutex<()>,
 }
 
 impl Hotkeys {
     pub fn backend(&self) -> Backend {
-        match &*self
-            .backend
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-        {
+        match &*lock(&self.backend) {
             Backend::Portal(h) => Backend::Portal(h.clone()),
             Backend::X11(h) => Backend::X11(h.clone()),
             Backend::None => Backend::None,
@@ -134,64 +131,93 @@ impl Hotkeys {
     }
 
     pub fn config(&self) -> HotkeyConfig {
-        self.config
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone()
+        lock(&self.config).clone()
+    }
+
+    pub fn update_config(&self, change: impl FnOnce(&mut HotkeyConfig)) -> HotkeyConfig {
+        let mut config = lock(&self.config);
+        change(&mut config);
+        config.clone()
     }
 }
 
-/// Connect the best available backend; never blocks startup.
+/// A poisoned lock still holds usable state; a panic elsewhere shouldn't
+/// take the hotkeys down with it.
+pub(crate) fn lock<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Connect the best available backend; never blocks startup. A portal
+/// session that ends (portal restart, relogin) is reconnected.
 pub fn start(app: AppHandle) {
     tauri::async_runtime::spawn(async move {
-        let hotkeys = app.state::<Hotkeys>();
         let config = HotkeyConfig::load();
-        *hotkeys
-            .config
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = config.clone();
-        let backend = match portal::connect().await {
-            Ok(handle) => {
-                let handle = Arc::new(handle);
-                portal::listen(handle.clone(), app.clone());
-                Backend::Portal(handle)
-            }
-            Err(portal_err) => {
-                let x11 = std::env::var("XDG_SESSION_TYPE").is_ok_and(|t| t == "x11");
-                match x11.then(|| x11::connect(&config, app.clone())) {
-                    Some(Ok(handle)) => Backend::X11(Arc::new(handle)),
-                    Some(Err(e)) => {
-                        eprintln!(
-                            "sink: global hotkeys unavailable (portal: {portal_err}; x11: {e})"
-                        );
-                        Backend::None
-                    }
-                    None => {
-                        eprintln!("sink: global hotkeys unavailable ({portal_err})");
-                        Backend::None
-                    }
+        app.state::<Hotkeys>()
+            .update_config(|c| *c = config.clone());
+        let mut first = true;
+        loop {
+            match portal::connect().await {
+                Ok(handle) => {
+                    first = false;
+                    let handle = Arc::new(handle);
+                    set_backend(&app, Backend::Portal(handle.clone()));
+                    portal::run(handle, &app).await;
+                    set_backend(&app, Backend::None);
+                    eprintln!("sink: hotkey portal session ended; reconnecting");
                 }
+                Err(e) if first => {
+                    set_backend(&app, fallback(&config, &app, &e));
+                    return;
+                }
+                Err(e) => eprintln!("sink: hotkey portal reconnect failed: {e}"),
             }
-        };
-        eprintln!("sink: hotkeys via {}", backend.name());
-        *hotkeys
-            .backend
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = backend;
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        }
     });
 }
 
-pub fn perform(app: &AppHandle, action: Action) {
-    let result = match action {
-        Action::ProfileNext => switch_profile(app, 1),
-        Action::ProfilePrev => switch_profile(app, -1),
-        Action::BalanceA => nudge_balance(app, -1),
-        Action::BalanceB => nudge_balance(app, 1),
-        Action::BalanceCenter => set_balance(app, 0.0),
-    };
-    if let Err(e) = result {
-        eprintln!("sink: hotkey {} failed: {e}", action.id());
+/// Without a portal, X11 can still grab keys; Wayland cannot.
+fn fallback(config: &HotkeyConfig, app: &AppHandle, portal_err: &str) -> Backend {
+    let x11 = std::env::var("XDG_SESSION_TYPE").is_ok_and(|t| t == "x11");
+    match x11.then(|| x11::connect(config, app.clone())) {
+        Some(Ok(handle)) => Backend::X11(Arc::new(handle)),
+        Some(Err(e)) => {
+            eprintln!("sink: global hotkeys unavailable (portal: {portal_err}; x11: {e})");
+            Backend::None
+        }
+        None => {
+            eprintln!("sink: global hotkeys unavailable ({portal_err})");
+            Backend::None
+        }
     }
+}
+
+fn set_backend(app: &AppHandle, backend: Backend) {
+    eprintln!("sink: hotkeys via {}", backend.name());
+    *lock(&app.state::<Hotkeys>().backend) = backend;
+    let _ = app.emit("hotkeys-changed", ());
+}
+
+/// Run `action` off the caller's thread; a press that lands while one is
+/// still running is dropped rather than queued.
+pub fn perform(app: &AppHandle, action: Action) {
+    let app = app.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let hotkeys = app.state::<Hotkeys>();
+        let Ok(_running) = hotkeys.running.try_lock() else {
+            return;
+        };
+        let result = match action {
+            Action::ProfileNext => switch_profile(&app, 1),
+            Action::ProfilePrev => switch_profile(&app, -1),
+            Action::BalanceA => nudge_balance(&app, -1),
+            Action::BalanceB => nudge_balance(&app, 1),
+            Action::BalanceCenter => set_balance(&app, 0.0),
+        };
+        if let Err(e) = result {
+            eprintln!("sink: hotkey {} failed: {e}", action.id());
+        }
+    });
 }
 
 fn switch_profile(app: &AppHandle, direction: i32) -> Result<(), String> {
@@ -229,11 +255,9 @@ pub fn balance_position(a: u8, b: u8) -> f32 {
     (f32::from(b) - f32::from(a)) / 100.0
 }
 
-/// Volumes for a position, snapping to centre near the middle like the
-/// slider does.
+/// Volumes for a position. No centre dead zone: a one-point step must move.
 pub fn balance_volumes(position: f32) -> (u8, u8) {
     let p = position.clamp(-1.0, 1.0);
-    let p = if p.abs() < 0.04 { 0.0 } else { p };
     let a = (100.0 * (1.0 - p).min(1.0)).round() as u8;
     let b = (100.0 * (1.0 + p).min(1.0)).round() as u8;
     (a, b)
@@ -311,7 +335,6 @@ mod tests {
         assert_eq!(balance_volumes(0.0), (100, 100));
         assert_eq!(balance_volumes(0.5), (50, 100));
         assert_eq!(balance_volumes(-0.25), (100, 75));
-        assert_eq!(balance_volumes(0.03), (100, 100), "snaps to centre");
         assert_eq!(balance_volumes(2.0), (0, 100), "clamped");
         assert_eq!(balance_position(50, 100), 0.5);
         assert_eq!(balance_position(100, 75), -0.25);
@@ -323,6 +346,17 @@ mod tests {
         assert_eq!((a, b), (90, 100));
         let (a, b) = balance_volumes(balance_position(90, 100) - 0.25);
         assert_eq!((a, b), (100, 85));
+    }
+
+    #[test]
+    fn the_smallest_step_still_moves_and_accumulates() {
+        let (mut a, mut b) = (100u8, 100u8);
+        for _ in 0..3 {
+            let next = balance_volumes(balance_position(a, b) + 0.01);
+            assert_ne!(next, (a, b));
+            (a, b) = next;
+        }
+        assert_eq!((a, b), (97, 100));
     }
 
     #[test]

--- a/src-tauri/src/hotkeys/portal.rs
+++ b/src-tauri/src/hotkeys/portal.rs
@@ -9,7 +9,7 @@ use ashpd::desktop::global_shortcuts::{
 };
 use ashpd::desktop::Session;
 use futures_util::StreamExt;
-use tauri::AppHandle;
+use tauri::{AppHandle, Emitter};
 
 use super::{Action, ShortcutInfo};
 
@@ -18,10 +18,7 @@ pub struct Handle {
     session: Session<GlobalShortcuts>,
 }
 
-/// The id the portal files our shortcuts under. A host app is otherwise
-/// named after whatever launched it (a terminal, say); a reverse-DNS id
-/// is required, and us.echo.Sink.desktop ships hidden so desktops can
-/// turn it into a name.
+/// Registered explicitly, or the portal names us after whatever launched us.
 const APP_ID: &str = "us.echo.Sink";
 
 pub async fn connect() -> Result<Handle, String> {
@@ -71,8 +68,10 @@ pub async fn bind(handle: &Handle) -> Result<(), String> {
 }
 
 pub fn listen(handle: Arc<Handle>, app: AppHandle) {
+    let activations = handle.clone();
+    let on_activated = app.clone();
     tauri::async_runtime::spawn(async move {
-        let mut activated = match handle.proxy.receive_activated().await {
+        let mut activated = match activations.proxy.receive_activated().await {
             Ok(stream) => stream,
             Err(e) => {
                 eprintln!("sink: hotkey signals unavailable: {e}");
@@ -81,8 +80,17 @@ pub fn listen(handle: Arc<Handle>, app: AppHandle) {
         };
         while let Some(event) = activated.next().await {
             if let Some(action) = Action::from_id(event.shortcut_id()) {
-                super::perform(&app, action);
+                super::perform(&on_activated, action);
             }
+        }
+    });
+    // Keys edited in the desktop's settings show up in ours without a restart.
+    tauri::async_runtime::spawn(async move {
+        let Ok(mut changed) = handle.proxy.receive_shortcuts_changed().await else {
+            return;
+        };
+        while changed.next().await.is_some() {
+            let _ = app.emit("hotkeys-changed", ());
         }
     });
 }
@@ -106,9 +114,7 @@ pub async fn shortcuts(handle: &Handle) -> Result<Vec<ShortcutInfo>, String> {
         .collect())
 }
 
-/// Bind first (the desktop prompts for ids it hasn't seen), then open the
-/// desktop's own shortcut settings for keys it knows but left unbound or
-/// that the user wants to change.
+/// Bind (prompts only for new ids), then the desktop's own shortcut settings.
 pub async fn configure(handle: &Handle) -> Result<(), String> {
     bind(handle).await?;
     handle

--- a/src-tauri/src/hotkeys/portal.rs
+++ b/src-tauri/src/hotkeys/portal.rs
@@ -16,6 +16,8 @@ use super::{Action, ShortcutInfo};
 pub struct Handle {
     proxy: GlobalShortcuts,
     session: Session<GlobalShortcuts>,
+    /// The session's object path, to tell our activations from other apps'.
+    path: String,
 }
 
 /// Registered explicitly, or the portal names us after whatever launched us.
@@ -31,14 +33,20 @@ pub async fn connect() -> Result<Handle, String> {
         Err(e) => eprintln!("sink: bad portal app id: {e}"),
     }
     let proxy = GlobalShortcuts::new().await.map_err(|e| e.to_string())?;
-    if proxy.version() == 0 {
-        return Err("no GlobalShortcuts portal".into());
-    }
     let session = proxy
         .create_session(Default::default())
         .await
         .map_err(|e| e.to_string())?;
-    let handle = Handle { proxy, session };
+    // ashpd keeps the path private; the session serialises as its path.
+    let path = serde_json::to_value(&session)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_string))
+        .ok_or("session path")?;
+    let handle = Handle {
+        proxy,
+        session,
+        path,
+    };
     // A dismissed dialog must not cost the session: Settings can bind again.
     if let Err(e) = bind(&handle).await {
         eprintln!("sink: hotkeys not bound yet: {e}");
@@ -67,32 +75,48 @@ pub async fn bind(handle: &Handle) -> Result<(), String> {
         .map_err(|e| e.to_string())
 }
 
-pub fn listen(handle: Arc<Handle>, app: AppHandle) {
-    let activations = handle.clone();
-    let on_activated = app.clone();
-    tauri::async_runtime::spawn(async move {
-        let mut activated = match activations.proxy.receive_activated().await {
-            Ok(stream) => stream,
-            Err(e) => {
-                eprintln!("sink: hotkey signals unavailable: {e}");
-                return;
-            }
-        };
-        while let Some(event) = activated.next().await {
-            if let Some(action) = Action::from_id(event.shortcut_id()) {
-                super::perform(&on_activated, action);
-            }
+/// Act on activations until the session closes or the signals stop.
+pub async fn run(handle: Arc<Handle>, app: &AppHandle) {
+    let mut activated = match handle.proxy.receive_activated().await {
+        Ok(stream) => stream,
+        Err(e) => {
+            eprintln!("sink: hotkey signals unavailable: {e}");
+            return;
         }
-    });
+    };
+    let mut closed = match handle.session.receive_closed().await {
+        Ok(stream) => stream,
+        Err(e) => {
+            eprintln!("sink: hotkey session watch unavailable: {e}");
+            return;
+        }
+    };
     // Keys edited in the desktop's settings show up in ours without a restart.
-    tauri::async_runtime::spawn(async move {
-        let Ok(mut changed) = handle.proxy.receive_shortcuts_changed().await else {
+    let changes = handle.clone();
+    let notify = app.clone();
+    let watcher = tauri::async_runtime::spawn(async move {
+        let Ok(mut changed) = changes.proxy.receive_shortcuts_changed().await else {
             return;
         };
         while changed.next().await.is_some() {
-            let _ = app.emit("hotkeys-changed", ());
+            let _ = notify.emit("hotkeys-changed", ());
         }
     });
+    loop {
+        tokio::select! {
+            event = activated.next() => {
+                let Some(event) = event else { break };
+                if event.session_handle().as_str() != handle.path {
+                    continue;
+                }
+                if let Some(action) = Action::from_id(event.shortcut_id()) {
+                    super::perform(app, action);
+                }
+            }
+            _ = closed.next() => break,
+        }
+    }
+    watcher.abort();
 }
 
 pub async fn shortcuts(handle: &Handle) -> Result<Vec<ShortcutInfo>, String> {
@@ -117,6 +141,9 @@ pub async fn shortcuts(handle: &Handle) -> Result<Vec<ShortcutInfo>, String> {
 /// Bind (prompts only for new ids), then the desktop's own shortcut settings.
 pub async fn configure(handle: &Handle) -> Result<(), String> {
     bind(handle).await?;
+    if handle.proxy.version() < 2 {
+        return Err("this desktop can't open shortcut settings from an app yet; use its own shortcut settings".into());
+    }
     handle
         .proxy
         .configure_shortcuts(&handle.session, None, ConfigureShortcutsOptions::default())

--- a/src-tauri/src/hotkeys/portal.rs
+++ b/src-tauri/src/hotkeys/portal.rs
@@ -41,17 +41,33 @@ pub async fn connect() -> Result<Handle, String> {
         .create_session(Default::default())
         .await
         .map_err(|e| e.to_string())?;
+    let handle = Handle { proxy, session };
+    // A dismissed dialog must not cost the session: Settings can bind again.
+    if let Err(e) = bind(&handle).await {
+        eprintln!("sink: hotkeys not bound yet: {e}");
+    }
+    Ok(handle)
+}
+
+/// Declare our shortcuts; the desktop asks the user the first time.
+pub async fn bind(handle: &Handle) -> Result<(), String> {
     let shortcuts: Vec<NewShortcut> = Action::ALL
         .iter()
         .map(|a| NewShortcut::new(a.id(), a.description()).preferred_trigger(a.portal_trigger()))
         .collect();
-    proxy
-        .bind_shortcuts(&session, &shortcuts, None, BindShortcutsOptions::default())
+    handle
+        .proxy
+        .bind_shortcuts(
+            &handle.session,
+            &shortcuts,
+            None,
+            BindShortcutsOptions::default(),
+        )
         .await
         .map_err(|e| e.to_string())?
         .response()
-        .map_err(|e| e.to_string())?;
-    Ok(Handle { proxy, session })
+        .map(|_| ())
+        .map_err(|e| e.to_string())
 }
 
 pub fn listen(handle: Arc<Handle>, app: AppHandle) {
@@ -90,8 +106,16 @@ pub async fn shortcuts(handle: &Handle) -> Result<Vec<ShortcutInfo>, String> {
         .collect())
 }
 
-/// Open the desktop's own binding dialog.
+/// Bind if anything is still unbound, else open the desktop's own dialog
+/// to change keys.
 pub async fn configure(handle: &Handle) -> Result<(), String> {
+    let unbound = shortcuts(handle)
+        .await?
+        .iter()
+        .any(|s| s.trigger.is_empty());
+    if unbound {
+        return bind(handle).await;
+    }
     handle
         .proxy
         .configure_shortcuts(&handle.session, None, ConfigureShortcutsOptions::default())

--- a/src-tauri/src/hotkeys/portal.rs
+++ b/src-tauri/src/hotkeys/portal.rs
@@ -9,7 +9,7 @@ use ashpd::desktop::global_shortcuts::{
 };
 use ashpd::desktop::Session;
 use futures_util::StreamExt;
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 
 use super::{Action, ShortcutInfo};
 
@@ -84,6 +84,13 @@ pub async fn run(handle: Arc<Handle>, app: &AppHandle) {
             return;
         }
     };
+    let mut deactivated = match handle.proxy.receive_deactivated().await {
+        Ok(stream) => stream,
+        Err(e) => {
+            eprintln!("sink: hotkey release signals unavailable: {e}");
+            return;
+        }
+    };
     let mut closed = match handle.session.receive_closed().await {
         Ok(stream) => stream,
         Err(e) => {
@@ -110,7 +117,15 @@ pub async fn run(handle: Arc<Handle>, app: &AppHandle) {
                     continue;
                 }
                 if let Some(action) = Action::from_id(event.shortcut_id()) {
-                    super::perform(app, action);
+                    if app.state::<super::Hotkeys>().press(action) {
+                        super::perform(app, action);
+                    }
+                }
+            }
+            event = deactivated.next() => {
+                let Some(event) = event else { break };
+                if let Some(action) = Action::from_id(event.shortcut_id()) {
+                    app.state::<super::Hotkeys>().release(action);
                 }
             }
             _ = closed.next() => break,

--- a/src-tauri/src/hotkeys/portal.rs
+++ b/src-tauri/src/hotkeys/portal.rs
@@ -1,0 +1,87 @@
+//! The XDG GlobalShortcuts portal: the desktop owns the bindings and shows
+//! its own dialog; we declare the shortcuts and act on activations.
+
+use std::sync::Arc;
+
+use ashpd::desktop::global_shortcuts::{
+    BindShortcutsOptions, ConfigureShortcutsOptions, GlobalShortcuts, ListShortcutsOptions,
+    NewShortcut,
+};
+use ashpd::desktop::Session;
+use futures_util::StreamExt;
+use tauri::AppHandle;
+
+use super::{Action, ShortcutInfo};
+
+pub struct Handle {
+    proxy: GlobalShortcuts,
+    session: Session<GlobalShortcuts>,
+}
+
+pub async fn connect() -> Result<Handle, String> {
+    let proxy = GlobalShortcuts::new().await.map_err(|e| e.to_string())?;
+    if proxy.version() == 0 {
+        return Err("no GlobalShortcuts portal".into());
+    }
+    let session = proxy
+        .create_session(Default::default())
+        .await
+        .map_err(|e| e.to_string())?;
+    let shortcuts: Vec<NewShortcut> = Action::ALL
+        .iter()
+        .map(|a| NewShortcut::new(a.id(), a.description()).preferred_trigger(a.portal_trigger()))
+        .collect();
+    proxy
+        .bind_shortcuts(&session, &shortcuts, None, BindShortcutsOptions::default())
+        .await
+        .map_err(|e| e.to_string())?
+        .response()
+        .map_err(|e| e.to_string())?;
+    Ok(Handle { proxy, session })
+}
+
+pub fn listen(handle: Arc<Handle>, app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let mut activated = match handle.proxy.receive_activated().await {
+            Ok(stream) => stream,
+            Err(e) => {
+                eprintln!("sink: hotkey signals unavailable: {e}");
+                return;
+            }
+        };
+        while let Some(event) = activated.next().await {
+            if let Some(action) = Action::from_id(event.shortcut_id()) {
+                super::perform(&app, action);
+            }
+        }
+    });
+}
+
+pub async fn shortcuts(handle: &Handle) -> Result<Vec<ShortcutInfo>, String> {
+    let listed = handle
+        .proxy
+        .list_shortcuts(&handle.session, ListShortcutsOptions::default())
+        .await
+        .map_err(|e| e.to_string())?
+        .response()
+        .map_err(|e| e.to_string())?;
+    Ok(listed
+        .shortcuts()
+        .iter()
+        .map(|s| ShortcutInfo {
+            id: s.id().to_string(),
+            description: s.description().to_string(),
+            trigger: s.trigger_description().to_string(),
+        })
+        .collect())
+}
+
+/// Open the desktop's own binding dialog.
+pub async fn configure(handle: &Handle) -> Result<(), String> {
+    handle
+        .proxy
+        .configure_shortcuts(&handle.session, None, ConfigureShortcutsOptions::default())
+        .await
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/hotkeys/portal.rs
+++ b/src-tauri/src/hotkeys/portal.rs
@@ -106,16 +106,11 @@ pub async fn shortcuts(handle: &Handle) -> Result<Vec<ShortcutInfo>, String> {
         .collect())
 }
 
-/// Bind if anything is still unbound, else open the desktop's own dialog
-/// to change keys.
+/// Bind first (the desktop prompts for ids it hasn't seen), then open the
+/// desktop's own shortcut settings for keys it knows but left unbound or
+/// that the user wants to change.
 pub async fn configure(handle: &Handle) -> Result<(), String> {
-    let unbound = shortcuts(handle)
-        .await?
-        .iter()
-        .any(|s| s.trigger.is_empty());
-    if unbound {
-        return bind(handle).await;
-    }
+    bind(handle).await?;
     handle
         .proxy
         .configure_shortcuts(&handle.session, None, ConfigureShortcutsOptions::default())

--- a/src-tauri/src/hotkeys/portal.rs
+++ b/src-tauri/src/hotkeys/portal.rs
@@ -18,7 +18,21 @@ pub struct Handle {
     session: Session<GlobalShortcuts>,
 }
 
+/// The id the portal files our shortcuts under. A host app is otherwise
+/// named after whatever launched it (a terminal, say); a reverse-DNS id
+/// is required, and us.echo.Sink.desktop ships hidden so desktops can
+/// turn it into a name.
+const APP_ID: &str = "us.echo.Sink";
+
 pub async fn connect() -> Result<Handle, String> {
+    match APP_ID.parse() {
+        Ok(id) => {
+            if let Err(e) = ashpd::register_host_app(id).await {
+                eprintln!("sink: portal app registration unavailable: {e}");
+            }
+        }
+        Err(e) => eprintln!("sink: bad portal app id: {e}"),
+    }
     let proxy = GlobalShortcuts::new().await.map_err(|e| e.to_string())?;
     if proxy.version() == 0 {
         return Err("no GlobalShortcuts portal".into());

--- a/src-tauri/src/hotkeys/x11.rs
+++ b/src-tauri/src/hotkeys/x11.rs
@@ -115,9 +115,49 @@ impl Handle {
                 trigger: keys
                     .values()
                     .find(|g| g.action == *a)
-                    .map(|g| g.trigger.clone())
+                    .map(|g| label(&g.trigger))
                     .unwrap_or_default(),
             })
             .collect()
+    }
+}
+
+/// Bindings are stored as key codes ("Ctrl+Alt+BracketRight"); show them
+/// the way a keyboard prints them.
+fn label(trigger: &str) -> String {
+    trigger
+        .split('+')
+        .map(|part| match part {
+            "BracketLeft" => "[",
+            "BracketRight" => "]",
+            "Comma" => ",",
+            "Period" => ".",
+            "Slash" => "/",
+            "Backslash" => "\\",
+            "Semicolon" => ";",
+            "Quote" => "'",
+            "Backquote" => "`",
+            "Minus" => "-",
+            "Equal" => "=",
+            key => key
+                .strip_prefix("Key")
+                .or_else(|| key.strip_prefix("Digit"))
+                .unwrap_or(key),
+        })
+        .collect::<Vec<_>>()
+        .join("+")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::label;
+
+    #[test]
+    fn labels_read_like_the_keys_themselves() {
+        assert_eq!(label("Ctrl+Alt+BracketRight"), "Ctrl+Alt+]");
+        assert_eq!(label("Ctrl+Alt+Comma"), "Ctrl+Alt+,");
+        assert_eq!(label("Ctrl+Shift+KeyF"), "Ctrl+Shift+F");
+        assert_eq!(label("Super+Digit1"), "Super+1");
+        assert_eq!(label("Alt+F5"), "Alt+F5");
     }
 }

--- a/src-tauri/src/hotkeys/x11.rs
+++ b/src-tauri/src/hotkeys/x11.rs
@@ -8,12 +8,20 @@ use global_hotkey::hotkey::HotKey;
 use global_hotkey::{GlobalHotKeyEvent, GlobalHotKeyManager, HotKeyState};
 use tauri::AppHandle;
 
-use super::{Action, ShortcutInfo};
+use super::{lock, Action, ShortcutInfo};
 use crate::persistence::hotkeys::HotkeyConfig;
 
 pub struct Handle {
     manager: Mutex<GlobalHotKeyManager>,
-    keys: Arc<Mutex<HashMap<u32, (Action, HotKey)>>>,
+    /// Live grabs by hotkey id; a key that failed to register isn't here.
+    keys: Arc<Mutex<HashMap<u32, Grab>>>,
+}
+
+#[derive(Clone)]
+struct Grab {
+    action: Action,
+    hotkey: HotKey,
+    trigger: String,
 }
 
 pub fn connect(config: &HotkeyConfig, app: AppHandle) -> Result<Handle, String> {
@@ -36,17 +44,14 @@ pub fn connect(config: &HotkeyConfig, app: AppHandle) -> Result<Handle, String> 
             );
         }
     }
+    // Process-lifetime by design: the backend is chosen once per run.
     std::thread::spawn(move || {
         let receiver = GlobalHotKeyEvent::receiver();
         while let Ok(event) = receiver.recv() {
             if event.state() != HotKeyState::Pressed {
                 continue;
             }
-            let action = keys
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .get(&event.id())
-                .map(|(a, _)| *a);
+            let action = lock(&keys).get(&event.id()).map(|g| g.action);
             if let Some(action) = action {
                 super::perform(&app, action);
             }
@@ -56,43 +61,57 @@ pub fn connect(config: &HotkeyConfig, app: AppHandle) -> Result<Handle, String> 
 }
 
 impl Handle {
-    /// Register `trigger` for `action`, releasing whatever it had.
+    /// Register `trigger` for `action`, releasing whatever it had once the
+    /// new grab holds.
     pub fn bind(&self, action: Action, trigger: &str) -> Result<(), String> {
         let hotkey: HotKey = trigger.parse().map_err(|e| format!("{e}"))?;
-        let manager = self
-            .manager
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let mut keys = self
-            .keys
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // A bare key would be grabbed from every other app on the desktop.
+        if hotkey.mods.is_empty() {
+            return Err("a hotkey needs a modifier".into());
+        }
+        let manager = lock(&self.manager);
+        let mut keys = lock(&self.keys);
+        if let Some(other) = keys.get(&hotkey.id()).filter(|g| g.action != action) {
+            return Err(format!(
+                "{trigger} is already {}",
+                other.action.description()
+            ));
+        }
+        manager.register(hotkey).map_err(|e| e.to_string())?;
         let previous: Vec<u32> = keys
             .iter()
-            .filter(|(_, (a, _))| *a == action)
+            .filter(|(id, g)| g.action == action && **id != hotkey.id())
             .map(|(id, _)| *id)
             .collect();
         for id in previous {
-            if let Some((_, old)) = keys.remove(&id) {
-                let _ = manager.unregister(old);
+            if let Some(old) = keys.remove(&id) {
+                let _ = manager.unregister(old.hotkey);
             }
         }
-        manager.register(hotkey).map_err(|e| e.to_string())?;
-        keys.insert(hotkey.id(), (action, hotkey));
+        keys.insert(
+            hotkey.id(),
+            Grab {
+                action,
+                hotkey,
+                trigger: trigger.to_string(),
+            },
+        );
         Ok(())
     }
 
-    pub fn shortcuts(&self, config: &HotkeyConfig) -> Vec<ShortcutInfo> {
+    /// What is really grabbed: a key the desktop refused shows as unbound.
+    pub fn shortcuts(&self) -> Vec<ShortcutInfo> {
+        let keys = lock(&self.keys);
         Action::ALL
             .iter()
             .map(|a| ShortcutInfo {
                 id: a.id().to_string(),
                 description: a.description().to_string(),
-                trigger: config
-                    .bindings
-                    .get(a.id())
-                    .cloned()
-                    .unwrap_or_else(|| a.x11_trigger().to_string()),
+                trigger: keys
+                    .values()
+                    .find(|g| g.action == *a)
+                    .map(|g| g.trigger.clone())
+                    .unwrap_or_default(),
             })
             .collect()
     }

--- a/src-tauri/src/hotkeys/x11.rs
+++ b/src-tauri/src/hotkeys/x11.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 
 use global_hotkey::hotkey::HotKey;
 use global_hotkey::{GlobalHotKeyEvent, GlobalHotKeyManager, HotKeyState};
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 
 use super::{lock, Action, ShortcutInfo};
 use crate::persistence::hotkeys::HotkeyConfig;
@@ -48,12 +48,17 @@ pub fn connect(config: &HotkeyConfig, app: AppHandle) -> Result<Handle, String> 
     std::thread::spawn(move || {
         let receiver = GlobalHotKeyEvent::receiver();
         while let Ok(event) = receiver.recv() {
-            if event.state() != HotKeyState::Pressed {
+            let Some(action) = lock(&keys).get(&event.id()).map(|g| g.action) else {
                 continue;
-            }
-            let action = lock(&keys).get(&event.id()).map(|g| g.action);
-            if let Some(action) = action {
-                super::perform(&app, action);
+            };
+            let hotkeys = app.state::<super::Hotkeys>();
+            match event.state() {
+                HotKeyState::Pressed => {
+                    if hotkeys.press(action) {
+                        super::perform(&app, action);
+                    }
+                }
+                HotKeyState::Released => hotkeys.release(action),
             }
         }
     });

--- a/src-tauri/src/hotkeys/x11.rs
+++ b/src-tauri/src/hotkeys/x11.rs
@@ -1,0 +1,99 @@
+//! X11 fallback: grab the keys ourselves. Bindings are ours to keep, so
+//! they live in hotkeys.json.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use global_hotkey::hotkey::HotKey;
+use global_hotkey::{GlobalHotKeyEvent, GlobalHotKeyManager, HotKeyState};
+use tauri::AppHandle;
+
+use super::{Action, ShortcutInfo};
+use crate::persistence::hotkeys::HotkeyConfig;
+
+pub struct Handle {
+    manager: Mutex<GlobalHotKeyManager>,
+    keys: Arc<Mutex<HashMap<u32, (Action, HotKey)>>>,
+}
+
+pub fn connect(config: &HotkeyConfig, app: AppHandle) -> Result<Handle, String> {
+    let manager = GlobalHotKeyManager::new().map_err(|e| e.to_string())?;
+    let keys = Arc::new(Mutex::new(HashMap::new()));
+    let handle = Handle {
+        manager: Mutex::new(manager),
+        keys: keys.clone(),
+    };
+    for action in Action::ALL {
+        let trigger = config
+            .bindings
+            .get(action.id())
+            .map(String::as_str)
+            .unwrap_or(action.x11_trigger());
+        if let Err(e) = handle.bind(action, trigger) {
+            eprintln!(
+                "sink: hotkey {} ({trigger}) not registered: {e}",
+                action.id()
+            );
+        }
+    }
+    std::thread::spawn(move || {
+        let receiver = GlobalHotKeyEvent::receiver();
+        while let Ok(event) = receiver.recv() {
+            if event.state() != HotKeyState::Pressed {
+                continue;
+            }
+            let action = keys
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .get(&event.id())
+                .map(|(a, _)| *a);
+            if let Some(action) = action {
+                super::perform(&app, action);
+            }
+        }
+    });
+    Ok(handle)
+}
+
+impl Handle {
+    /// Register `trigger` for `action`, releasing whatever it had.
+    pub fn bind(&self, action: Action, trigger: &str) -> Result<(), String> {
+        let hotkey: HotKey = trigger.parse().map_err(|e| format!("{e}"))?;
+        let manager = self
+            .manager
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut keys = self
+            .keys
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous: Vec<u32> = keys
+            .iter()
+            .filter(|(_, (a, _))| *a == action)
+            .map(|(id, _)| *id)
+            .collect();
+        for id in previous {
+            if let Some((_, old)) = keys.remove(&id) {
+                let _ = manager.unregister(old);
+            }
+        }
+        manager.register(hotkey).map_err(|e| e.to_string())?;
+        keys.insert(hotkey.id(), (action, hotkey));
+        Ok(())
+    }
+
+    pub fn shortcuts(&self, config: &HotkeyConfig) -> Vec<ShortcutInfo> {
+        Action::ALL
+            .iter()
+            .map(|a| ShortcutInfo {
+                id: a.id().to_string(),
+                description: a.description().to_string(),
+                trigger: config
+                    .bindings
+                    .get(a.id())
+                    .cloned()
+                    .unwrap_or_else(|| a.x11_trigger().to_string()),
+            })
+            .collect()
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod audio;
 mod commands;
 mod error;
+mod hotkeys;
 mod mixer;
 mod persistence;
 mod state;
@@ -51,6 +52,7 @@ pub fn run() {
         }))
         .plugin(tauri_plugin_dialog::init())
         .manage(app_state)
+        .manage(hotkeys::Hotkeys::default())
         .invoke_handler(tauri::generate_handler![
             commands::devices::get_virtual_devices,
             commands::devices::get_app_streams,
@@ -119,9 +121,14 @@ pub fn run() {
             commands::settings::set_balance_visible,
             commands::settings::set_start_minimized,
             commands::settings::reset_app,
+            commands::hotkeys::get_hotkeys,
+            commands::hotkeys::configure_hotkeys,
+            commands::hotkeys::set_hotkey_binding,
+            commands::hotkeys::set_balance_step,
         ])
         .setup(move |app| {
             build_tray(app)?;
+            hotkeys::start(app.handle().clone());
             // The window starts hidden (config) to avoid a flash; show it
             // now unless launched with --minimized (autostart-to-tray).
             let minimized = std::env::args().any(|a| a == "--minimized");

--- a/src-tauri/src/persistence/hotkeys.rs
+++ b/src-tauri/src/persistence/hotkeys.rs
@@ -41,11 +41,15 @@ impl HotkeyConfig {
     }
 
     pub fn load() -> Self {
-        Self::config_path()
+        let mut config: Self = Self::config_path()
             .ok()
             .and_then(|p| std::fs::read_to_string(p).ok())
             .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default()
+            .unwrap_or_default();
+        if !BALANCE_STEPS.contains(&config.balance_step) {
+            config.balance_step = default_step();
+        }
+        config
     }
 
     pub fn save(&self) -> Result<(), SinkError> {

--- a/src-tauri/src/persistence/hotkeys.rs
+++ b/src-tauri/src/persistence/hotkeys.rs
@@ -1,0 +1,61 @@
+//! Hotkey settings: the balance step, and key bindings for the X11 fallback.
+//! Under the desktop portal the bindings live with the desktop, not here.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::SinkError;
+
+/// Balance moves per press, in percentage points; the UI offers these.
+pub const BALANCE_STEPS: [u8; 4] = [1, 10, 15, 25];
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HotkeyConfig {
+    #[serde(default = "default_step")]
+    pub balance_step: u8,
+    /// Action id -> accelerator, X11 only.
+    #[serde(default)]
+    pub bindings: BTreeMap<String, String>,
+}
+
+fn default_step() -> u8 {
+    10
+}
+
+impl Default for HotkeyConfig {
+    fn default() -> Self {
+        Self {
+            balance_step: default_step(),
+            bindings: BTreeMap::new(),
+        }
+    }
+}
+
+impl HotkeyConfig {
+    pub fn config_path() -> Result<PathBuf, SinkError> {
+        let dir = super::config_root()
+            .ok_or_else(|| SinkError::Config("cannot resolve the user config directory".into()))?;
+        Ok(dir.join("sink").join("hotkeys.json"))
+    }
+
+    pub fn load() -> Self {
+        Self::config_path()
+            .ok()
+            .and_then(|p| std::fs::read_to_string(p).ok())
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self) -> Result<(), SinkError> {
+        let path = Self::config_path()?;
+        if let Some(parent) = path.parent() {
+            super::ensure_private_dir(parent)?;
+        }
+        let json = serde_json::to_string_pretty(self)
+            .map_err(|e| SinkError::Config(format!("serialize hotkeys: {e}")))?;
+        super::write_atomic(&path, &json)?;
+        Ok(())
+    }
+}

--- a/src-tauri/src/persistence/mod.rs
+++ b/src-tauri/src/persistence/mod.rs
@@ -6,6 +6,7 @@ pub mod buses;
 pub mod channels;
 pub mod eq;
 pub mod eq_presets;
+pub mod hotkeys;
 pub mod mic;
 pub mod outputs;
 pub mod prefs;

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -10,6 +10,8 @@ pub struct AppState {
     /// True when the native PipeWire backend is driving (vs pactl fallback).
     pub backend_native: bool,
     pub mixer: Mutex<MixerState>,
+    /// Held for a whole profile load, which takes the mixer lock piecemeal.
+    pub profile_switch: Mutex<()>,
     /// Lets the pactl-backend ticker yield while an on-screen window is
     /// already polling (see `lib::spawn_route_enforcer`).
     ui_stream_poll: Mutex<Option<Instant>>,
@@ -78,6 +80,7 @@ impl AppState {
             backend,
             backend_native,
             mixer: Mutex::new(mixer),
+            profile_switch: Mutex::new(()),
             ui_stream_poll: Mutex::new(None),
             refresh_gate: Mutex::new(()),
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,7 +40,11 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["deb", "rpm", "appimage"],
+    "targets": [
+      "deb",
+      "rpm",
+      "appimage"
+    ],
     "linux": {
       "deb": {
         "depends": [
@@ -48,7 +52,10 @@
           "pulseaudio-utils",
           "pipewire-pulse",
           "wireplumber"
-        ]
+        ],
+        "files": {
+          "/usr/share/applications/us.echo.Sink.desktop": "../packaging/linux/us.echo.Sink.desktop"
+        }
       },
       "rpm": {
         "depends": [
@@ -56,7 +63,10 @@
           "pulseaudio-utils",
           "pipewire-pulseaudio",
           "wireplumber"
-        ]
+        ],
+        "files": {
+          "/usr/share/applications/us.echo.Sink.desktop": "../packaging/linux/us.echo.Sink.desktop"
+        }
       }
     },
     "icon": [

--- a/src/components/Settings/HotkeysSection.test.ts
+++ b/src/components/Settings/HotkeysSection.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { acceleratorFrom } from "./HotkeysSection";
+
+describe("acceleratorFrom", () => {
+  it("spells modifiers and the key code the X11 grabber understands", () => {
+    expect(acceleratorFrom({ code: "ArrowLeft", ctrlKey: true, altKey: true, shiftKey: false, metaKey: false })).toBe(
+      "Ctrl+Alt+ArrowLeft",
+    );
+    expect(acceleratorFrom({ code: "KeyP", ctrlKey: false, altKey: false, shiftKey: true, metaKey: true })).toBe(
+      "Shift+Super+KeyP",
+    );
+  });
+  it("waits for a real key when only a modifier is down", () => {
+    expect(acceleratorFrom({ code: "ControlLeft", ctrlKey: true, altKey: false, shiftKey: false, metaKey: false })).toBeNull();
+    expect(acceleratorFrom({ code: "", ctrlKey: true, altKey: false, shiftKey: false, metaKey: false })).toBeNull();
+  });
+});

--- a/src/components/Settings/HotkeysSection.test.ts
+++ b/src/components/Settings/HotkeysSection.test.ts
@@ -10,6 +10,9 @@ describe("acceleratorFrom", () => {
       "Shift+Super+KeyP",
     );
   });
+  it("refuses a bare key", () => {
+    expect(acceleratorFrom({ code: "KeyA", ctrlKey: false, altKey: false, shiftKey: false, metaKey: false })).toBeNull();
+  });
   it("waits for a real key when only a modifier is down", () => {
     expect(acceleratorFrom({ code: "ControlLeft", ctrlKey: true, altKey: false, shiftKey: false, metaKey: false })).toBeNull();
     expect(acceleratorFrom({ code: "", ctrlKey: true, altKey: false, shiftKey: false, metaKey: false })).toBeNull();

--- a/src/components/Settings/HotkeysSection.tsx
+++ b/src/components/Settings/HotkeysSection.tsx
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { HotkeyStatus } from "../../types";
+import { Ms } from "../Icons";
+
+const ICONS: Record<string, string> = {
+  "profile.next": "skip_next",
+  "profile.prev": "skip_previous",
+  "balance.a": "keyboard_arrow_left",
+  "balance.b": "keyboard_arrow_right",
+  "balance.center": "vertical_align_center",
+};
+
+const MODIFIER_CODES = new Set([
+  "ControlLeft",
+  "ControlRight",
+  "ShiftLeft",
+  "ShiftRight",
+  "AltLeft",
+  "AltRight",
+  "MetaLeft",
+  "MetaRight",
+]);
+
+/** An accelerator in the form the X11 grabber parses, from a key event. */
+export function acceleratorFrom(e: {
+  code: string;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+}): string | null {
+  if (MODIFIER_CODES.has(e.code) || !e.code) return null;
+  const parts: string[] = [];
+  if (e.ctrlKey) parts.push("Ctrl");
+  if (e.shiftKey) parts.push("Shift");
+  if (e.altKey) parts.push("Alt");
+  if (e.metaKey) parts.push("Super");
+  parts.push(e.code);
+  return parts.join("+");
+}
+
+export function HotkeysSection({ onError }: Readonly<{ onError: (e: string) => void }>) {
+  const [status, setStatus] = useState<HotkeyStatus | null>(null);
+  const [capturing, setCapturing] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setStatus(await invoke<HotkeyStatus>("get_hotkeys"));
+    } catch (e) {
+      onError(String(e));
+    }
+  }, [onError]);
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!capturing) return;
+    const onKey = (e: KeyboardEvent) => {
+      e.preventDefault();
+      if (e.key === "Escape") {
+        setCapturing(null);
+        return;
+      }
+      const trigger = acceleratorFrom(e);
+      if (!trigger) return;
+      const id = capturing;
+      setCapturing(null);
+      void invoke("set_hotkey_binding", { id, trigger })
+        .then(refresh)
+        .catch((err) => onError(String(err)));
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [capturing, refresh, onError]);
+
+  const setStep = (step: number) => {
+    void invoke("set_balance_step", { step })
+      .then(refresh)
+      .catch((e) => onError(String(e)));
+  };
+  const configure = () => {
+    void invoke("configure_hotkeys")
+      .then(refresh)
+      .catch((e) => onError(String(e)));
+  };
+
+  if (!status) return null;
+  return (
+    <>
+      <div className="section-label">Hotkeys</div>
+      <div className="card" style={{ padding: "var(--sp-2)" }}>
+        {status.backend === "none" && (
+          <div className="row">
+            <div className="ricon">
+              <Ms name="keyboard" />
+            </div>
+            <div className="rmain">
+              <div className="rtitle">Global hotkeys aren’t available here</div>
+              <div className="rsub">
+                They need a desktop with the GlobalShortcuts portal (KDE Plasma, GNOME 48, Hyprland) or an X11 session
+              </div>
+            </div>
+          </div>
+        )}
+        {status.shortcuts.map((s) => (
+          <div className="row" key={s.id}>
+            <div className="ricon">
+              <Ms name={ICONS[s.id] ?? "keyboard"} />
+            </div>
+            <div className="rmain">
+              <div className="rtitle">{s.description}</div>
+              <div className="rsub">{capturing === s.id ? "Press the new keys, Esc to cancel" : s.trigger || "Not bound"}</div>
+            </div>
+            {status.backend === "x11" && (
+              <button type="button" className="modal-btn" onClick={() => setCapturing(capturing === s.id ? null : s.id)}>
+                {capturing === s.id ? "Cancel" : "Change"}
+              </button>
+            )}
+          </div>
+        ))}
+        {status.backend === "portal" && (
+          <div className="row">
+            <div className="ricon">
+              <Ms name="tune" />
+            </div>
+            <div className="rmain">
+              <div className="rtitle">Key bindings</div>
+              <div className="rsub">Kept by your desktop; also under System Settings › Shortcuts</div>
+            </div>
+            <button type="button" className="modal-btn primary" onClick={configure}>
+              Set up hotkeys
+            </button>
+          </div>
+        )}
+        <div className="row">
+          <div className="ricon">
+            <Ms name="swap_horiz" />
+          </div>
+          <div className="rmain">
+            <div className="rtitle">Balance step</div>
+            <div className="rsub">Percentage points the balance moves per press</div>
+          </div>
+          <div className="seg" role="radiogroup" aria-label="Balance step">
+            {status.steps.map((v) => (
+              <button
+                type="button"
+                key={v}
+                role="radio"
+                aria-checked={v === status.balance_step}
+                className={"seg-btn" + (v === status.balance_step ? " active" : "")}
+                onClick={() => setStep(v)}
+              >
+                {v}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/Settings/HotkeysSection.tsx
+++ b/src/components/Settings/HotkeysSection.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import type { HotkeyStatus } from "../../types";
 import { Ms } from "../Icons";
@@ -53,6 +54,15 @@ export function HotkeysSection({ onError }: Readonly<{ onError: (e: string) => v
   }, [onError]);
   useEffect(() => {
     void refresh();
+    // The desktop owns the bindings; pick up edits made there, and re-read
+    // when the window comes back from its settings.
+    const onFocus = () => void refresh();
+    window.addEventListener("focus", onFocus);
+    const unlisten = listen("hotkeys-changed", onFocus);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      void unlisten.then((stop) => stop());
+    };
   }, [refresh]);
 
   useEffect(() => {
@@ -105,18 +115,17 @@ export function HotkeysSection({ onError }: Readonly<{ onError: (e: string) => v
           </div>
         )}
         {status.shortcuts.map((s) => (
-          <div className="row" key={s.id}>
-            <div className="ricon">
-              <Ms name={ICONS[s.id] ?? "keyboard"} />
-            </div>
+          <div className="row row-compact" key={s.id}>
+            <Ms name={ICONS[s.id] ?? "keyboard"} className="row-compact-icon" />
             <div className="rmain">
               <div className="rtitle">{s.description}</div>
-              <div className="rsub">{capturing === s.id ? "Press the new keys, Esc to cancel" : s.trigger || "Not bound"}</div>
             </div>
-            {status.backend === "x11" && (
-              <button type="button" className="modal-btn" onClick={() => setCapturing(capturing === s.id ? null : s.id)}>
-                {capturing === s.id ? "Cancel" : "Change"}
+            {status.backend === "x11" ? (
+              <button type="button" className="kbd kbd-btn" onClick={() => setCapturing(capturing === s.id ? null : s.id)}>
+                {capturing === s.id ? "Press keys…" : s.trigger || "Not bound"}
               </button>
+            ) : (
+              <span className={"kbd" + (s.trigger ? "" : " kbd-unbound")}>{s.trigger || "Not bound"}</span>
             )}
           </div>
         ))}

--- a/src/components/Settings/HotkeysSection.tsx
+++ b/src/components/Settings/HotkeysSection.tsx
@@ -32,6 +32,8 @@ export function acceleratorFrom(e: {
   metaKey: boolean;
 }): string | null {
   if (MODIFIER_CODES.has(e.code) || !e.code) return null;
+  // A bare key would be grabbed from every other app on the desktop.
+  if (!e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey) return null;
   const parts: string[] = [];
   if (e.ctrlKey) parts.push("Ctrl");
   if (e.shiftKey) parts.push("Shift");
@@ -109,7 +111,7 @@ export function HotkeysSection({ onError }: Readonly<{ onError: (e: string) => v
             <div className="rmain">
               <div className="rtitle">Global hotkeys aren’t available here</div>
               <div className="rsub">
-                They need a desktop with the GlobalShortcuts portal (KDE Plasma, GNOME 48, Hyprland) or an X11 session
+                They need a desktop that implements the GlobalShortcuts portal (KDE Plasma, recent GNOME, Hyprland) or an X11 session
               </div>
             </div>
           </div>
@@ -121,7 +123,11 @@ export function HotkeysSection({ onError }: Readonly<{ onError: (e: string) => v
               <div className="rtitle">{s.description}</div>
             </div>
             {status.backend === "x11" ? (
-              <button type="button" className="kbd kbd-btn" onClick={() => setCapturing(capturing === s.id ? null : s.id)}>
+              <button
+                type="button"
+                className={"kbd kbd-btn" + (s.trigger ? "" : " kbd-unbound")}
+                onClick={() => setCapturing(capturing === s.id ? null : s.id)}
+              >
                 {capturing === s.id ? "Press keys…" : s.trigger || "Not bound"}
               </button>
             ) : (

--- a/src/components/Settings/SettingsScreen.tsx
+++ b/src/components/Settings/SettingsScreen.tsx
@@ -5,6 +5,7 @@ import { useMixerStore } from "../../store/mixer";
 import { useTheme, THEMES } from "../../store/theme";
 import type { OutputDevice } from "../../types";
 import { Ms } from "../Icons";
+import { HotkeysSection } from "./HotkeysSection";
 import { ConfirmModal } from "../ConfirmModal";
 import { MenuItem } from "../MenuItem";
 import { Popover } from "../Popover";
@@ -196,6 +197,8 @@ export function SettingsScreen() {
             </div>
           </div>
         </div>
+
+        <HotkeysSection onError={setError} />
 
         <div className="section-label">Preferences</div>
         <div className="card" style={{ padding: "var(--sp-2)" }}>

--- a/src/components/Settings/SettingsScreen.tsx
+++ b/src/components/Settings/SettingsScreen.tsx
@@ -198,8 +198,6 @@ export function SettingsScreen() {
           </div>
         </div>
 
-        <HotkeysSection onError={setError} />
-
         <div className="section-label">Preferences</div>
         <div className="card" style={{ padding: "var(--sp-2)" }}>
           <div className="row">
@@ -284,6 +282,8 @@ export function SettingsScreen() {
             </div>
           )}
         </div>
+
+        <HotkeysSection onError={setError} />
 
         <div className="section-label">About</div>
         <div className="card" style={{ padding: "var(--sp-2)" }}>

--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -71,6 +71,15 @@ export function useAudio() {
     };
   }, [onProfileChanged]);
 
+  // A hotkey moved the balance in the backend; the strips need the volumes.
+  const fetchChannels = useMixerStore((s) => s.fetchChannels);
+  useEffect(() => {
+    const unlisten = listen("channels-changed", () => void fetchChannels());
+    return () => {
+      void unlisten.then((fn) => fn());
+    };
+  }, [fetchChannels]);
+
   // Hardware profile auto-switch: when a device with a bound profile
   // appears, load that profile (Sonar-style).
   const seenDevices = useRef<Set<string> | null>(null);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2503,3 +2503,30 @@ body,
   border-color: var(--border);
   color: var(--fg-secondary);
 }
+
+/* Segmented picker (balance step). */
+.seg {
+  display: flex;
+  gap: 2px;
+  padding: 2px;
+  background: var(--bg-active);
+  border-radius: var(--r-sm);
+}
+.seg-btn {
+  min-width: 34px;
+  padding: 4px 8px;
+  border: 0;
+  border-radius: var(--r-xs);
+  background: transparent;
+  color: var(--fg-secondary);
+  font: inherit;
+  font-size: var(--fs-caption);
+  cursor: pointer;
+}
+.seg-btn:hover {
+  color: var(--fg-primary);
+}
+.seg-btn.active {
+  background: var(--bg-surface);
+  color: var(--fg-primary);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2530,3 +2530,36 @@ body,
   background: var(--bg-surface);
   color: var(--fg-primary);
 }
+
+/* Compact settings rows: one line, the value on the right as a key cap. */
+.row-compact {
+  padding: var(--sp-2) var(--sp-4);
+}
+.row-compact-icon {
+  font-size: 18px;
+  color: var(--fg-muted);
+  width: 24px;
+  text-align: center;
+}
+.kbd {
+  font-family: inherit;
+  font-size: var(--fs-caption);
+  color: var(--fg-primary);
+  background: var(--bg-active);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: var(--r-xs);
+  padding: 2px 8px;
+  white-space: nowrap;
+}
+.kbd-unbound {
+  color: var(--fg-muted);
+  background: transparent;
+  border-style: dashed;
+}
+.kbd-btn {
+  cursor: pointer;
+}
+.kbd-btn:hover {
+  border-color: var(--accent);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1900,22 +1900,33 @@ body,
 .bal-side .ms {
   font-size: 16px;
 }
+/* The hit area is the full title-bar height; the visible line stays 5px,
+   so a drag or a double-click to recentre doesn't need pixel aim. */
 .bal-track {
   position: relative;
   width: 110px;
+  height: 24px;
+  cursor: pointer;
+}
+.bal-track::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
   height: 5px;
+  transform: translateY(-50%);
   border-radius: var(--r-pill);
   background: var(--bg-main);
   border: 1px solid var(--border);
-  cursor: pointer;
 }
 .bal-center {
   position: absolute;
   left: 50%;
-  top: -4px;
-  bottom: -4px;
+  top: 50%;
+  height: 13px;
   width: 2px;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   background: var(--fg-muted);
   opacity: 0.5;
   border-radius: 1px;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -172,4 +172,18 @@ export const MAX_MIC_GAIN = 200;
 /** Levels key for the mic chain. */
 export const MIC_LEVEL_KEY = "sink_mic";
 /** Node name of the always-on master mix (carries every channel). */
+export interface HotkeyShortcut {
+  id: string;
+  description: string;
+  /** Human-readable key; empty when nothing is bound yet. */
+  trigger: string;
+}
+
+export interface HotkeyStatus {
+  backend: "portal" | "x11" | "none";
+  shortcuts: HotkeyShortcut[];
+  balance_step: number;
+  steps: number[];
+}
+
 export const MASTER_BUS = "sink_stream";


### PR DESCRIPTION
Closes #57.

**Problem**

No way to switch profiles or move the balance without alt-tabbing to sink. Under wayland an app can't grab keys on its own, so the usual global shortcut plugin doesn't work there.

**Fix**

Hotkeys through the desktop portal's GlobalShortcuts interface, with a fallback for plain x11.

- five actions: next profile, previous profile, balance toward A, toward B, center
- suggested keys `ctrl+alt+]` / `[` for profiles and `ctrl+alt+,` / `.` / `/` for balance, the desktop shows its own dialog the first time and owns the bindings after that
- works on kde plasma, gnome 48+ and hyprland. an x11 session without the portal grabs the keys directly and keeps them in `hotkeys.json`
- settings gets a hotkeys section: current key per action, a button that opens the desktop's shortcut settings (or press-a-key on x11), and a balance step of 1, 10, 15 or 25
- the app registers itself with the portal as `us.echo.Sink` and ships a hidden desktop entry of that name, otherwise the shortcuts show up under whatever launched it

Profile switching uses the same path as the tray menu, balance uses the slider's own maths, both unit tested. The steelseries dial from the issue isn't in here, the actions are plain functions a dial driver can call later.
