### PR TITLE
ci: install-test on any distro on demand

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -68,8 +68,8 @@ jobs:
           jq -nc --arg picked "$picked" '
             {
               # The appimage has no image: it runs on the runner itself,
-              # which has a desktop's worth of libraries like a real machine.
-              # A bare container has none, so it would only prove that an
+              # which carries the libraries a real desktop has. A bare
+              # container carries none, so the test would only prove that an
               # appimage does not bundle all of gtk, which is by design.
               arch:     "archlinux:latest",
               fedora:   "fedora:latest",

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -234,8 +234,10 @@ jobs:
               dnf -y install xorg-x11-server-Xvfb mesa-dri-drivers findutils
               ;;
             opensuse)
+              # A tumbleweed base image has neither find nor xvfb-run.
               zypper --non-interactive refresh
-              zypper --non-interactive install xorg-x11-server-Xvfb Mesa-dri tar gzip
+              zypper --non-interactive install \
+                findutils xvfb-run xorg-x11-server-Xvfb Mesa-dri tar gzip
               ;;
             debian | appimage)
               apt-get update
@@ -282,7 +284,7 @@ jobs:
               # Nothing to install: the point of an AppImage is that it runs
               # anywhere. Extract rather than mount, since a container has no
               # /dev/fuse.
-              chmod +x bundles/*.AppImage
+              chmod +x "$(find bundles -name '*.AppImage' | head -1)"
               ;;
           esac
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -67,11 +67,15 @@ jobs:
           echo "install-testing: ${picked:-nothing}"
           jq -nc --arg picked "$picked" '
             {
+              # The appimage has no image: it runs on the runner itself,
+              # which has a desktop's worth of libraries like a real machine.
+              # A bare container has none, so it would only prove that an
+              # appimage does not bundle all of gtk, which is by design.
               arch:     "archlinux:latest",
               fedora:   "fedora:latest",
               opensuse: "opensuse/tumbleweed:latest",
               debian:   "debian:trixie",
-              appimage: "ubuntu:24.04"
+              appimage: ""
             } as $image
             | [$picked | split(" ") | .[] | select(length > 0)
                | {distro: ., image: $image[.]}]
@@ -239,9 +243,13 @@ jobs:
               zypper --non-interactive install \
                 findutils xvfb-run xorg-x11-server-Xvfb Mesa-dri tar gzip
               ;;
-            debian | appimage)
+            debian)
               apt-get update
-              DEBIAN_FRONTEND=noninteractive apt-get install -y xvfb libfuse2t64 file
+              DEBIAN_FRONTEND=noninteractive apt-get install -y xvfb file
+              ;;
+            appimage)
+              sudo apt-get update
+              sudo DEBIAN_FRONTEND=noninteractive apt-get install -y xvfb
               ;;
           esac
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -3,6 +3,10 @@ name: Dev
 on:
   pull_request:
     branches: [main]
+    # `labeled` so adding a ci:<distro> label to an open pr starts the run
+    # that installs it there; without it a label changes nothing until the
+    # next push.
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
     inputs:
       distros:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,10 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
-      arch:
-        description: "Build and smoke-test the Arch package even without packaging changes"
-        type: boolean
-        default: false
+      distros:
+        description: "Install-test on these distros: all, or a comma list of arch, fedora, opensuse, debian, appimage"
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -18,14 +18,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # What changed, so the packaging job only runs when it can find something.
+  # Which distros to install-test. Packaging changes test everywhere;
+  # otherwise a pr opts in with a `ci:<distro>` label (or `ci:distros` for
+  # all), and a manual dispatch can name them.
   changes:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
-      packaging: ${{ steps.filter.outputs.packaging }}
+      distros: ${{ steps.pick.outputs.distros }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
@@ -35,6 +38,44 @@ jobs:
               - 'src-tauri/tauri.conf.json'
               - 'src-tauri/Cargo.toml'
               - '.github/workflows/dev.yml'
+
+      - name: Pick the distros
+        id: pick
+        env:
+          PACKAGING: ${{ steps.filter.outputs.packaging }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          REQUESTED: ${{ inputs.distros }}
+        run: |
+          set -euo pipefail
+          all="arch fedora opensuse debian appimage"
+          on_pr=",${LABELS},"
+          on_dispatch=",$(echo "$REQUESTED" | tr -d '[:space:]'),"
+          picked=""
+          case "$on_pr$on_dispatch" in
+            *",ci:distros,"* | *",all,"*) picked="$all" ;;
+            *)
+              if [ "$PACKAGING" = "true" ]; then
+                picked="$all"
+              else
+                for d in $all; do
+                  case "$on_pr" in *",ci:$d,"*) picked="$picked $d"; continue ;; esac
+                  case "$on_dispatch" in *",$d,"*) picked="$picked $d" ;; esac
+                done
+              fi
+              ;;
+          esac
+          echo "install-testing: ${picked:-nothing}"
+          jq -nc --arg picked "$picked" '
+            {
+              arch:     "archlinux:latest",
+              fedora:   "fedora:latest",
+              opensuse: "opensuse/tumbleweed:latest",
+              debian:   "debian:trixie",
+              appimage: "ubuntu:24.04"
+            } as $image
+            | [$picked | split(" ") | .[] | select(length > 0)
+               | {distro: ., image: $image[.]}]
+          ' | sed 's/^/distros=/' >> "$GITHUB_OUTPUT"
 
   check:
     runs-on: ubuntu-24.04
@@ -165,21 +206,42 @@ jobs:
           path: |
             target/release/bundle/deb/*.deb
             target/release/bundle/rpm/*.rpm
+            target/release/bundle/appimage/*.AppImage
 
-  # Packaging changes only: this repackages the deb the `bundles` job built
-  # and smoke-tests it, and release.yml runs the same gate before publishing.
-  # Force it on a pr with the `ci:arch` label, or dispatch with arch=true.
-  archpkg:
+  # Install what `bundles` built on each distro and launch it, which is what
+  # catches a missing runtime dependency or a packaging mistake. Not required
+  # to merge: release.yml runs the same gate before it publishes anything.
+  distros:
     needs: [bundles, changes]
-    if: >-
-      needs.changes.outputs.packaging == 'true' ||
-      contains(github.event.pull_request.labels.*.name, 'ci:arch') ||
-      inputs.arch
+    if: needs.changes.outputs.distros != '[]'
+    name: ${{ matrix.distro }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    container: archlinux:latest
+    timeout-minutes: 25
+    container: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.changes.outputs.distros) }}
     steps:
-      - run: pacman -Syu --noconfirm --needed base-devel
+      - name: Install the distro's tooling
+        run: |
+          set -eu
+          case "${{ matrix.distro }}" in
+            arch)
+              pacman -Syu --noconfirm --needed base-devel xorg-server-xvfb mesa
+              ;;
+            fedora)
+              dnf -y install xorg-x11-server-Xvfb mesa-dri-drivers findutils
+              ;;
+            opensuse)
+              zypper --non-interactive refresh
+              zypper --non-interactive install xorg-x11-server-Xvfb Mesa-dri tar gzip
+              ;;
+            debian | appimage)
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y xvfb libfuse2t64 file
+              ;;
+          esac
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -188,43 +250,48 @@ jobs:
           name: bundles
           path: bundles
 
-      - name: Build and smoke-test sink-bin
+      - name: Install sink
         run: |
-          set -euo pipefail
+          set -eu
           deb=$(find bundles -name 'sink_*_amd64.deb' | head -1)
-          ver=$(basename "$deb" | sed 's/^sink_//; s/_amd64\.deb$//')
-          useradd -m builder
-          install -d -o builder /build
-          cp "$deb" "/build/sink_${ver}_amd64.deb"
-          sum=$(sha256sum "/build/sink_${ver}_amd64.deb" | cut -d' ' -f1)
-          cp packaging/arch/PKGBUILD /build/PKGBUILD
-          sed -i "s/^pkgver=.*/pkgver=${ver}/; s/^sha256sums=.*/sha256sums=('${sum}')/" /build/PKGBUILD
-          chown -R builder:builder /build
-          sudo -u builder bash -lc 'cd /build && makepkg --noconfirm --nodeps'
-          pkg=$(ls /build/sink-bin-*-x86_64.pkg.tar.zst)
-          pacman -U --noconfirm "$pkg" >/dev/null
-          pacman -S --noconfirm --needed xorg-server-xvfb mesa >/dev/null
-          # A healthy tray app runs its event loop until timeout kills it (exit
-          # 124). Any earlier exit is a real failure: a missing shared library
-          # (the loader aborts before main), a tray/webkit init failure, or a
-          # panic. `|| true` + a panic-only grep would let all of those pass.
-          set +e
-          timeout 25 xvfb-run -a /usr/bin/sink >/tmp/launch.log 2>&1
-          code=$?
-          set -e
-          cat /tmp/launch.log || true
-          if grep -qiE 'panicked at|error while loading shared libraries|cannot open shared object|symbol lookup error' /tmp/launch.log; then
-            echo "::error::sink failed to start cleanly - see log above"
-            exit 1
-          fi
-          if [ "$code" -ne 124 ]; then
-            echo "::error::sink exited early (code $code) instead of staying alive for 25s"
-            exit 1
-          fi
-          echo "sink launched and stayed alive under xvfb"
-          cp "$pkg" "$GITHUB_WORKSPACE/"
+          rpm=$(find bundles -name 'sink-*.x86_64.rpm' | head -1)
+          case "${{ matrix.distro }}" in
+            arch)
+              # The AUR package repackages the deb; build it the same way.
+              ver=$(basename "$deb" | sed 's/^sink_//; s/_amd64\.deb$//')
+              useradd -m builder
+              install -d -o builder /build
+              cp "$deb" "/build/sink_${ver}_amd64.deb"
+              sum=$(sha256sum "/build/sink_${ver}_amd64.deb" | cut -d' ' -f1)
+              cp packaging/arch/PKGBUILD /build/PKGBUILD
+              sed -i "s/^pkgver=.*/pkgver=${ver}/; s/^sha256sums=.*/sha256sums=('${sum}')/" /build/PKGBUILD
+              chown -R builder:builder /build
+              sudo -u builder bash -lc 'cd /build && makepkg --noconfirm --nodeps'
+              pacman -U --noconfirm /build/sink-bin-*-x86_64.pkg.tar.zst
+              ;;
+            fedora)
+              dnf -y install "$rpm"
+              ;;
+            opensuse)
+              zypper --non-interactive install --allow-unsigned-rpm "$rpm"
+              ;;
+            debian)
+              DEBIAN_FRONTEND=noninteractive apt-get install -y "./$deb"
+              ;;
+            appimage)
+              # Nothing to install: the point of an AppImage is that it runs
+              # anywhere. Extract rather than mount, since a container has no
+              # /dev/fuse.
+              chmod +x bundles/*.AppImage
+              ;;
+          esac
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: sink-bin
-          path: sink-bin-*-x86_64.pkg.tar.zst
+      - name: Launch it
+        run: |
+          set -eu
+          if [ "${{ matrix.distro }}" = appimage ]; then
+            app=$(find bundles -name '*.AppImage' | head -1)
+            packaging/smoke-test.sh "$app" --appimage-extract-and-run
+          else
+            packaging/smoke-test.sh
+          fi

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -248,8 +248,12 @@ jobs:
               DEBIAN_FRONTEND=noninteractive apt-get install -y xvfb file
               ;;
             appimage)
+              # The runner is headless: give it the graphics stack any
+              # desktop has, since an appimage is not expected to ship the
+              # drivers. Everything else it needs, it must bring itself.
               sudo apt-get update
-              sudo DEBIAN_FRONTEND=noninteractive apt-get install -y xvfb
+              sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+                xvfb libegl1 libgl1 libgles2
               ;;
           esac
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,24 +235,11 @@ jobs:
           chown -R builder:builder /build
           sudo -u builder bash -lc 'cd /build && makepkg --noconfirm --nodeps'
           pkg=$(ls /build/sink-bin-*-x86_64.pkg.tar.zst)
-          # Smoke test: install and launch headlessly. A healthy tray app runs
-          # until timeout kills it (exit 124); an earlier exit means a missing
-          # runtime dep (loader abort), a tray/webkit init failure, or a panic.
+          # Same gate the pull-request install tests use: nothing publishes
+          # unless the packaged binary launches and stays up.
           pacman -U --noconfirm "$pkg" >/dev/null
           pacman -S --noconfirm --needed xorg-server-xvfb mesa >/dev/null
-          set +e
-          timeout 25 xvfb-run -a /usr/bin/sink >/tmp/launch.log 2>&1
-          code=$?
-          set -e
-          cat /tmp/launch.log || true
-          if grep -qiE 'panicked at|error while loading shared libraries|cannot open shared object|symbol lookup error' /tmp/launch.log; then
-            echo "::error::sink failed to start cleanly - not publishing"
-            exit 1
-          fi
-          if [ "$code" -ne 124 ]; then
-            echo "::error::sink exited early (code $code) instead of staying alive - not publishing"
-            exit 1
-          fi
+          packaging/smoke-test.sh
           gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber "$pkg"
           # Append the Arch package checksum to the release SHA256SUMS.
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern SHA256SUMS --dir /tmp 2>/dev/null || true

--- a/packaging/smoke-test.sh
+++ b/packaging/smoke-test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Launch an installed Sink headlessly and prove it stays up.
+#
+#   packaging/smoke-test.sh [command...]     (default: /usr/bin/sink)
+#
+# A healthy tray app runs its event loop until timeout kills it (exit 124).
+# Any earlier exit is a real failure: a missing shared library (the loader
+# aborts before main), a tray or webkit init failure, or a panic. Grepping
+# the log for panics alone would let the first two pass.
+set -uo pipefail
+
+log=$(mktemp)
+timeout 25 xvfb-run -a "${@:-/usr/bin/sink}" >"$log" 2>&1
+code=$?
+cat "$log"
+
+if grep -qiE 'panicked at|error while loading shared libraries|cannot open shared object|symbol lookup error' "$log"; then
+  echo "::error::sink failed to start cleanly - see the log above"
+  exit 1
+fi
+if [ "$code" -ne 124 ]; then
+  echo "::error::sink exited early (code $code) instead of staying alive for 25s"
+  exit 1
+fi
+echo "sink launched and stayed alive under xvfb"


### PR DESCRIPTION
**Problem**

We build a deb, an rpm and an appimage on every pr and never install any of them. Only the arch package got installed and launched, and #68 made even that conditional. So a change that breaks a runtime dependency on fedora or debian gets found at release time, or by a user.

**Fix**

One install test per distro, opt-in, so anyone opening a pr can check their change on the os they care about.

- arch, fedora, opensuse, debian and the appimage, each installing what the build job produced and launching it under xvfb
- to run one, add the matching label to your pr: `ci:fedora`, `ci:debian`, `ci:arch`, `ci:opensuse`, `ci:appimage`, or `ci:distros` for all. the label starts the run on its own, no new commit needed
- packaging changes run all of them without asking, and the actions tab can dispatch the workflow with a list like `fedora,opensuse`
- a plain pr runs none, so nothing gets slower by default
- the smoke test moves to `packaging/smoke-test.sh`, shared with the release gate, so the two cannot drift apart
- the appimage is now uploaded from the build job, which it never was, and it runs on the runner rather than a bare container, which has no graphics stack at all
