### PR TITLE
chore: format the crate with rustfmt

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -55,6 +55,7 @@ jobs:
       - run: npm ci
       - run: npx tsc --noEmit
       - run: npm test
+      - run: cargo fmt --manifest-path src-tauri/Cargo.toml --check
       - run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
       - run: cargo test --manifest-path src-tauri/Cargo.toml
 

--- a/src-tauri/src/audio/backend.rs
+++ b/src-tauri/src/audio/backend.rs
@@ -79,7 +79,12 @@ pub trait AudioBackend: Send + Sync {
     /// no override, same as the direct path). Independent of the member's
     /// own volume/EQ and of what you hear locally - only that mix's
     /// recorders/listeners hear the difference. Native-only.
-    fn set_bus_member_gain(&self, bus_name: &str, member: &str, percent: u8) -> Result<(), SinkError>;
+    fn set_bus_member_gain(
+        &self,
+        bus_name: &str,
+        member: &str,
+        percent: u8,
+    ) -> Result<(), SinkError>;
 
     /// Monitor a channel/mix/mic on the system default output (session
     /// scoped, an extra passive link set). Native-only.

--- a/src-tauri/src/audio/eq_import.rs
+++ b/src-tauri/src/audio/eq_import.rs
@@ -103,10 +103,9 @@ mod tests {
 
     #[test]
     fn parses_comma_separated_values() {
-        let config = parse_autoeq(
-            "Preamp: -3,7 dB\nFilter 1: ON PK Fc 195 Hz Gain -7,3 dB Q 0,5\n",
-        )
-        .expect("parses");
+        let config =
+            parse_autoeq("Preamp: -3,7 dB\nFilter 1: ON PK Fc 195 Hz Gain -7,3 dB Q 0,5\n")
+                .expect("parses");
         assert_eq!(config.preamp_db, -3.7);
         assert_eq!(config.bands.len(), 1);
         let b = &config.bands[0];
@@ -118,10 +117,9 @@ mod tests {
 
     #[test]
     fn parses_preamp_and_peaking_filter() {
-        let config = parse_autoeq(
-            "Preamp: -6.0 dB\nFilter 1: ON PK Fc 105 Hz Gain -2.4 dB Q 0.70\n",
-        )
-        .expect("parses");
+        let config =
+            parse_autoeq("Preamp: -6.0 dB\nFilter 1: ON PK Fc 105 Hz Gain -2.4 dB Q 0.70\n")
+                .expect("parses");
         assert_eq!(config.preamp_db, -6.0);
         assert_eq!(config.bands.len(), 1);
         let b = &config.bands[0];
@@ -152,7 +150,10 @@ mod tests {
         )
         .expect("parses");
         assert_eq!(config.bands[0].kind, EqBandKind::LowShelf);
-        assert_eq!(config.bands[0].q, 0.71, "shelf without Q gets the slope default");
+        assert_eq!(
+            config.bands[0].q, 0.71,
+            "shelf without Q gets the slope default"
+        );
         assert_eq!(config.bands[1].kind, EqBandKind::HighShelf);
         assert_eq!(config.bands[2].kind, EqBandKind::HighPass);
     }
@@ -190,10 +191,9 @@ mod tests {
 
     #[test]
     fn out_of_range_values_are_clamped() {
-        let config = parse_autoeq(
-            "Preamp: -80.0 dB\nFilter 1: ON PK Fc 99999 Hz Gain 80 dB Q 900\n",
-        )
-        .expect("parses");
+        let config =
+            parse_autoeq("Preamp: -80.0 dB\nFilter 1: ON PK Fc 99999 Hz Gain 80 dB Q 900\n")
+                .expect("parses");
         assert_eq!(config.preamp_db, -24.0);
         assert_eq!(config.bands[0].freq_hz, 20000.0);
         assert_eq!(config.bands[0].gain_db, 24.0);

--- a/src-tauri/src/audio/icons.rs
+++ b/src-tauri/src/audio/icons.rs
@@ -214,7 +214,9 @@ fn exe_basename(pid: u32) -> Option<String> {
 fn load_desktops() -> Vec<DesktopEntry> {
     let mut entries = Vec::new();
     for dir in desktop_dirs() {
-        let Ok(read) = fs::read_dir(&dir) else { continue };
+        let Ok(read) = fs::read_dir(&dir) else {
+            continue;
+        };
         for file in read.flatten() {
             let path = file.path();
             if path.extension().is_some_and(|e| e == "desktop") {

--- a/src-tauri/src/audio/pactl.rs
+++ b/src-tauri/src/audio/pactl.rs
@@ -275,11 +275,7 @@ impl AudioBackend for PactlBackend {
     }
 
     fn set_sink_volume(&self, sink_name: &str, volume_percent: u8) -> Result<(), SinkError> {
-        Self::run(&[
-            "set-sink-volume",
-            sink_name,
-            &format!("{volume_percent}%"),
-        ])?;
+        Self::run(&["set-sink-volume", sink_name, &format!("{volume_percent}%")])?;
         Ok(())
     }
 
@@ -365,7 +361,12 @@ impl AudioBackend for PactlBackend {
         ))
     }
 
-    fn set_bus_member_gain(&self, _bus_name: &str, _member: &str, _percent: u8) -> Result<(), SinkError> {
+    fn set_bus_member_gain(
+        &self,
+        _bus_name: &str,
+        _member: &str,
+        _percent: u8,
+    ) -> Result<(), SinkError> {
         Err(SinkError::Config(
             "per-mix send levels require the native PipeWire backend".into(),
         ))
@@ -378,8 +379,12 @@ impl AudioBackend for PactlBackend {
     }
 
     fn get_default_devices(&self) -> Result<(Option<String>, Option<String>), SinkError> {
-        let sink = Self::run(&["get-default-sink"]).ok().map(|s| s.trim().to_string());
-        let source = Self::run(&["get-default-source"]).ok().map(|s| s.trim().to_string());
+        let sink = Self::run(&["get-default-sink"])
+            .ok()
+            .map(|s| s.trim().to_string());
+        let source = Self::run(&["get-default-source"])
+            .ok()
+            .map(|s| s.trim().to_string());
         Ok((
             sink.filter(|s| !s.is_empty()),
             source.filter(|s| !s.is_empty()),
@@ -495,6 +500,9 @@ mod tests {
         let inputs: Vec<PactlSinkInput> =
             serde_json::from_str(json).expect("sink-input json should parse");
         assert_eq!(inputs[0].index, 12);
-        assert_eq!(prop(&inputs[0].properties, "application.name"), Some("Firefox"));
+        assert_eq!(
+            prop(&inputs[0].properties, "application.name"),
+            Some("Firefox")
+        );
     }
 }

--- a/src-tauri/src/audio/presets.rs
+++ b/src-tauri/src/audio/presets.rs
@@ -40,8 +40,7 @@ include!(concat!(env!("OUT_DIR"), "/eq_presets_generated.rs"));
 
 /// Parse one bundled source, or explain why it's unusable.
 fn parse_bundled(stem: &str, raw: &str) -> Result<EqPreset, String> {
-    let preset: EqPreset =
-        serde_json::from_str(raw).map_err(|e| format!("preset {stem}: {e}"))?;
+    let preset: EqPreset = serde_json::from_str(raw).map_err(|e| format!("preset {stem}: {e}"))?;
     if preset.schema != PRESET_SCHEMA {
         return Err(format!(
             "preset {stem}: unsupported schema {}",

--- a/src-tauri/src/audio/pw_native/dsp.rs
+++ b/src-tauri/src/audio/pw_native/dsp.rs
@@ -125,7 +125,11 @@ impl DspChain {
                     self.gate_hold -= 1;
                 }
                 let target = if open || self.gate_hold > 0 { 1.0 } else { 0.0 };
-                let c = if target > self.gate_gain { gate_att } else { gate_rel };
+                let c = if target > self.gate_gain {
+                    gate_att
+                } else {
+                    gate_rel
+                };
                 self.gate_gain = target + c * (self.gate_gain - target);
                 x *= self.gate_gain;
             }
@@ -204,15 +208,19 @@ mod tests {
     fn gate_blocks_noise_floor_but_passes_speech() {
         let mut chain = DspChain::new(48000.0);
         // quiet hiss well below -45 dB (~0.001 ≈ -60 dB)
-        let mut hiss: Vec<f32> = (0..4800).map(|i| 0.001 * ((i % 7) as f32 - 3.0) / 3.0).collect();
+        let mut hiss: Vec<f32> = (0..4800)
+            .map(|i| 0.001 * ((i % 7) as f32 - 3.0) / 3.0)
+            .collect();
         chain.process(&mut hiss, &settings(true, false, false, 1.0));
-        assert!(peak(&hiss) < 0.0005, "noise should be gated, got {}", peak(&hiss));
+        assert!(
+            peak(&hiss) < 0.0005,
+            "noise should be gated, got {}",
+            peak(&hiss)
+        );
 
         // loud signal (~-12 dB) opens the gate
         let mut chain = DspChain::new(48000.0);
-        let mut voice: Vec<f32> = (0..4800)
-            .map(|i| 0.25 * (i as f32 * 0.05).sin())
-            .collect();
+        let mut voice: Vec<f32> = (0..4800).map(|i| 0.25 * (i as f32 * 0.05).sin()).collect();
         chain.process(&mut voice, &settings(true, false, false, 1.0));
         // after the attack settles, the tail should be near full level
         assert!(peak(&voice[2400..]) > 0.2, "speech should pass the gate");
@@ -246,6 +254,11 @@ mod tests {
         let mut buf: Vec<f32> = (0..48000).map(|i| 0.9 * (i as f32 * 0.07).sin()).collect();
         chain.process(&mut buf, &settings(false, false, true, 4.0));
         let ceiling = db_to_linear(-1.0);
-        assert!(peak(&buf) <= ceiling + 1e-4, "peak {} above ceiling {}", peak(&buf), ceiling);
+        assert!(
+            peak(&buf) <= ceiling + 1e-4,
+            "peak {} above ceiling {}",
+            peak(&buf),
+            ceiling
+        );
     }
 }

--- a/src-tauri/src/audio/pw_native/eq.rs
+++ b/src-tauri/src/audio/pw_native/eq.rs
@@ -67,8 +67,7 @@ impl BiquadCoeffs {
                 // Shelf slope form: alpha from S, the cookbook's
                 // "shelf slope" parameterization.
                 let s = q;
-                let alpha =
-                    sin_w0 / 2.0 * ((a + 1.0 / a) * (1.0 / s - 1.0) + 2.0).max(0.0).sqrt();
+                let alpha = sin_w0 / 2.0 * ((a + 1.0 / a) * (1.0 / s - 1.0) + 2.0).max(0.0).sqrt();
                 let two_sqrt_a_alpha = 2.0 * a.sqrt() * alpha;
                 let (ap1, am1) = (a + 1.0, a - 1.0);
                 if kind == EqBandKind::LowShelf {
@@ -303,8 +302,13 @@ impl EqEngine {
         self.count = params.band_count.load(Ordering::Relaxed).min(MAX_EQ_BANDS);
         for i in 0..self.count {
             let band = params.bands[i].load();
-            self.coeffs[i] =
-                BiquadCoeffs::design(band.kind, band.freq_hz, band.gain_db, band.q, self.sample_rate);
+            self.coeffs[i] = BiquadCoeffs::design(
+                band.kind,
+                band.freq_hz,
+                band.gain_db,
+                band.q,
+                self.sample_rate,
+            );
         }
     }
 
@@ -343,8 +347,8 @@ mod tests {
         let num_im = -(b1 * w.sin() + b2 * (2.0 * w).sin());
         let den_re = 1.0 + a1 * w.cos() + a2 * (2.0 * w).cos();
         let den_im = -(a1 * w.sin() + a2 * (2.0 * w).sin());
-        let mag = ((num_re * num_re + num_im * num_im) / (den_re * den_re + den_im * den_im))
-            .sqrt();
+        let mag =
+            ((num_re * num_re + num_im * num_im) / (den_re * den_re + den_im * den_im)).sqrt();
         (20.0 * mag.log10()) as f32
     }
 
@@ -395,7 +399,10 @@ mod tests {
         let c = BiquadCoeffs::design(EqBandKind::LowShelf, 200.0, 6.0, 0.71, SR);
         let low = measured_gain_db(&c, 40.0, SR);
         let high = measured_gain_db(&c, 4000.0, SR);
-        assert!((low - 6.0).abs() < 0.5, "low end should be ~+6 dB, got {low}");
+        assert!(
+            (low - 6.0).abs() < 0.5,
+            "low end should be ~+6 dB, got {low}"
+        );
         assert!(high.abs() < 0.5, "high end should be flat, got {high}");
     }
 
@@ -405,7 +412,10 @@ mod tests {
         let low = measured_gain_db(&c, 200.0, SR);
         let high = measured_gain_db(&c, 15000.0, SR);
         assert!(low.abs() < 0.5, "low end should be flat, got {low}");
-        assert!((high + 6.0).abs() < 0.6, "high end should be ~-6 dB, got {high}");
+        assert!(
+            (high + 6.0).abs() < 0.6,
+            "high end should be ~-6 dB, got {high}"
+        );
     }
 
     #[test]
@@ -414,7 +424,10 @@ mod tests {
         let pass = measured_gain_db(&c, 100.0, SR);
         let stop = measured_gain_db(&c, 8000.0, SR);
         assert!(pass.abs() < 0.5, "passband should be flat, got {pass}");
-        assert!(stop < -30.0, "stopband should be strongly attenuated, got {stop}");
+        assert!(
+            stop < -30.0,
+            "stopband should be strongly attenuated, got {stop}"
+        );
     }
 
     #[test]
@@ -422,7 +435,10 @@ mod tests {
         let c = BiquadCoeffs::design(EqBandKind::HighPass, 1000.0, 0.0, 0.71, SR);
         let stop = measured_gain_db(&c, 100.0, SR);
         let pass = measured_gain_db(&c, 8000.0, SR);
-        assert!(stop < -30.0, "stopband should be strongly attenuated, got {stop}");
+        assert!(
+            stop < -30.0,
+            "stopband should be strongly attenuated, got {stop}"
+        );
         assert!(pass.abs() < 0.5, "passband should be flat, got {pass}");
     }
 
@@ -441,7 +457,10 @@ mod tests {
         assert_eq!(engine.coeffs[0], expected);
 
         // A second apply with different bands is picked up on next refresh.
-        params.apply(&config(vec![band(EqBandKind::HighPass, 80.0, 0.0, 0.71)], 0.0));
+        params.apply(&config(
+            vec![band(EqBandKind::HighPass, 80.0, 0.0, 0.71)],
+            0.0,
+        ));
         engine.refresh(&params);
         assert_eq!(engine.count, 1);
         let expected = BiquadCoeffs::design(EqBandKind::HighPass, 80.0, 0.0, 0.71, SR);
@@ -492,7 +511,14 @@ mod tests {
     #[test]
     fn cascade_of_ten_flat_bands_is_still_flat() {
         let bands: Vec<EqBand> = (0..MAX_EQ_BANDS)
-            .map(|i| band(EqBandKind::Peaking, 100.0 * (i as f32 + 1.0) * 2.0, 0.0, 1.0))
+            .map(|i| {
+                band(
+                    EqBandKind::Peaking,
+                    100.0 * (i as f32 + 1.0) * 2.0,
+                    0.0,
+                    1.0,
+                )
+            })
             .collect();
         let params = EqParams::from_config(&config(bands, 0.0));
         let mut engine = EqEngine::new(SR);
@@ -524,7 +550,13 @@ mod tests {
         engine.process_interleaved(&mut buf, &params);
         let right_energy: f32 = buf.iter().skip(1).step_by(2).map(|s| s.abs()).sum();
         assert_eq!(right_energy, 0.0, "silent right channel picked up energy");
-        let left_tail = buf[3000..].iter().step_by(2).fold(0.0f32, |m, s| m.max(s.abs()));
-        assert!(left_tail < 0.01, "DC should be blocked on the left, got {left_tail}");
+        let left_tail = buf[3000..]
+            .iter()
+            .step_by(2)
+            .fold(0.0f32, |m, s| m.max(s.abs()));
+        assert!(
+            left_tail < 0.01,
+            "DC should be blocked on the left, got {left_tail}"
+        );
     }
 }

--- a/src-tauri/src/audio/pw_native/eq_chain.rs
+++ b/src-tauri/src/audio/pw_native/eq_chain.rs
@@ -127,7 +127,9 @@ impl EqChainHandle {
                     return;
                 };
                 let datas = buffer.datas_mut();
-                let Some(data) = datas.first_mut() else { return };
+                let Some(data) = datas.first_mut() else {
+                    return;
+                };
                 let valid = data.chunk().size() as usize;
                 let Some(bytes) = data.data() else { return };
 
@@ -139,7 +141,8 @@ impl EqChainHandle {
                         .map(|b| f32::from_ne_bytes([b[0], b[1], b[2], b[3]])),
                 );
 
-                ctx.engine.process_interleaved(&mut ctx.scratch, &ctx.params);
+                ctx.engine
+                    .process_interleaved(&mut ctx.scratch, &ctx.params);
                 ctx.ring.push(&ctx.scratch);
             })
             .register()
@@ -188,7 +191,9 @@ impl EqChainHandle {
                 // interleaved stereo = 2 samples, 8 bytes per frame.
                 let requested = buffer.requested() as usize;
                 let datas = buffer.datas_mut();
-                let Some(data) = datas.first_mut() else { return };
+                let Some(data) = datas.first_mut() else {
+                    return;
+                };
                 let max_bytes = data.data().map(|d| d.len()).unwrap_or(0);
                 let max_frames = max_bytes / 8;
                 let frames = if requested > 0 {

--- a/src-tauri/src/audio/pw_native/levels.rs
+++ b/src-tauri/src/audio/pw_native/levels.rs
@@ -35,13 +35,10 @@ impl LevelStore {
         if let Some(slot) = registry.by_name.get(name) {
             return Some(*slot);
         }
-        let slot = registry
-            .free
-            .pop()
-            .or_else(|| {
-                let next = registry.by_name.len() + registry.free.len();
-                (next < MAX_METERS).then_some(next)
-            })?;
+        let slot = registry.free.pop().or_else(|| {
+            let next = registry.by_name.len() + registry.free.len();
+            (next < MAX_METERS).then_some(next)
+        })?;
         registry.by_name.insert(name.to_string(), slot);
         Some(slot)
     }

--- a/src-tauri/src/audio/pw_native/mic.rs
+++ b/src-tauri/src/audio/pw_native/mic.rs
@@ -59,7 +59,8 @@ impl MicParams {
         self.gain_bits.store(gain.to_bits(), Ordering::Relaxed);
         self.gate.store(config.gate_enabled, Ordering::Relaxed);
         self.comp.store(config.comp_enabled, Ordering::Relaxed);
-        self.limiter.store(config.limiter_enabled, Ordering::Relaxed);
+        self.limiter
+            .store(config.limiter_enabled, Ordering::Relaxed);
         self.muted.store(config.muted, Ordering::Relaxed);
         self.gate_threshold_bits
             .store(config.gate_threshold_db.to_bits(), Ordering::Relaxed);
@@ -200,7 +201,9 @@ impl MicStreams {
                     return;
                 };
                 let datas = buffer.datas_mut();
-                let Some(data) = datas.first_mut() else { return };
+                let Some(data) = datas.first_mut() else {
+                    return;
+                };
                 let valid = data.chunk().size() as usize;
                 let Some(bytes) = data.data() else { return };
 
@@ -270,7 +273,9 @@ impl MicStreams {
                 // quantum) starves the ring and chops the audio.
                 let requested = buffer.requested() as usize;
                 let datas = buffer.datas_mut();
-                let Some(data) = datas.first_mut() else { return };
+                let Some(data) = datas.first_mut() else {
+                    return;
+                };
                 let max_bytes = data.data().map(|d| d.len()).unwrap_or(0);
                 let max_frames = max_bytes / 4;
                 let n = if requested > 0 {

--- a/src-tauri/src/audio/pw_native/mod.rs
+++ b/src-tauri/src/audio/pw_native/mod.rs
@@ -173,7 +173,11 @@ impl AudioBackend for PipeWireBackend {
     fn set_bus_members(&self, name: &str, channels: &[String]) -> Result<(), SinkError> {
         let name = name.to_string();
         let channels = channels.to_vec();
-        self.request(|reply| Cmd::SetBusMembers { name, channels, reply })
+        self.request(|reply| Cmd::SetBusMembers {
+            name,
+            channels,
+            reply,
+        })
     }
 
     fn set_bus_mic(&self, name: &str, mic: bool) -> Result<(), SinkError> {
@@ -181,15 +185,29 @@ impl AudioBackend for PipeWireBackend {
         self.request(|reply| Cmd::SetBusMic { name, mic, reply })
     }
 
-    fn set_bus_member_gain(&self, bus_name: &str, member: &str, percent: u8) -> Result<(), SinkError> {
+    fn set_bus_member_gain(
+        &self,
+        bus_name: &str,
+        member: &str,
+        percent: u8,
+    ) -> Result<(), SinkError> {
         let bus_name = bus_name.to_string();
         let member = member.to_string();
-        self.request(|reply| Cmd::SetBusMemberGain { bus_name, member, percent, reply })
+        self.request(|reply| Cmd::SetBusMemberGain {
+            bus_name,
+            member,
+            percent,
+            reply,
+        })
     }
 
     fn set_monitor(&self, name: &str, enabled: bool) -> Result<(), SinkError> {
         let name = name.to_string();
-        self.request(|reply| Cmd::SetMonitor { name, enabled, reply })
+        self.request(|reply| Cmd::SetMonitor {
+            name,
+            enabled,
+            reply,
+        })
     }
 
     fn list_input_devices(&self) -> Result<Vec<crate::audio::types::OutputDevice>, SinkError> {
@@ -208,7 +226,11 @@ impl AudioBackend for PipeWireBackend {
     ) -> Result<(), SinkError> {
         let sink_name = sink_name.to_string();
         let config = config.clone();
-        self.request(|reply| Cmd::SetChannelEq { sink_name, config, reply })
+        self.request(|reply| Cmd::SetChannelEq {
+            sink_name,
+            config,
+            reply,
+        })
     }
 
     fn get_default_devices(&self) -> Result<(Option<String>, Option<String>), SinkError> {
@@ -217,11 +239,19 @@ impl AudioBackend for PipeWireBackend {
 
     fn set_default_output(&self, name: &str) -> Result<(), SinkError> {
         let name = name.to_string();
-        self.request(|reply| Cmd::SetDefault { input: false, name, reply })
+        self.request(|reply| Cmd::SetDefault {
+            input: false,
+            name,
+            reply,
+        })
     }
 
     fn set_default_input(&self, name: &str) -> Result<(), SinkError> {
         let name = name.to_string();
-        self.request(|reply| Cmd::SetDefault { input: true, name, reply })
+        self.request(|reply| Cmd::SetDefault {
+            input: true,
+            name,
+            reply,
+        })
     }
 }

--- a/src-tauri/src/audio/pw_native/pods.rs
+++ b/src-tauri/src/audio/pw_native/pods.rs
@@ -3,10 +3,10 @@
 
 use std::io::Cursor;
 
-use pipewire::spa as libspa;
 use libspa::pod::deserialize::PodDeserializer;
 use libspa::pod::serialize::PodSerializer;
 use libspa::pod::{Object, Pod, Property, PropertyFlags, Value, ValueArray};
+use pipewire::spa as libspa;
 
 use crate::error::SinkError;
 
@@ -77,9 +77,9 @@ pub fn parse_props(pod: &Pod) -> PropsState {
         if property.key == libspa::sys::SPA_PROP_channelVolumes {
             if let Value::ValueArray(ValueArray::Float(volumes)) = property.value {
                 state.channels = Some(volumes.len());
-                state.volume_linear = volumes.into_iter().fold(None, |acc, v| {
-                    Some(acc.map_or(v, |a: f32| a.max(v)))
-                });
+                state.volume_linear = volumes
+                    .into_iter()
+                    .fold(None, |acc, v| Some(acc.map_or(v, |a: f32| a.max(v))));
             }
         } else if property.key == libspa::sys::SPA_PROP_mute {
             if let Value::Bool(muted) = property.value {

--- a/src-tauri/src/audio/pw_native/send_gain.rs
+++ b/src-tauri/src/audio/pw_native/send_gain.rs
@@ -117,7 +117,9 @@ impl SendGainHandle {
                     return;
                 };
                 let datas = buffer.datas_mut();
-                let Some(data) = datas.first_mut() else { return };
+                let Some(data) = datas.first_mut() else {
+                    return;
+                };
                 let valid = data.chunk().size() as usize;
                 let Some(bytes) = data.data() else { return };
 
@@ -172,7 +174,9 @@ impl SendGainHandle {
                 };
                 let requested = buffer.requested() as usize;
                 let datas = buffer.datas_mut();
-                let Some(data) = datas.first_mut() else { return };
+                let Some(data) = datas.first_mut() else {
+                    return;
+                };
                 let max_bytes = data.data().map(|d| d.len()).unwrap_or(0);
                 let max_frames = max_bytes / 8;
                 let frames = if requested > 0 {

--- a/src-tauri/src/audio/pw_native/thread.rs
+++ b/src-tauri/src/audio/pw_native/thread.rs
@@ -41,40 +41,116 @@ type Reply<T> = mpsc::Sender<Result<T, SinkError>>;
 type LinkSet = Vec<(u32, u32, pw::link::Link)>;
 
 pub enum Cmd {
-    CreateSink { name: String, label: String, reply: Reply<()> },
-    DestroySink { name: String, reply: Reply<()> },
-    ListStreams { reply: Reply<Vec<AppStream>> },
-    ListOutputs { reply: Reply<Vec<OutputDevice>> },
-    ResolvedOutputs { reply: Reply<HashMap<String, Option<String>>> },
-    SetNodeVolumeByName { name: String, percent: u8, reply: Reply<()> },
-    SetNodeMuteByName { name: String, muted: bool, reply: Reply<()> },
-    SetNodeVolumeById { id: u32, percent: u8, reply: Reply<()> },
-    MoveStream { id: u32, sink_name: String, reply: Reply<()> },
+    CreateSink {
+        name: String,
+        label: String,
+        reply: Reply<()>,
+    },
+    DestroySink {
+        name: String,
+        reply: Reply<()>,
+    },
+    ListStreams {
+        reply: Reply<Vec<AppStream>>,
+    },
+    ListOutputs {
+        reply: Reply<Vec<OutputDevice>>,
+    },
+    ResolvedOutputs {
+        reply: Reply<HashMap<String, Option<String>>>,
+    },
+    SetNodeVolumeByName {
+        name: String,
+        percent: u8,
+        reply: Reply<()>,
+    },
+    SetNodeMuteByName {
+        name: String,
+        muted: bool,
+        reply: Reply<()>,
+    },
+    SetNodeVolumeById {
+        id: u32,
+        percent: u8,
+        reply: Reply<()>,
+    },
+    MoveStream {
+        id: u32,
+        sink_name: String,
+        reply: Reply<()>,
+    },
     /// Route a channel's monitor to an output device (None = follow default).
-    SetChannelOutput { sink_name: String, output_name: Option<String>, reply: Reply<()> },
-    SetChannelFailover { sink_name: String, enabled: bool, reply: Reply<()> },
+    SetChannelOutput {
+        sink_name: String,
+        output_name: Option<String>,
+        reply: Reply<()>,
+    },
+    SetChannelFailover {
+        sink_name: String,
+        enabled: bool,
+        reply: Reply<()>,
+    },
     /// Create a mix bus (capturable virtual source).
-    CreateBus { name: String, label: String, reply: Reply<()> },
+    CreateBus {
+        name: String,
+        label: String,
+        reply: Reply<()>,
+    },
     /// Destroy a mix bus and its links.
-    DestroyBus { name: String, reply: Reply<()> },
+    DestroyBus {
+        name: String,
+        reply: Reply<()>,
+    },
     /// Replace the channel set feeding a bus.
-    SetBusMembers { name: String, channels: Vec<String>, reply: Reply<()> },
+    SetBusMembers {
+        name: String,
+        channels: Vec<String>,
+        reply: Reply<()>,
+    },
     /// Include (or drop) the virtual mic as a member of a bus.
-    SetBusMic { name: String, mic: bool, reply: Reply<()> },
+    SetBusMic {
+        name: String,
+        mic: bool,
+        reply: Reply<()>,
+    },
     /// Set one member's send level within one specific mix (0-150%).
-    SetBusMemberGain { bus_name: String, member: String, percent: u8, reply: Reply<()> },
+    SetBusMemberGain {
+        bus_name: String,
+        member: String,
+        percent: u8,
+        reply: Reply<()>,
+    },
     /// Listen to a channel/mix/mic on the default output (session scoped).
-    SetMonitor { name: String, enabled: bool, reply: Reply<()> },
+    SetMonitor {
+        name: String,
+        enabled: bool,
+        reply: Reply<()>,
+    },
     /// Apply mic chain configuration (create/destroy/re-tune as needed).
-    SetMicConfig { config: MicConfig, reply: Reply<()> },
+    SetMicConfig {
+        config: MicConfig,
+        reply: Reply<()>,
+    },
     /// Apply a channel's parametric EQ (create/destroy/re-tune the insert).
-    SetChannelEq { sink_name: String, config: EqConfig, reply: Reply<()> },
+    SetChannelEq {
+        sink_name: String,
+        config: EqConfig,
+        reply: Reply<()>,
+    },
     /// Hardware capture devices (microphones).
-    ListInputs { reply: Reply<Vec<OutputDevice>> },
+    ListInputs {
+        reply: Reply<Vec<OutputDevice>>,
+    },
     /// Current system defaults: (output sink name, input source name).
-    GetDefaults { reply: Reply<(Option<String>, Option<String>)> },
+    GetDefaults {
+        reply: Reply<(Option<String>, Option<String>)>,
+    },
     /// Set the configured system default sink (input=false) or source.
-    SetDefault { input: bool, name: String, reply: Reply<()> },
+    SetDefault {
+        input: bool,
+        name: String,
+        reply: Reply<()>,
+    },
 }
 
 struct PortEntry {
@@ -436,9 +512,7 @@ fn on_global(
                     // than the virtual mic, destroy that link - mic audio
                     // must never leak into the speakers.
                     let mic_stray = match (s.mic_playback_node(), s.node_by_name(MIC_NODE)) {
-                        (Some(playback), mic) if out == playback => {
-                            mic.map(|n| n.id) != Some(inp)
-                        }
+                        (Some(playback), mic) if out == playback => mic.map(|n| n.id) != Some(inp),
                         _ => false,
                     };
                     // Same policing for EQ playback streams: only the links
@@ -446,10 +520,7 @@ fn on_global(
                     // EQ node with no plan yet (chain just built, first
                     // reconcile pending) allows nothing - our own links are
                     // always created after the plan is recorded.
-                    let eq_stray = s
-                        .eq_streams
-                        .values()
-                        .any(|h| h.playback_node_id() == out)
+                    let eq_stray = s.eq_streams.values().any(|h| h.playback_node_id() == out)
                         && !s
                             .eq_desired_targets
                             .get(&out)
@@ -464,10 +535,7 @@ fn on_global(
                             .get(&out)
                             .is_some_and(|allowed| allowed.contains(&inp))
                     };
-                    let send_stray = (s
-                        .send_gains
-                        .values()
-                        .any(|h| h.playback_node_id() == out)
+                    let send_stray = (s.send_gains.values().any(|h| h.playback_node_id() == out)
                         || s.send_gains.values().any(|h| h.capture_node_id() == inp))
                         && !allowed(out, inp);
                     mic_stray || eq_stray || send_stray
@@ -719,7 +787,9 @@ fn build_mic_streams(state: &Rc<RefCell<State>>) {
             .clone()
             .filter(|name| name != MIC_NODE)
     });
-    let Some(levels) = s.levels.clone() else { return };
+    let Some(levels) = s.levels.clone() else {
+        return;
+    };
     match MicStreams::new(&core, &s.mic_config, mic_target.as_deref(), levels) {
         Ok(streams) => {
             s.mic_links.clear();
@@ -898,7 +968,13 @@ fn reconcile_bus_member(
     link: MemberLink,
     eq_targets: &mut HashMap<u32, std::collections::HashSet<u32>>,
 ) {
-    let MemberLink { bus_name, bus_id, member, source_id, included } = link;
+    let MemberLink {
+        bus_name,
+        bus_id,
+        member,
+        source_id,
+        included,
+    } = link;
     let key = (bus_name.to_string(), member.to_string());
     let gain = s.bus_member_gains.get(&key).copied().unwrap_or(100);
 
@@ -1044,7 +1120,8 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
     // real sink, so audio fails over instead of dropping to silence.
     let fallback = fallback_sink(&s);
     // Forget resolved targets for channels that no longer exist.
-    s.channel_targets.retain(|name, _| channel_names.contains(name));
+    s.channel_targets
+        .retain(|name, _| channel_names.contains(name));
 
     // The link plan for every live EQ insert, rebuilt from scratch each
     // pass - the link police destroys anything an EQ playback node feeds
@@ -1065,7 +1142,9 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
         // ---- output device links ----
         let explicit = s.channel_outputs.get(sink_name).cloned().flatten();
         let pinned = explicit.is_some();
-        let explicit_id = explicit.as_deref().and_then(|name| node_ids.get(name).copied());
+        let explicit_id = explicit
+            .as_deref()
+            .and_then(|name| node_ids.get(name).copied());
         let strict = s.channel_strict.contains(sink_name);
         // A user can make one of our channels the system default; following
         // it would loop every follow-default channel (and the channel's own
@@ -1122,7 +1201,13 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
             reconcile_bus_member(
                 &core,
                 &mut s,
-                MemberLink { bus_name, bus_id: *bus_id, member: sink_name, source_id, included },
+                MemberLink {
+                    bus_name,
+                    bus_id: *bus_id,
+                    member: sink_name,
+                    source_id,
+                    included,
+                },
                 &mut eq_targets,
             );
         }
@@ -1210,13 +1295,12 @@ fn node_needs_monitor_volumes(kind: u8) -> bool {
 
 /// The three virtual node shapes we own (kind 0=channel sink, 1=mix bus,
 /// 2=virtual mic). The heal path mirrors the create handlers with this.
-fn create_node_object(
-    core: &CoreRc,
-    name: &str,
-    label: &str,
-    kind: u8,
-) -> Result<Node, pw::Error> {
-    let class = if kind == 0 { SINK_CLASS } else { VIRTUAL_SOURCE_CLASS };
+fn create_node_object(core: &CoreRc, name: &str, label: &str, kind: u8) -> Result<Node, pw::Error> {
+    let class = if kind == 0 {
+        SINK_CLASS
+    } else {
+        VIRTUAL_SOURCE_CLASS
+    };
     let position = if kind == 2 { "[ MONO ]" } else { "[ FL FR ]" };
     let mut props = pw::properties::properties! {
         "factory.name" => "support.null-audio-sink",
@@ -1388,7 +1472,11 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
                 .collect();
             let _ = reply.send(Ok(resolved));
         }
-        Cmd::SetNodeVolumeByName { name, percent, reply } => {
+        Cmd::SetNodeVolumeByName {
+            name,
+            percent,
+            reply,
+        } => {
             let s = state.borrow();
             let _ = reply.send(set_props(s.node_by_name(&name), Some(percent), None));
         }
@@ -1443,7 +1531,11 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
             }
             let _ = reply.send(Ok(()));
         }
-        Cmd::SetBusMembers { name, channels, reply } => {
+        Cmd::SetBusMembers {
+            name,
+            channels,
+            reply,
+        } => {
             state
                 .borrow_mut()
                 .bus_members
@@ -1471,7 +1563,12 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
             ensure_all_links(state);
             let _ = reply.send(Ok(()));
         }
-        Cmd::SetBusMemberGain { bus_name, member, percent, reply } => {
+        Cmd::SetBusMemberGain {
+            bus_name,
+            member,
+            percent,
+            reply,
+        } => {
             let percent = percent.min(150);
             {
                 let mut s = state.borrow_mut();
@@ -1500,7 +1597,11 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
             ensure_all_links(state);
             let _ = reply.send(Ok(()));
         }
-        Cmd::SetMonitor { name, enabled, reply } => {
+        Cmd::SetMonitor {
+            name,
+            enabled,
+            reply,
+        } => {
             {
                 let mut s = state.borrow_mut();
                 if enabled {
@@ -1513,7 +1614,11 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
             ensure_all_links(state);
             let _ = reply.send(Ok(()));
         }
-        Cmd::SetChannelEq { sink_name, config, reply } => {
+        Cmd::SetChannelEq {
+            sink_name,
+            config,
+            reply,
+        } => {
             if !is_virtual_sink(&sink_name) {
                 let _ = reply.send(Err(SinkError::UnknownSink(sink_name)));
                 return;
@@ -1532,10 +1637,7 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
             if needs_destroy {
                 state.borrow_mut().eq_streams.remove(&sink_name);
             } else if needs_create {
-                let sink_id = state
-                    .borrow()
-                    .node_by_name(&sink_name)
-                    .map(|n| n.id);
+                let sink_id = state.borrow().node_by_name(&sink_name).map(|n| n.id);
                 if let Some(sink_id) = sink_id {
                     let Some(core) = CORE.with(|c| c.borrow().clone()) else {
                         let _ = reply.send(Err(SinkError::Config(
@@ -1545,7 +1647,10 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
                     };
                     match EqChainHandle::new(&core, &sink_name, sink_id, &config) {
                         Ok(handle) => {
-                            state.borrow_mut().eq_streams.insert(sink_name.clone(), handle);
+                            state
+                                .borrow_mut()
+                                .eq_streams
+                                .insert(sink_name.clone(), handle);
                         }
                         Err(e) => {
                             let _ = reply.send(Err(e));
@@ -1596,10 +1701,14 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
                     }
                     s.mic_streams = None;
                     s.mic_links.clear();
-                    s.bus_links.retain(|(_, member), _| member.as_str() != MIC_NODE);
-                    s.send_gains.retain(|(_, member), _| member.as_str() != MIC_NODE);
-                    s.send_gain_in_links.retain(|(_, member), _| member.as_str() != MIC_NODE);
-                    s.send_gain_failed.retain(|(_, member)| member.as_str() != MIC_NODE);
+                    s.bus_links
+                        .retain(|(_, member), _| member.as_str() != MIC_NODE);
+                    s.send_gains
+                        .retain(|(_, member), _| member.as_str() != MIC_NODE);
+                    s.send_gain_in_links
+                        .retain(|(_, member), _| member.as_str() != MIC_NODE);
+                    s.send_gain_failed
+                        .retain(|(_, member)| member.as_str() != MIC_NODE);
                     if let Some(proxy) = s.mic_source.take() {
                         // Our own destroy - the heal path should expect this
                         // removal rather than treat it as external and race a
@@ -1617,7 +1726,13 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
                     && s.mic_streams.is_some()
                     && prev.input_device != config.input_device;
                 let source_exists = s.node_by_name(MIC_NODE).is_some();
-                (needs_create, needs_destroy, needs_rebuild, source_exists, orphaned)
+                (
+                    needs_create,
+                    needs_destroy,
+                    needs_rebuild,
+                    source_exists,
+                    orphaned,
+                )
             };
 
             if needs_destroy {
@@ -1626,10 +1741,14 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
                     s.desired.remove(MIC_NODE);
                     s.mic_streams = None;
                     s.mic_links.clear();
-                    s.bus_links.retain(|(_, member), _| member.as_str() != MIC_NODE);
-                    s.send_gains.retain(|(_, member), _| member.as_str() != MIC_NODE);
-                    s.send_gain_in_links.retain(|(_, member), _| member.as_str() != MIC_NODE);
-                    s.send_gain_failed.retain(|(_, member)| member.as_str() != MIC_NODE);
+                    s.bus_links
+                        .retain(|(_, member), _| member.as_str() != MIC_NODE);
+                    s.send_gains
+                        .retain(|(_, member), _| member.as_str() != MIC_NODE);
+                    s.send_gain_in_links
+                        .retain(|(_, member), _| member.as_str() != MIC_NODE);
+                    s.send_gain_failed
+                        .retain(|(_, member)| member.as_str() != MIC_NODE);
                     if let Some(proxy) = s.mic_source.take() {
                         if let Some(core) = CORE.with(|c| c.borrow().clone()) {
                             let _ = core.destroy_object(proxy);
@@ -1753,7 +1872,11 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
             metadata.set_property(0, key, Some("Spa:String:JSON"), Some(&value));
             let _ = reply.send(Ok(()));
         }
-        Cmd::SetChannelOutput { sink_name, output_name, reply } => {
+        Cmd::SetChannelOutput {
+            sink_name,
+            output_name,
+            reply,
+        } => {
             if !is_virtual_sink(&sink_name) {
                 let _ = reply.send(Err(SinkError::UnknownSink(sink_name)));
                 return;
@@ -1765,7 +1888,11 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
             ensure_all_links(state);
             let _ = reply.send(Ok(()));
         }
-        Cmd::SetChannelFailover { sink_name, enabled, reply } => {
+        Cmd::SetChannelFailover {
+            sink_name,
+            enabled,
+            reply,
+        } => {
             if !is_virtual_sink(&sink_name) {
                 let _ = reply.send(Err(SinkError::UnknownSink(sink_name)));
                 return;
@@ -1781,7 +1908,11 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
             ensure_all_links(state);
             let _ = reply.send(Ok(()));
         }
-        Cmd::MoveStream { id, sink_name, reply } => {
+        Cmd::MoveStream {
+            id,
+            sink_name,
+            reply,
+        } => {
             let s = state.borrow();
             let Some(metadata) = s.metadata.as_ref() else {
                 let _ = reply.send(Err(SinkError::Config(
@@ -1916,10 +2047,19 @@ mod tests {
     #[test]
     fn resolve_target_covers_the_failover_matrix() {
         // Pinned and present -> that device, failover on or off.
-        assert_eq!(resolve_target(Some(7), true, false, Some(1), Some(2)), Some(7));
-        assert_eq!(resolve_target(Some(7), true, true, Some(1), Some(2)), Some(7));
+        assert_eq!(
+            resolve_target(Some(7), true, false, Some(1), Some(2)),
+            Some(7)
+        );
+        assert_eq!(
+            resolve_target(Some(7), true, true, Some(1), Some(2)),
+            Some(7)
+        );
         // Follow-default, failover on -> default, else the fallback sink.
-        assert_eq!(resolve_target(None, false, false, Some(1), Some(2)), Some(1));
+        assert_eq!(
+            resolve_target(None, false, false, Some(1), Some(2)),
+            Some(1)
+        );
         assert_eq!(resolve_target(None, false, false, None, Some(2)), Some(2));
         // Follow-default, failover off -> default only; silent when it's gone.
         assert_eq!(resolve_target(None, false, true, Some(1), Some(2)), Some(1));

--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -194,7 +194,8 @@ mod identity_tests {
 
     #[test]
     fn pure_generic_still_shows_something() {
-        let (display, _, value) = resolve(&[("media.name", "audio-src"), ("node.name", "audio-src")]);
+        let (display, _, value) =
+            resolve(&[("media.name", "audio-src"), ("node.name", "audio-src")]);
         assert_eq!(display, "Audio-src");
         assert_eq!(value, "audio-src");
     }
@@ -322,10 +323,25 @@ impl MicConfig {
             }
         }
         self.gain_percent = self.gain_percent.min(200);
-        self.gate_threshold_db = finite(self.gate_threshold_db, default_gate_threshold(), -100.0, 0.0);
-        self.comp_threshold_db = finite(self.comp_threshold_db, default_comp_threshold(), -100.0, 0.0);
+        self.gate_threshold_db = finite(
+            self.gate_threshold_db,
+            default_gate_threshold(),
+            -100.0,
+            0.0,
+        );
+        self.comp_threshold_db = finite(
+            self.comp_threshold_db,
+            default_comp_threshold(),
+            -100.0,
+            0.0,
+        );
         self.comp_ratio = finite(self.comp_ratio, default_comp_ratio(), 1.0, 20.0);
-        self.limiter_ceiling_db = finite(self.limiter_ceiling_db, default_limiter_ceiling(), -60.0, 0.0);
+        self.limiter_ceiling_db = finite(
+            self.limiter_ceiling_db,
+            default_limiter_ceiling(),
+            -60.0,
+            0.0,
+        );
     }
 }
 

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -5,7 +5,6 @@ use crate::audio::types::is_virtual_sink;
 use crate::persistence::wireplumber;
 use crate::state::AppState;
 
-
 /// A seen-app entry enriched with its current routing, alias and icon.
 #[derive(Debug, Clone, Serialize)]
 pub struct SeenApp {
@@ -40,23 +39,23 @@ pub fn get_seen_apps(state: State<'_, AppState>) -> Result<Vec<SeenApp>, String>
                 None,
             );
             SeenApp {
-            match_prop: entry.match_prop.clone(),
-            match_value: entry.match_value.clone(),
-            display_name: resolved
-                .display_name
-                .unwrap_or_else(|| entry.display_name.clone()),
-            icon_name: entry.icon_name.clone(),
-            icon_path: resolved.icon_path,
-            last_seen: entry.last_seen,
-            ignored: entry.ignored,
-            assigned_sink: mixer
-                .assignments
-                .sink_for(&entry.match_prop, &entry.match_value)
-                .map(str::to_string),
-            alias: mixer
-                .aliases
-                .get(&entry.match_prop, &entry.match_value)
-                .map(str::to_string),
+                match_prop: entry.match_prop.clone(),
+                match_value: entry.match_value.clone(),
+                display_name: resolved
+                    .display_name
+                    .unwrap_or_else(|| entry.display_name.clone()),
+                icon_name: entry.icon_name.clone(),
+                icon_path: resolved.icon_path,
+                last_seen: entry.last_seen,
+                ignored: entry.ignored,
+                assigned_sink: mixer
+                    .assignments
+                    .sink_for(&entry.match_prop, &entry.match_value)
+                    .map(str::to_string),
+                alias: mixer
+                    .aliases
+                    .get(&entry.match_prop, &entry.match_value)
+                    .map(str::to_string),
             }
         })
         .collect())

--- a/src-tauri/src/commands/buses.rs
+++ b/src-tauri/src/commands/buses.rs
@@ -46,7 +46,10 @@ pub fn add_bus(state: State<'_, AppState>, label: String) -> Result<(), String> 
             channel_names(&mixer),
         )
     };
-    if let Err(e) = state.backend.create_bus(&def.name, &prefs.decorate(&def.label)) {
+    if let Err(e) = state
+        .backend
+        .create_bus(&def.name, &prefs.decorate(&def.label))
+    {
         let mut mixer = state.lock_mixer()?;
         let _ = mixer.buses.remove(&def.name);
         return Err(e.to_string());
@@ -70,7 +73,10 @@ pub fn add_bus(state: State<'_, AppState>, label: String) -> Result<(), String> 
 pub fn rename_bus(state: State<'_, AppState>, name: String, label: String) -> Result<(), String> {
     let (def, defs, prefs, all) = {
         let mut mixer = state.lock_mixer()?;
-        mixer.buses.rename(&name, &label).map_err(|e| e.to_string())?;
+        mixer
+            .buses
+            .rename(&name, &label)
+            .map_err(|e| e.to_string())?;
         let def = mixer
             .buses
             .get(&name)
@@ -84,7 +90,10 @@ pub fn rename_bus(state: State<'_, AppState>, name: String, label: String) -> Re
         )
     };
 
-    state.backend.destroy_bus(&name).map_err(|e| e.to_string())?;
+    state
+        .backend
+        .destroy_bus(&name)
+        .map_err(|e| e.to_string())?;
     state
         .backend
         .create_bus(&def.name, &prefs.decorate(&def.label))
@@ -96,7 +105,10 @@ pub fn rename_bus(state: State<'_, AppState>, name: String, label: String) -> Re
     // The recreate cleared mic membership in the loop's state.
     if def.mic {
         if let Err(e) = state.backend.set_bus_mic(&def.name, true) {
-            eprintln!("sink: mic membership for renamed mix {} failed: {e}", def.name);
+            eprintln!(
+                "sink: mic membership for renamed mix {} failed: {e}",
+                def.name
+            );
         }
     }
     // The node is fresh; restore its saved level and send gains.
@@ -120,7 +132,10 @@ pub fn remove_bus(state: State<'_, AppState>, name: String) -> Result<(), String
         .buses
         .removable(&name)
         .map_err(|e| e.to_string())?;
-    state.backend.destroy_bus(&name).map_err(|e| e.to_string())?;
+    state
+        .backend
+        .destroy_bus(&name)
+        .map_err(|e| e.to_string())?;
     let defs = {
         let mut mixer = state.lock_mixer()?;
         mixer.buses.remove(&name).map_err(|e| e.to_string())?;
@@ -216,8 +231,8 @@ pub fn set_bus_member_gain(
         if mixer.buses.get(&bus).is_none() {
             return Err(format!("unknown mix: {bus}"));
         }
-        let known_member = member == "sink_mic"
-            || mixer.channel_defs.channels.iter().any(|c| c.name == member);
+        let known_member =
+            member == "sink_mic" || mixer.channel_defs.channels.iter().any(|c| c.name == member);
         if !known_member {
             return Err(format!("unknown mix member: {member}"));
         }
@@ -318,7 +333,10 @@ pub fn set_bus_volume(state: State<'_, AppState>, name: String, volume: u8) -> R
         .map_err(|e| e.to_string())?;
     let defs = {
         let mut mixer = state.lock_mixer()?;
-        mixer.buses.set_volume(&name, volume).map_err(|e| e.to_string())?;
+        mixer
+            .buses
+            .set_volume(&name, volume)
+            .map_err(|e| e.to_string())?;
         crate::commands::profiles::autosave_active(&mixer);
         mixer.buses.clone()
     };
@@ -337,7 +355,10 @@ pub fn set_bus_mute(state: State<'_, AppState>, name: String, muted: bool) -> Re
         .map_err(|e| e.to_string())?;
     let defs = {
         let mut mixer = state.lock_mixer()?;
-        mixer.buses.set_muted(&name, muted).map_err(|e| e.to_string())?;
+        mixer
+            .buses
+            .set_muted(&name, muted)
+            .map_err(|e| e.to_string())?;
         crate::commands::profiles::autosave_active(&mixer);
         mixer.buses.clone()
     };

--- a/src-tauri/src/commands/channels.rs
+++ b/src-tauri/src/commands/channels.rs
@@ -4,7 +4,6 @@ use crate::audio::types::VirtualSink;
 use crate::persistence::wireplumber;
 use crate::state::AppState;
 
-
 /// Create a new channel from a label and icon (sink name is generated).
 /// The new channel starts at 100%, unmuted, following the default output.
 #[tauri::command]
@@ -79,9 +78,12 @@ pub fn reorder_channels(state: State<'_, AppState>, order: Vec<String>) -> Resul
             .reorder(&order)
             .map_err(|e| e.to_string())?;
         // Keep the live strip list in the same order.
-        mixer
-            .channels
-            .sort_by_key(|c| order.iter().position(|n| n == &c.name).unwrap_or(usize::MAX));
+        mixer.channels.sort_by_key(|c| {
+            order
+                .iter()
+                .position(|n| n == &c.name)
+                .unwrap_or(usize::MAX)
+        });
         crate::commands::profiles::autosave_active(&mixer);
         mixer.channel_defs.clone()
     };

--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -27,7 +27,10 @@ pub fn refresh_streams(state: &AppState) -> Result<Vec<AppStream>, String> {
         .refresh_gate
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let mut streams = state.backend.list_app_streams().map_err(|e| e.to_string())?;
+    let mut streams = state
+        .backend
+        .list_app_streams()
+        .map_err(|e| e.to_string())?;
 
     // Desktop-entry resolution: real icon files and polished display names
     // ("spotify" binary → Spotify with its actual icon). Cached per identity.
@@ -199,7 +202,10 @@ pub fn init_virtual_devices(
     // Bring up the user's mixes and their memberships.
     let names: Vec<String> = defs.channels.iter().map(|c| c.name.clone()).collect();
     for bus in &buses.buses {
-        if let Err(e) = state.backend.create_bus(&bus.name, &prefs.decorate(&bus.label)) {
+        if let Err(e) = state
+            .backend
+            .create_bus(&bus.name, &prefs.decorate(&bus.label))
+        {
             eprintln!("sink: creating mix {} failed: {e}", bus.name);
             continue;
         }

--- a/src-tauri/src/commands/mic.rs
+++ b/src-tauri/src/commands/mic.rs
@@ -4,7 +4,6 @@ use crate::audio::types::{MicConfig, OutputDevice};
 use crate::persistence::mic;
 use crate::state::AppState;
 
-
 #[tauri::command]
 pub fn get_mic_config(state: State<'_, AppState>) -> Result<MicConfig, String> {
     let mixer = state.lock_mixer()?;

--- a/src-tauri/src/commands/profiles.rs
+++ b/src-tauri/src/commands/profiles.rs
@@ -60,7 +60,11 @@ pub fn set_profile_trigger(
     name: String,
     device: String,
 ) -> Result<(), String> {
-    let trigger = if device.is_empty() { None } else { Some(device) };
+    let trigger = if device.is_empty() {
+        None
+    } else {
+        Some(device)
+    };
     profiles::set_trigger(&name, trigger.clone()).map_err(|e| e.to_string())?;
     // Keep the cache in step so a later autosave doesn't overwrite the trigger
     // we just set on the active profile with a stale value.
@@ -172,7 +176,10 @@ pub fn load_profile(
     }
     for bus in &target_buses.buses {
         if current_buses.get(&bus.name).is_none() {
-            if let Err(e) = state.backend.create_bus(&bus.name, &prefs.decorate(&bus.label)) {
+            if let Err(e) = state
+                .backend
+                .create_bus(&bus.name, &prefs.decorate(&bus.label))
+            {
                 eprintln!("sink: profile mix {} failed: {e}", bus.name);
                 continue;
             }
@@ -184,7 +191,10 @@ pub fn load_profile(
             eprintln!("sink: profile members for mix {} failed: {e}", bus.name);
         }
         if let Err(e) = state.backend.set_bus_mic(&bus.name, bus.mic) {
-            eprintln!("sink: profile mic membership for mix {} failed: {e}", bus.name);
+            eprintln!(
+                "sink: profile mic membership for mix {} failed: {e}",
+                bus.name
+            );
         }
         crate::commands::buses::apply_bus_level(state.backend.as_ref(), bus);
         crate::commands::buses::apply_bus_member_gains(state.backend.as_ref(), bus);

--- a/src-tauri/src/commands/routing.rs
+++ b/src-tauri/src/commands/routing.rs
@@ -43,7 +43,10 @@ pub fn route_app(state: &AppState, stream_index: u32, sink_name: &str) -> Result
     }
 
     // Assignments are per app, not per stream: siblings move too.
-    let streams = state.backend.list_app_streams().map_err(|e| e.to_string())?;
+    let streams = state
+        .backend
+        .list_app_streams()
+        .map_err(|e| e.to_string())?;
     let Some(stream) = streams.iter().find(|s| s.index == stream_index) else {
         // Vanished between the click and now; move the raw index anyway in
         // case the listing raced, with nothing to record against it.
@@ -164,7 +167,11 @@ pub fn set_monitor(
     {
         let mixer = state.lock_mixer()?;
         let known = sink_name == "sink_mic"
-            || mixer.channel_defs.channels.iter().any(|c| c.name == sink_name)
+            || mixer
+                .channel_defs
+                .channels
+                .iter()
+                .any(|c| c.name == sink_name)
             || mixer.buses.buses.iter().any(|b| b.name == sink_name);
         if !known {
             return Err(format!("unknown monitor target: {sink_name}"));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -186,7 +186,11 @@ fn spawn_route_enforcer(handle: tauri::AppHandle) {
         let mut last_error: Option<String> = None;
         let mut failures: u32 = 0;
         loop {
-            let pause = if failures >= 3 { interval * 10 } else { interval };
+            let pause = if failures >= 3 {
+                interval * 10
+            } else {
+                interval
+            };
             std::thread::sleep(pause);
             let state = handle.state::<AppState>();
             if !native && state.ui_polled_within(UI_POLL_GRACE) {
@@ -251,9 +255,7 @@ fn spawn_level_emitter(handle: tauri::AppHandle, levels: Arc<LevelStore>) {
 
 /// Build the tray menu, including the live Profiles submenu (check on the
 /// active profile). Rebuilt via `refresh_tray` whenever profiles change.
-fn build_tray_menu(
-    app: &tauri::AppHandle,
-) -> Result<Menu<tauri::Wry>, Box<dyn std::error::Error>> {
+fn build_tray_menu(app: &tauri::AppHandle) -> Result<Menu<tauri::Wry>, Box<dyn std::error::Error>> {
     use tauri::menu::{IsMenuItem, Submenu};
 
     let show = MenuItem::with_id(app, "show", "Show Window", true, None::<&str>)?;
@@ -318,11 +320,7 @@ fn build_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             let id = event.id.as_ref();
             if let Some(name) = id.strip_prefix("profile:") {
                 // Switch profiles straight from the tray; tell the UI.
-                match commands::profiles::load_profile(
-                    app.clone(),
-                    app.state(),
-                    name.to_string(),
-                ) {
+                match commands::profiles::load_profile(app.clone(), app.state(), name.to_string()) {
                     Ok(()) => {
                         let _ = app.emit("profile-changed", name);
                     }

--- a/src-tauri/src/mixer/state.rs
+++ b/src-tauri/src/mixer/state.rs
@@ -144,7 +144,10 @@ mod tests {
         assert!(state.initialized);
         assert_eq!(state.channels[0].name, "sink_game");
         assert_eq!(state.channels[0].label, "Game");
-        assert!(state.channels.iter().all(|c| c.volume_percent == 100 && !c.muted));
+        assert!(state
+            .channels
+            .iter()
+            .all(|c| c.volume_percent == 100 && !c.muted));
     }
 
     #[test]
@@ -154,7 +157,9 @@ mod tests {
         let old = now - 30 * DAY;
         let mut state = MixerState::default();
         for value in ["plain", "assigned", "aliased"] {
-            state.seen.upsert("application.name", value, value, None, old);
+            state
+                .seen
+                .upsert("application.name", value, value, None, old);
         }
         state
             .assignments
@@ -239,7 +244,9 @@ mod tests {
             .assignments
             .set("application.name", "Firefox", "sink_game");
         assert_eq!(
-            state.plan_auto_routes(&[stream(7, 100, "Firefox", None)]).len(),
+            state
+                .plan_auto_routes(&[stream(7, 100, "Firefox", None)])
+                .len(),
             1
         );
 

--- a/src-tauri/src/persistence/autostart.rs
+++ b/src-tauri/src/persistence/autostart.rs
@@ -25,7 +25,10 @@ fn render_unit() -> Result<String, SinkError> {
     // however unlikely) don't split into command + arguments.
     let exe = format!(
         "\"{}\"",
-        exe.display().to_string().replace('\\', "\\\\").replace('"', "\\\"")
+        exe.display()
+            .to_string()
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
     );
     // Boot to tray on login when the user asked for it. Only the autostart
     // launch carries this flag, so manual launches still show the window.

--- a/src-tauri/src/persistence/buses.rs
+++ b/src-tauri/src/persistence/buses.rs
@@ -243,7 +243,9 @@ impl Buses {
     pub fn add(&mut self, label: &str) -> Result<BusDef, SinkError> {
         let label = label.trim();
         if label.is_empty() || label.len() > 24 {
-            return Err(SinkError::Config("mix label must be 1-24 characters".into()));
+            return Err(SinkError::Config(
+                "mix label must be 1-24 characters".into(),
+            ));
         }
         // The master mix doesn't count against the user's mixes.
         if self.buses.iter().filter(|b| !is_master(&b.name)).count() >= MAX_BUSES {
@@ -278,7 +280,9 @@ impl Buses {
     pub fn rename(&mut self, name: &str, label: &str) -> Result<(), SinkError> {
         let label = label.trim();
         if label.is_empty() || label.len() > 24 {
-            return Err(SinkError::Config("mix label must be 1-24 characters".into()));
+            return Err(SinkError::Config(
+                "mix label must be 1-24 characters".into(),
+            ));
         }
         let def = self
             .buses
@@ -356,7 +360,12 @@ impl Buses {
 
     /// Unity (100) drops the entry, so a fader back at rest doesn't bloat
     /// the persisted file.
-    pub fn set_member_gain(&mut self, name: &str, member: &str, percent: u8) -> Result<(), SinkError> {
+    pub fn set_member_gain(
+        &mut self,
+        name: &str,
+        member: &str,
+        percent: u8,
+    ) -> Result<(), SinkError> {
         let def = self
             .buses
             .iter_mut()
@@ -419,7 +428,9 @@ mod tests {
     fn master_is_protected_and_auto_synced() {
         let mut b = Buses::default();
         assert!(b.remove("sink_stream").is_err());
-        assert!(b.set_members("sink_stream", vec!["sink_game".into()]).is_err());
+        assert!(b
+            .set_members("sink_stream", vec!["sink_game".into()])
+            .is_err());
         // Renaming is allowed - recorders see the label.
         b.rename("sink_stream", "Everything").expect("renames");
 
@@ -467,10 +478,14 @@ mod tests {
         // …and a new channel joins without touching the definition.
         let mut grown = all.clone();
         grown.push("sink_voice".to_string());
-        assert_eq!(b.get(&mix.name).expect("mix").effective_members(&grown), grown);
+        assert_eq!(
+            b.get(&mix.name).expect("mix").effective_members(&grown),
+            grown
+        );
 
         // Keep music out: only music is stored; everything else flows.
-        b.set_members(&mix.name, vec!["sink_music".into()]).expect("sets");
+        b.set_members(&mix.name, vec!["sink_music".into()])
+            .expect("sets");
         assert_eq!(
             b.get(&mix.name).expect("mix").effective_members(&grown),
             vec!["sink_game", "sink_chat", "sink_voice"]
@@ -482,7 +497,8 @@ mod tests {
         let all = vec!["sink_game".to_string(), "sink_music".to_string()];
         let mut b = Buses::default();
         let mix = b.add("Mix").expect("adds"); // exclude, carries all
-        b.set_members(&mix.name, vec!["sink_music".into()]).expect("excludes music");
+        b.set_members(&mix.name, vec!["sink_music".into()])
+            .expect("excludes music");
 
         b.set_exclude(&mix.name, false, &all).expect("to manual");
         let def = b.get(&mix.name).expect("mix");
@@ -503,7 +519,10 @@ mod tests {
         b.sync_master(&["sink_game".into(), "sink_chat".into()]);
         // A channel disappeared: sync must drop it, not merge.
         b.sync_master(&["sink_game".into()]);
-        assert_eq!(b.get("sink_stream").expect("master").channels, vec!["sink_game"]);
+        assert_eq!(
+            b.get("sink_stream").expect("master").channels,
+            vec!["sink_game"]
+        );
         // No channels at all: the master mirrors that too.
         b.sync_master(&[]);
         assert!(b.get("sink_stream").expect("master").channels.is_empty());
@@ -555,22 +574,45 @@ mod tests {
     #[test]
     fn member_gain_round_trips_and_unity_drops_the_entry() {
         let mut b = Buses::default();
-        b.set_member_gain("sink_stream", "sink_game", 60).expect("sets gain");
-        assert_eq!(b.get("sink_stream").expect("master").member_gains.get("sink_game"), Some(&60));
+        b.set_member_gain("sink_stream", "sink_game", 60)
+            .expect("sets gain");
+        assert_eq!(
+            b.get("sink_stream")
+                .expect("master")
+                .member_gains
+                .get("sink_game"),
+            Some(&60)
+        );
 
         // A mic send level, keyed the same way as a channel.
-        b.set_member_gain("sink_stream", "sink_mic", 130).expect("sets mic gain");
-        assert_eq!(b.get("sink_stream").expect("master").member_gains.get("sink_mic"), Some(&130));
+        b.set_member_gain("sink_stream", "sink_mic", 130)
+            .expect("sets mic gain");
+        assert_eq!(
+            b.get("sink_stream")
+                .expect("master")
+                .member_gains
+                .get("sink_mic"),
+            Some(&130)
+        );
 
         // Returning to unity (100) drops the entry rather than storing it.
-        b.set_member_gain("sink_stream", "sink_game", 100).expect("resets gain");
-        assert!(!b.get("sink_stream").expect("master").member_gains.contains_key("sink_game"));
+        b.set_member_gain("sink_stream", "sink_game", 100)
+            .expect("resets gain");
+        assert!(!b
+            .get("sink_stream")
+            .expect("master")
+            .member_gains
+            .contains_key("sink_game"));
 
         assert!(b.set_member_gain("sink_missing", "sink_game", 50).is_err());
 
         // Deleting the channel drops its per-mix send level too.
         b.remove_channel("sink_mic"); // exercises the mic key through the same path
-        assert!(!b.get("sink_stream").expect("master").member_gains.contains_key("sink_mic"));
+        assert!(!b
+            .get("sink_stream")
+            .expect("master")
+            .member_gains
+            .contains_key("sink_mic"));
 
         // Legacy buses.json written before this field loads at the default.
         let legacy = r#"{"buses":[{"name":"sink_stream","label":"Master Mix","channels":[],"exclude":false}]}"#;

--- a/src-tauri/src/persistence/channels.rs
+++ b/src-tauri/src/persistence/channels.rs
@@ -192,7 +192,9 @@ impl Channels {
     pub fn add(&mut self, label: &str, icon: Option<String>) -> Result<ChannelDef, SinkError> {
         let label = label.trim();
         if label.is_empty() || label.len() > 24 {
-            return Err(SinkError::Config("channel label must be 1-24 characters".into()));
+            return Err(SinkError::Config(
+                "channel label must be 1-24 characters".into(),
+            ));
         }
         if self.channels.len() >= MAX_CHANNELS {
             return Err(SinkError::Config(format!(
@@ -227,7 +229,9 @@ impl Channels {
     pub fn rename(&mut self, name: &str, label: &str) -> Result<(), SinkError> {
         let label = label.trim();
         if label.is_empty() || label.len() > 24 {
-            return Err(SinkError::Config("channel label must be 1-24 characters".into()));
+            return Err(SinkError::Config(
+                "channel label must be 1-24 characters".into(),
+            ));
         }
         let def = self
             .channels
@@ -241,15 +245,16 @@ impl Channels {
     /// Reorder the channel set. `order` must contain exactly the current
     /// sink names (it's a permutation, not an edit).
     pub fn reorder(&mut self, order: &[String]) -> Result<(), SinkError> {
-        if order.len() != self.channels.len()
-            || !order.iter().all(|n| self.get(n).is_some())
-        {
+        if order.len() != self.channels.len() || !order.iter().all(|n| self.get(n).is_some()) {
             return Err(SinkError::Config(
                 "reorder must list every existing channel exactly once".into(),
             ));
         }
         self.channels.sort_by_key(|c| {
-            order.iter().position(|n| n == &c.name).unwrap_or(usize::MAX)
+            order
+                .iter()
+                .position(|n| n == &c.name)
+                .unwrap_or(usize::MAX)
         });
         Ok(())
     }
@@ -332,7 +337,10 @@ mod tests {
         ])
         .expect("reorders");
         let names: Vec<&str> = c.channels.iter().map(|d| d.name.as_str()).collect();
-        assert_eq!(names, ["sink_music", "sink_game", "sink_system", "sink_chat"]);
+        assert_eq!(
+            names,
+            ["sink_music", "sink_game", "sink_system", "sink_chat"]
+        );
         // Wrong length and unknown names are rejected.
         assert!(c.reorder(&["sink_game".into()]).is_err());
         assert!(c
@@ -448,6 +456,9 @@ mod tests {
         // load() turns this into defaults; parse itself reports the empty set
         // so load can distinguish it from a corrupt (None) file.
         let raw = r#"{"channels":[{"name":"sink_mic","label":"x"},{"name":"bad","label":"y"}]}"#;
-        assert!(Channels::parse(raw).expect("valid json").channels.is_empty());
+        assert!(Channels::parse(raw)
+            .expect("valid json")
+            .channels
+            .is_empty());
     }
 }

--- a/src-tauri/src/persistence/mod.rs
+++ b/src-tauri/src/persistence/mod.rs
@@ -10,8 +10,8 @@ pub mod hotkeys;
 pub mod mic;
 pub mod outputs;
 pub mod prefs;
-pub mod seen;
 pub mod profiles;
+pub mod seen;
 pub mod wireplumber;
 
 /// Seconds since the Unix epoch, or 0 if the clock predates it.
@@ -152,11 +152,17 @@ mod tests {
 
         // A shorter follow-up must fully replace, not overlay, the old bytes.
         write_atomic(&path, b"second, longer contents").expect("overwrite");
-        assert_eq!(std::fs::read_to_string(&path).unwrap(), "second, longer contents");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "second, longer contents"
+        );
 
         let mut tmp = path.as_os_str().to_owned();
         tmp.push(".tmp");
-        assert!(!std::path::Path::new(&tmp).exists(), "temp file must not linger");
+        assert!(
+            !std::path::Path::new(&tmp).exists(),
+            "temp file must not linger"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/persistence/profiles.rs
+++ b/src-tauri/src/persistence/profiles.rs
@@ -121,7 +121,8 @@ pub fn load(name: &str) -> Result<Profile, SinkError> {
             e.into()
         }
     })?;
-    serde_json::from_str(&raw).map_err(|e| SinkError::Config(format!("malformed profile {name}: {e}")))
+    serde_json::from_str(&raw)
+        .map_err(|e| SinkError::Config(format!("malformed profile {name}: {e}")))
 }
 
 pub fn delete(name: &str) -> Result<(), SinkError> {
@@ -142,7 +143,10 @@ mod tests {
     #[test]
     fn sanitize_accepts_reasonable_names() {
         assert_eq!(sanitize_name("Gaming").expect("valid"), "Gaming");
-        assert_eq!(sanitize_name("  Work_2 -late ").expect("valid"), "Work_2 -late");
+        assert_eq!(
+            sanitize_name("  Work_2 -late ").expect("valid"),
+            "Work_2 -late"
+        );
     }
 
     #[test]

--- a/src-tauri/src/persistence/seen.rs
+++ b/src-tauri/src/persistence/seen.rs
@@ -97,8 +97,8 @@ impl SeenApps {
     ) -> bool {
         if let Some(entry) = self.entry_mut(match_prop, match_value) {
             entry.last_seen = now;
-            let changed = entry.display_name != display_name
-                || entry.icon_name.as_deref() != icon_name;
+            let changed =
+                entry.display_name != display_name || entry.icon_name.as_deref() != icon_name;
             if changed {
                 entry.display_name = display_name.to_string();
                 entry.icon_name = icon_name.map(str::to_string);
@@ -162,12 +162,35 @@ mod tests {
     #[test]
     fn upsert_reports_structural_changes_only() {
         let mut seen = SeenApps::default();
-        assert!(seen.upsert("application.name", "Firefox", "Firefox", Some("firefox"), 100));
+        assert!(seen.upsert(
+            "application.name",
+            "Firefox",
+            "Firefox",
+            Some("firefox"),
+            100
+        ));
         // Pure last_seen bump - not worth persisting.
-        assert!(!seen.upsert("application.name", "Firefox", "Firefox", Some("firefox"), 200));
-        assert_eq!(seen.get("application.name", "Firefox").expect("entry").last_seen, 200);
+        assert!(!seen.upsert(
+            "application.name",
+            "Firefox",
+            "Firefox",
+            Some("firefox"),
+            200
+        ));
+        assert_eq!(
+            seen.get("application.name", "Firefox")
+                .expect("entry")
+                .last_seen,
+            200
+        );
         // Display change - persist.
-        assert!(seen.upsert("application.name", "Firefox", "Firefox ESR", Some("firefox"), 300));
+        assert!(seen.upsert(
+            "application.name",
+            "Firefox",
+            "Firefox ESR",
+            Some("firefox"),
+            300
+        ));
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -93,7 +93,13 @@ impl AppState {
         let names: Vec<String> = self
             .mixer
             .lock()
-            .map(|m| m.channel_defs.channels.iter().map(|c| c.name.clone()).collect())
+            .map(|m| {
+                m.channel_defs
+                    .channels
+                    .iter()
+                    .map(|c| c.name.clone())
+                    .collect()
+            })
             .unwrap_or_default();
         let mut errors = Vec::new();
         for name in names {


### PR DESCRIPTION
**Problem**

The crate was never run through rustfmt, so any pr that touches a file and formats it drags a pile of unrelated formatting hunks into its diff. #59 is showing that right now.

**Fix**

- `cargo fmt` over the whole crate, nothing else changed
- ci checks `cargo fmt --check` from here on so it stays that way
