### PR TITLE
feat(mix): choose whether a mix is a recording or a playback device

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ processed virtual microphone for voice chat.
   input device holds your voice plus app audio (Sonar-style Stream Mix),
   and each member gets its own send level and mute inside the mix - what
   recorders hear, independent of your own volume (pop out a mix's levels
-  from its strip). In OBS, add a mix as an audio input - not Desktop Audio.
+  from its strip). In OBS, add a mix as an audio input - not Desktop Audio. A mix can also
+  sit with the output devices instead, if you would rather keep your
+  recording list short; it stays capturable through its monitor.
 - **Equalizer** - per-channel parametric EQ (up to 10 bands) with a
   draggable response curve, bundled community presets, and import/export
   including AutoEq text blocks

--- a/src-tauri/src/audio/backend.rs
+++ b/src-tauri/src/audio/backend.rs
@@ -60,8 +60,12 @@ pub trait AudioBackend: Send + Sync {
 
     /// Create a mix bus: a capturable virtual source whose label is the
     /// device name recorders (OBS) display. Native-only.
-    /// `input`: see `BusDef::input`.
-    fn create_bus(&self, name: &str, label: &str, input: bool) -> Result<(), SinkError>;
+    fn create_bus(
+        &self,
+        name: &str,
+        label: &str,
+        role: crate::persistence::buses::MixRole,
+    ) -> Result<(), SinkError>;
 
     /// Destroy a mix bus (its links go with it).
     fn destroy_bus(&self, name: &str) -> Result<(), SinkError>;

--- a/src-tauri/src/audio/backend.rs
+++ b/src-tauri/src/audio/backend.rs
@@ -60,8 +60,7 @@ pub trait AudioBackend: Send + Sync {
 
     /// Create a mix bus: a capturable virtual source whose label is the
     /// device name recorders (OBS) display. Native-only.
-    /// `input`: expose the mix as a recording device rather than a
-    /// playback device (see `BusDef::input`).
+    /// `input`: see `BusDef::input`.
     fn create_bus(&self, name: &str, label: &str, input: bool) -> Result<(), SinkError>;
 
     /// Destroy a mix bus (its links go with it).

--- a/src-tauri/src/audio/backend.rs
+++ b/src-tauri/src/audio/backend.rs
@@ -60,7 +60,9 @@ pub trait AudioBackend: Send + Sync {
 
     /// Create a mix bus: a capturable virtual source whose label is the
     /// device name recorders (OBS) display. Native-only.
-    fn create_bus(&self, name: &str, label: &str) -> Result<(), SinkError>;
+    /// `input`: expose the mix as a recording device rather than a
+    /// playback device (see `BusDef::input`).
+    fn create_bus(&self, name: &str, label: &str, input: bool) -> Result<(), SinkError>;
 
     /// Destroy a mix bus (its links go with it).
     fn destroy_bus(&self, name: &str) -> Result<(), SinkError>;

--- a/src-tauri/src/audio/mock.rs
+++ b/src-tauri/src/audio/mock.rs
@@ -162,7 +162,12 @@ impl AudioBackend for MockBackend {
         Ok(std::collections::HashMap::new())
     }
 
-    fn create_bus(&self, _name: &str, _label: &str, _input: bool) -> Result<(), SinkError> {
+    fn create_bus(
+        &self,
+        _name: &str,
+        _label: &str,
+        _role: crate::persistence::buses::MixRole,
+    ) -> Result<(), SinkError> {
         Ok(())
     }
 

--- a/src-tauri/src/audio/mock.rs
+++ b/src-tauri/src/audio/mock.rs
@@ -162,7 +162,7 @@ impl AudioBackend for MockBackend {
         Ok(std::collections::HashMap::new())
     }
 
-    fn create_bus(&self, _name: &str, _label: &str) -> Result<(), SinkError> {
+    fn create_bus(&self, _name: &str, _label: &str, _input: bool) -> Result<(), SinkError> {
         Ok(())
     }
 

--- a/src-tauri/src/audio/pactl.rs
+++ b/src-tauri/src/audio/pactl.rs
@@ -349,7 +349,7 @@ impl AudioBackend for PactlBackend {
         ))
     }
 
-    fn create_bus(&self, _name: &str, _label: &str) -> Result<(), SinkError> {
+    fn create_bus(&self, _name: &str, _label: &str, _input: bool) -> Result<(), SinkError> {
         Err(SinkError::Config(
             "mix buses require the native PipeWire backend".into(),
         ))

--- a/src-tauri/src/audio/pactl.rs
+++ b/src-tauri/src/audio/pactl.rs
@@ -349,7 +349,12 @@ impl AudioBackend for PactlBackend {
         ))
     }
 
-    fn create_bus(&self, _name: &str, _label: &str, _input: bool) -> Result<(), SinkError> {
+    fn create_bus(
+        &self,
+        _name: &str,
+        _label: &str,
+        _role: crate::persistence::buses::MixRole,
+    ) -> Result<(), SinkError> {
         Err(SinkError::Config(
             "mix buses require the native PipeWire backend".into(),
         ))

--- a/src-tauri/src/audio/pactl.rs
+++ b/src-tauri/src/audio/pactl.rs
@@ -5,7 +5,7 @@ use std::sync::Mutex;
 use serde::Deserialize;
 
 use crate::audio::backend::AudioBackend;
-use crate::audio::types::{is_virtual_sink, AppStream, OutputDevice};
+use crate::audio::types::{is_own_sink, is_virtual_sink, AppStream, OutputDevice};
 use crate::error::SinkError;
 
 /// `owner_module` value pactl uses when a sink has no owning module.
@@ -275,7 +275,7 @@ impl AudioBackend for PactlBackend {
     fn list_output_devices(&self) -> Result<Vec<OutputDevice>, SinkError> {
         Ok(Self::list_sinks()?
             .into_iter()
-            .filter(|s| !is_virtual_sink(&s.name))
+            .filter(|s| !is_own_sink(&s.name))
             .map(|s| OutputDevice {
                 index: s.index,
                 name: s.name,

--- a/src-tauri/src/audio/pw_native/mod.rs
+++ b/src-tauri/src/audio/pw_native/mod.rs
@@ -159,10 +159,15 @@ impl AudioBackend for PipeWireBackend {
         })
     }
 
-    fn create_bus(&self, name: &str, label: &str) -> Result<(), SinkError> {
+    fn create_bus(&self, name: &str, label: &str, input: bool) -> Result<(), SinkError> {
         let name = name.to_string();
         let label = label.to_string();
-        self.request(|reply| Cmd::CreateBus { name, label, reply })
+        self.request(|reply| Cmd::CreateBus {
+            name,
+            label,
+            input,
+            reply,
+        })
     }
 
     fn destroy_bus(&self, name: &str) -> Result<(), SinkError> {

--- a/src-tauri/src/audio/pw_native/mod.rs
+++ b/src-tauri/src/audio/pw_native/mod.rs
@@ -159,13 +159,18 @@ impl AudioBackend for PipeWireBackend {
         })
     }
 
-    fn create_bus(&self, name: &str, label: &str, input: bool) -> Result<(), SinkError> {
+    fn create_bus(
+        &self,
+        name: &str,
+        label: &str,
+        role: crate::persistence::buses::MixRole,
+    ) -> Result<(), SinkError> {
         let name = name.to_string();
         let label = label.to_string();
         self.request(|reply| Cmd::CreateBus {
             name,
             label,
-            input,
+            role,
             reply,
         })
     }

--- a/src-tauri/src/audio/pw_native/thread.rs
+++ b/src-tauri/src/audio/pw_native/thread.rs
@@ -201,10 +201,10 @@ struct State {
     owned_sinks: HashMap<String, Node>,
     /// Sinks that existed before us (e.g. leftover pactl modules): name -> global id.
     adopted_sinks: HashMap<String, u32>,
-    /// Nodes that must stay alive: name -> (label, kind 0=sink 1=bus 2=mic).
+    /// Nodes that must stay alive, by name, with what to recreate them as.
     /// If one vanishes without us destroying it (another instance dying,
     /// a PipeWire restart, wpctl) it gets recreated on the spot.
-    desired: HashMap<String, (String, u8)>,
+    desired: HashMap<String, (String, NodeKind)>,
     /// Create requests waiting for the sink's global to appear.
     pending_creates: HashMap<String, Vec<Reply<()>>>,
     /// Live meter capture streams per virtual sink name.
@@ -369,7 +369,7 @@ fn setup_and_run(
                 enum Heal {
                     Nothing,
                     Relink,
-                    Recreate(String, String, u8),
+                    Recreate(String, String, NodeKind),
                 }
                 let heal = {
                     let mut s = state.borrow_mut();
@@ -389,13 +389,13 @@ fn setup_and_run(
                             // Drop any dangling proxy so the heal isn't
                             // blocked by a corpse.
                             match kind {
-                                0 => {
+                                NodeKind::Channel => {
                                     s.owned_sinks.remove(&name);
                                 }
-                                1 => {
+                                NodeKind::MixSource | NodeKind::MixSink => {
                                     s.bus_sources.remove(&name);
                                 }
-                                _ => {}
+                                NodeKind::Mic => {}
                             }
                             // A deliberate recreate (mic rename) already has
                             // a fresh proxy/node - don't double up. For the
@@ -404,7 +404,7 @@ fn setup_and_run(
                             // can't tell our own destroy from an external one;
                             // the expected-removals counter can.
                             let already_back = match kind {
-                                2 => {
+                                NodeKind::Mic => {
                                     if s.mic_expected_removals > 0 {
                                         s.mic_expected_removals -= 1;
                                         true
@@ -416,7 +416,9 @@ fn setup_and_run(
                                         false
                                     }
                                 }
-                                _ => s.node_by_name(&name).is_some(),
+                                NodeKind::Channel | NodeKind::MixSource | NodeKind::MixSink => {
+                                    s.node_by_name(&name).is_some()
+                                }
                             };
                             if already_back {
                                 Heal::Relink
@@ -447,13 +449,13 @@ fn setup_and_run(
                                 Ok(proxy) => {
                                     let mut s = state.borrow_mut();
                                     match kind {
-                                        0 => {
+                                        NodeKind::Channel => {
                                             s.owned_sinks.insert(name, proxy);
                                         }
-                                        1 => {
+                                        NodeKind::MixSource | NodeKind::MixSink => {
                                             s.bus_sources.insert(name, proxy);
                                         }
-                                        _ => s.mic_source = Some(proxy),
+                                        NodeKind::Mic => s.mic_source = Some(proxy),
                                     }
                                 }
                                 Err(e) => eprintln!("sink: recreate {name} failed: {e}"),
@@ -798,8 +800,8 @@ fn on_node(
         return;
     }
 
-    // A mix bus came up: meter it and link members. A mix exposed as a
-    // playback device is metered through its monitor, like a channel.
+    // A mix in the playback list has no source of its own to meter, so it
+    // is metered through its monitor, like a channel.
     if (media_class == VIRTUAL_SOURCE_CLASS || media_class == SINK_CLASS) && is_bus_name(&node_name)
     {
         let from_monitor = media_class == SINK_CLASS;
@@ -1343,38 +1345,65 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
     s.eq_desired_targets = eq_targets;
 }
 
-fn node_needs_monitor_volumes(kind: u8) -> bool {
-    kind == 0 || kind == 1 || kind == 3
+/// A node Sink creates and keeps alive. A mix comes in two shapes because
+/// the user picks which device list it belongs in; nothing else about a mix
+/// depends on that, so the rest of the loop asks `is_mix`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NodeKind {
+    Channel,
+    MixSource,
+    MixSink,
+    Mic,
 }
 
-/// A mix is a recording device by default and a playback device when the
-/// user turns that off; the node kind carries the choice.
-fn bus_kind(input: bool) -> u8 {
-    if input {
-        1
-    } else {
-        3
+impl NodeKind {
+    fn mix(input: bool) -> Self {
+        if input {
+            Self::MixSource
+        } else {
+            Self::MixSink
+        }
+    }
+
+    fn is_mix(self) -> bool {
+        matches!(self, Self::MixSource | Self::MixSink)
+    }
+
+    fn media_class(self) -> &'static str {
+        match self {
+            Self::Channel | Self::MixSink => SINK_CLASS,
+            Self::MixSource | Self::Mic => VIRTUAL_SOURCE_CLASS,
+        }
+    }
+
+    fn audio_position(self) -> &'static str {
+        match self {
+            Self::Mic => "[ MONO ]",
+            _ => "[ FL FR ]",
+        }
+    }
+
+    /// Everything the user sets a level on needs its monitor to follow that
+    /// level; the mic chain sets its own gain upstream.
+    fn needs_monitor_volumes(self) -> bool {
+        !matches!(self, Self::Mic)
     }
 }
 
-/// The virtual node shapes we own (kind 0=channel sink, 1=mix as a source,
-/// 2=virtual mic, 3=mix as a sink). The heal path mirrors the create
-/// handlers with this.
-fn create_node_object(core: &CoreRc, name: &str, label: &str, kind: u8) -> Result<Node, pw::Error> {
-    let class = if kind == 0 || kind == 3 {
-        SINK_CLASS
-    } else {
-        VIRTUAL_SOURCE_CLASS
-    };
-    let position = if kind == 2 { "[ MONO ]" } else { "[ FL FR ]" };
+fn create_node_object(
+    core: &CoreRc,
+    name: &str,
+    label: &str,
+    kind: NodeKind,
+) -> Result<Node, pw::Error> {
     let mut props = pw::properties::properties! {
         "factory.name" => "support.null-audio-sink",
         "node.name" => name,
         "node.description" => label,
-        "media.class" => class,
-        "audio.position" => position,
+        "media.class" => kind.media_class(),
+        "audio.position" => kind.audio_position(),
     };
-    if node_needs_monitor_volumes(kind) {
+    if kind.needs_monitor_volumes() {
         props.insert("monitor.channel-volumes", "true");
     }
     core.create_object::<Node>("adapter", &props)
@@ -1387,7 +1416,7 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
             if s.node_by_name(&name).is_some() {
                 // Already exists (e.g. leftover from a previous run) - the
                 // registry handler has adopted it. Still ours to keep alive.
-                s.desired.insert(name, (label, 0));
+                s.desired.insert(name, (label, NodeKind::Channel));
                 let _ = reply.send(Ok(()));
                 return;
             }
@@ -1416,7 +1445,7 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
                 // reply fires when the global appears in the registry.
                 Ok(proxy) => {
                     s.owned_sinks.insert(name.clone(), proxy);
-                    s.desired.insert(name.clone(), (label, 0));
+                    s.desired.insert(name.clone(), (label, NodeKind::Channel));
                     s.pending_creates.entry(name).or_default().push(reply);
                 }
                 Err(e) => {
@@ -1567,7 +1596,7 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
             input,
             reply,
         } => {
-            let kind = bus_kind(input);
+            let kind = NodeKind::mix(input);
             let mut s = state.borrow_mut();
             if s.bus_sources.contains_key(&name) || s.node_by_name(&name).is_some() {
                 s.desired.insert(name, (label, kind)); // adopted - keep alive
@@ -1629,7 +1658,7 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
                 // but a deletion can race this queue: DestroyBus may land
                 // between that check and here, and a stale insert would be
                 // inherited by a same-named mix created later.
-                if !s.desired.get(&name).is_some_and(|(_, kind)| *kind == 1) {
+                if !s.desired.get(&name).is_some_and(|(_, kind)| kind.is_mix()) {
                     let _ = reply.send(Err(SinkError::UnknownSink(name)));
                     return;
                 }
@@ -1653,9 +1682,14 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
                 let mut s = state.borrow_mut();
                 // Same deletion race as SetBusMic: re-check both names
                 // against the loop's own live state before storing.
-                let bus_live = s.desired.get(&bus_name).is_some_and(|(_, kind)| *kind == 1);
+                let bus_live = s
+                    .desired
+                    .get(&bus_name)
+                    .is_some_and(|(_, kind)| kind.is_mix());
                 let member_live = member == MIC_NODE
-                    || s.desired.get(&member).is_some_and(|(_, kind)| *kind == 0);
+                    || s.desired
+                        .get(&member)
+                        .is_some_and(|(_, kind)| *kind == NodeKind::Channel);
                 if !bus_live || !member_live {
                     let _ = reply.send(Err(SinkError::UnknownSink(bus_name)));
                     return;
@@ -1857,8 +1891,10 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
                     Ok(proxy) => {
                         let mut s = state.borrow_mut();
                         s.mic_source = Some(proxy);
-                        s.desired
-                            .insert(MIC_NODE.to_string(), (config.output_label.clone(), 2));
+                        s.desired.insert(
+                            MIC_NODE.to_string(),
+                            (config.output_label.clone(), NodeKind::Mic),
+                        );
                         // Re-point streams that were capturing the old node
                         // (target.object by name survives the recreation -
                         // the session manager re-attaches them when the new
@@ -2092,9 +2128,9 @@ mod tests {
 
     #[test]
     fn mixes_get_monitor_volumes_like_channels() {
-        assert!(node_needs_monitor_volumes(0));
-        assert!(node_needs_monitor_volumes(1));
-        assert!(!node_needs_monitor_volumes(2));
+        assert!(NodeKind::Channel.needs_monitor_volumes());
+        assert!(NodeKind::MixSource.needs_monitor_volumes());
+        assert!(!NodeKind::Mic.needs_monitor_volumes());
     }
 
     #[test]
@@ -2129,13 +2165,14 @@ mod tests {
 
     #[test]
     fn a_mix_takes_the_node_shape_its_role_asks_for() {
-        // Recording device: a virtual source a recorder can select.
-        assert_eq!(bus_kind(true), 1);
-        // Playback device: a sink, metered through its monitor like a
-        // channel, still capturable there.
-        assert_eq!(bus_kind(false), 3);
-        assert!(node_needs_monitor_volumes(bus_kind(false)));
-        assert!(node_needs_monitor_volumes(bus_kind(true)));
+        assert_eq!(NodeKind::mix(true).media_class(), VIRTUAL_SOURCE_CLASS);
+        assert_eq!(NodeKind::mix(false).media_class(), SINK_CLASS);
+        // Both shapes are still a mix: the member, mic and send-level
+        // commands all gate on that, and one of them is a sink.
+        assert!(NodeKind::mix(true).is_mix() && NodeKind::mix(false).is_mix());
+        assert!(!NodeKind::Channel.is_mix() && !NodeKind::Mic.is_mix());
+        assert!(NodeKind::mix(false).needs_monitor_volumes());
+        assert_eq!(NodeKind::Mic.audio_position(), "[ MONO ]");
     }
 
     #[test]

--- a/src-tauri/src/audio/pw_native/thread.rs
+++ b/src-tauri/src/audio/pw_native/thread.rs
@@ -96,7 +96,7 @@ pub enum Cmd {
     CreateBus {
         name: String,
         label: String,
-        input: bool,
+        role: crate::persistence::buses::MixRole,
         reply: Reply<()>,
     },
     /// Destroy a mix bus and its links.
@@ -1360,8 +1360,8 @@ enum NodeKind {
 }
 
 impl NodeKind {
-    fn mix(input: bool) -> Self {
-        if input {
+    fn mix(role: crate::persistence::buses::MixRole) -> Self {
+        if role.is_recording() {
             Self::MixSource
         } else {
             Self::MixSink
@@ -1598,10 +1598,10 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
         Cmd::CreateBus {
             name,
             label,
-            input,
+            role,
             reply,
         } => {
-            let kind = NodeKind::mix(input);
+            let kind = NodeKind::mix(role);
             let mut s = state.borrow_mut();
             if s.bus_sources.contains_key(&name) || s.node_by_name(&name).is_some() {
                 s.desired.insert(name, (label, kind)); // adopted - keep alive
@@ -2170,13 +2170,19 @@ mod tests {
 
     #[test]
     fn a_mix_takes_the_node_shape_its_role_asks_for() {
-        assert_eq!(NodeKind::mix(true).media_class(), VIRTUAL_SOURCE_CLASS);
-        assert_eq!(NodeKind::mix(false).media_class(), SINK_CLASS);
+        use crate::persistence::buses::MixRole;
+        assert_eq!(
+            NodeKind::mix(MixRole::Recording).media_class(),
+            VIRTUAL_SOURCE_CLASS
+        );
+        assert_eq!(NodeKind::mix(MixRole::Playback).media_class(), SINK_CLASS);
         // Both shapes are still a mix: the member, mic and send-level
         // commands all gate on that, and one of them is a sink.
-        assert!(NodeKind::mix(true).is_mix() && NodeKind::mix(false).is_mix());
+        assert!(
+            NodeKind::mix(MixRole::Recording).is_mix() && NodeKind::mix(MixRole::Playback).is_mix()
+        );
         assert!(!NodeKind::Channel.is_mix() && !NodeKind::Mic.is_mix());
-        assert!(NodeKind::mix(false).needs_monitor_volumes());
+        assert!(NodeKind::mix(MixRole::Playback).needs_monitor_volumes());
         assert_eq!(NodeKind::Mic.audio_position(), "[ MONO ]");
     }
 

--- a/src-tauri/src/audio/pw_native/thread.rs
+++ b/src-tauri/src/audio/pw_native/thread.rs
@@ -22,7 +22,9 @@ use crate::audio::pw_native::meter::MeterHandle;
 use crate::audio::pw_native::mic::{MicStreams, MIC_NODE};
 use crate::audio::pw_native::pods;
 use crate::audio::pw_native::send_gain::SendGainHandle;
-use crate::audio::types::{is_virtual_sink, AppStream, EqConfig, MicConfig, OutputDevice};
+use crate::audio::types::{
+    is_own_sink, is_virtual_sink, AppStream, EqConfig, MicConfig, OutputDevice,
+};
 use crate::error::SinkError;
 use crate::persistence::buses::is_bus_name;
 
@@ -929,7 +931,7 @@ fn desired_pairs(s: &State, channel_id: u32, target_id: u32) -> Vec<(u32, u32)> 
 /// device the OS would pick, consistently across distros.
 fn pick_fallback_sink<'a>(candidates: impl Iterator<Item = (u32, &'a str, i64)>) -> Option<u32> {
     candidates
-        .filter(|(_, name, _)| !is_virtual_sink(name))
+        .filter(|(_, name, _)| !is_own_sink(name))
         .max_by_key(|&(_, _, priority)| priority)
         .map(|(id, _, _)| id)
 }
@@ -1202,15 +1204,16 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
             .as_deref()
             .and_then(|name| node_ids.get(name).copied());
         let strict = s.channel_strict.contains(sink_name);
-        // A user can make one of our channels the system default; following
-        // it would loop every follow-default channel (and the channel's own
-        // EQ playback) back into it. Treat that as "no default" so the real
-        // device fallback applies - pick_fallback_sink never picks a
-        // virtual sink.
+        // A user can make one of our own nodes the system default - a
+        // channel, or a mix they moved into the playback list. Following it
+        // would loop every follow-default channel (and the channel's own EQ
+        // playback) back into it. Treat that as "no default" so the real
+        // device fallback applies - pick_fallback_sink never picks one of
+        // ours either.
         let default_id = s
             .default_sink_name
             .as_ref()
-            .filter(|name| !is_virtual_sink(name))
+            .filter(|name| !is_own_sink(name))
             .and_then(|name| node_ids.get(name))
             .copied();
         let target_id = resolve_target(explicit_id, pinned, strict, default_id, fallback);
@@ -2222,12 +2225,26 @@ mod tests {
     }
 
     #[test]
-    fn fallback_is_none_when_only_virtual_channel_sinks_exist() {
-        // Channel sinks are virtual and must never be a fallback target.
-        // (sink_mic/sink_stream are sources, excluded by media_class before
-        // reaching here - so they're not exercised at this layer.)
-        let candidates = [(1u32, "sink_game", 0i64), (2, "sink_chat", 0)];
+    fn fallback_is_none_when_only_our_own_sinks_exist() {
+        // Routing a channel into one of our own nodes feeds it back: a mix
+        // already receives every channel, and a channel receiving itself is
+        // a loop. A mix the user moved into the playback list is a sink and
+        // reaches this layer, unlike a mix left as a source.
+        let candidates = [
+            (1u32, "sink_game", 0i64),
+            (2, "sink_chat", 0),
+            (3, "sink_stream", 0),
+            (4, "sink_bus_voice_only", 0),
+        ];
         assert_eq!(pick_fallback_sink(candidates.into_iter()), None);
+
+        // A real device among them still wins.
+        let candidates = [
+            (1u32, "sink_game", 0i64),
+            (3, "sink_stream", 0),
+            (9, "alsa_output.pci-0000_00_1f.3.analog-stereo", 1000),
+        ];
+        assert_eq!(pick_fallback_sink(candidates.into_iter()), Some(9));
     }
 
     fn kv(pairs: &[(&str, &str)]) -> HashMap<String, String> {

--- a/src-tauri/src/audio/pw_native/thread.rs
+++ b/src-tauri/src/audio/pw_native/thread.rs
@@ -94,6 +94,7 @@ pub enum Cmd {
     CreateBus {
         name: String,
         label: String,
+        input: bool,
         reply: Reply<()>,
     },
     /// Destroy a mix bus and its links.
@@ -797,10 +798,13 @@ fn on_node(
         return;
     }
 
-    // A mix bus came up: meter it (direct source capture) and link members.
-    if media_class == VIRTUAL_SOURCE_CLASS && is_bus_name(&node_name) {
+    // A mix bus came up: meter it and link members. A mix exposed as a
+    // playback device is metered through its monitor, like a channel.
+    if (media_class == VIRTUAL_SOURCE_CLASS || media_class == SINK_CLASS) && is_bus_name(&node_name)
+    {
+        let from_monitor = media_class == SINK_CLASS;
         if !s.meters.contains_key(&node_name) {
-            match MeterHandle::new(core, &node_name, global.id, levels.clone(), false) {
+            match MeterHandle::new(core, &node_name, global.id, levels.clone(), from_monitor) {
                 Ok(meter) => {
                     s.meters.insert(node_name.clone(), meter);
                 }
@@ -1340,13 +1344,24 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
 }
 
 fn node_needs_monitor_volumes(kind: u8) -> bool {
-    kind == 0 || kind == 1
+    kind == 0 || kind == 1 || kind == 3
 }
 
-/// The three virtual node shapes we own (kind 0=channel sink, 1=mix bus,
-/// 2=virtual mic). The heal path mirrors the create handlers with this.
+/// A mix is a recording device by default and a playback device when the
+/// user turns that off; the node kind carries the choice.
+fn bus_kind(input: bool) -> u8 {
+    if input {
+        1
+    } else {
+        3
+    }
+}
+
+/// The virtual node shapes we own (kind 0=channel sink, 1=mix as a source,
+/// 2=virtual mic, 3=mix as a sink). The heal path mirrors the create
+/// handlers with this.
 fn create_node_object(core: &CoreRc, name: &str, label: &str, kind: u8) -> Result<Node, pw::Error> {
-    let class = if kind == 0 {
+    let class = if kind == 0 || kind == 3 {
         SINK_CLASS
     } else {
         VIRTUAL_SOURCE_CLASS
@@ -1546,10 +1561,16 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
             let s = state.borrow();
             let _ = reply.send(set_props(s.nodes.get(&id), Some(percent), None));
         }
-        Cmd::CreateBus { name, label, reply } => {
+        Cmd::CreateBus {
+            name,
+            label,
+            input,
+            reply,
+        } => {
+            let kind = bus_kind(input);
             let mut s = state.borrow_mut();
             if s.bus_sources.contains_key(&name) || s.node_by_name(&name).is_some() {
-                s.desired.insert(name, (label, 1)); // adopted - keep alive
+                s.desired.insert(name, (label, kind)); // adopted - keep alive
                 let _ = reply.send(Ok(()));
                 return;
             }
@@ -1557,9 +1578,9 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
                 let _ = reply.send(Err(SinkError::Config("core is gone".into())));
                 return;
             };
-            match create_node_object(&core, &name, &label, 1) {
+            match create_node_object(&core, &name, &label, kind) {
                 Ok(proxy) => {
-                    s.desired.insert(name.clone(), (label, 1));
+                    s.desired.insert(name.clone(), (label, kind));
                     s.bus_sources.insert(name, proxy);
                     let _ = reply.send(Ok(()));
                 }
@@ -2104,6 +2125,17 @@ mod tests {
         let mut pairs = desired_pairs(&s, 10, 20);
         pairs.sort_unstable();
         assert_eq!(pairs, vec![(1, 2), (1, 3)]);
+    }
+
+    #[test]
+    fn a_mix_takes_the_node_shape_its_role_asks_for() {
+        // Recording device: a virtual source a recorder can select.
+        assert_eq!(bus_kind(true), 1);
+        // Playback device: a sink, metered through its monitor like a
+        // channel, still capturable there.
+        assert_eq!(bus_kind(false), 3);
+        assert!(node_needs_monitor_volumes(bus_kind(false)));
+        assert!(node_needs_monitor_volumes(bus_kind(true)));
     }
 
     #[test]

--- a/src-tauri/src/audio/pw_native/thread.rs
+++ b/src-tauri/src/audio/pw_native/thread.rs
@@ -1540,12 +1540,14 @@ fn handle_cmd(state: &Rc<RefCell<State>>, registry: &RegistryRc, cmd: Cmd) {
             let outputs = s
                 .nodes
                 .values()
+                // Where a channel may be sent: real devices only. One of
+                // our own nodes would feed itself.
                 .filter(|n| {
                     n.media_class == SINK_CLASS
                         && !n
                             .props
                             .get("node.name")
-                            .is_some_and(|name| is_virtual_sink(name))
+                            .is_some_and(|name| is_own_sink(name))
                 })
                 .map(|n| OutputDevice {
                     index: n.id,

--- a/src-tauri/src/audio/pw_native/thread.rs
+++ b/src-tauri/src/audio/pw_native/thread.rs
@@ -1292,12 +1292,12 @@ fn ensure_all_links(state: &Rc<RefCell<State>>) {
     }
 
     // ---- monitor links (listen on the default output, session scoped) ----
-    // Same virtual-default guard as the channel links above: never treat
-    // one of our own channels as the listening device.
+    // Same guard as the channel links above: listening on one of our own
+    // nodes would feed it whatever it already carries.
     let default_id = s
         .default_sink_name
         .as_ref()
-        .filter(|name| !is_virtual_sink(name))
+        .filter(|name| !is_own_sink(name))
         .and_then(|name| node_ids.get(name))
         .copied();
     let monitored: Vec<String> = s.monitored.iter().cloned().collect();

--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -2,6 +2,14 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+/// Any sink node Sink itself created: a channel, a service node, or a mix
+/// the user moved into the playback list. None of these is somewhere audio
+/// may be routed *to* as if it were an output - a mix already receives every
+/// channel, so sending a channel into one feeds it back into itself.
+pub fn is_own_sink(name: &str) -> bool {
+    name.starts_with("sink_")
+}
+
 /// True if `sink_name` is one of our managed virtual channels. Channels
 /// are user-defined (see persistence::channels) but always carry the
 /// `sink_` prefix; Sink's own service nodes and mix buses are excluded,
@@ -150,6 +158,33 @@ pub fn resolve_identity(get: impl Fn(&str) -> Option<String>) -> (String, String
             "application.name".to_string(),
             "Unknown".to_string(),
         ),
+    }
+}
+
+#[cfg(test)]
+mod own_sink_tests {
+    use super::*;
+
+    #[test]
+    fn every_node_we_create_counts_as_ours() {
+        // Whatever list the user puts a mix in, audio must never be routed
+        // into it as if it were an output.
+        for name in [
+            "sink_game",
+            "sink_music",
+            "sink_stream",
+            "sink_bus_voice_only",
+            "sink_mic",
+        ] {
+            assert!(is_own_sink(name), "{name}");
+        }
+        for name in [
+            "alsa_output.pci-0000_00_1f.3.analog-stereo",
+            "bluez_output.AA_BB",
+            "",
+        ] {
+            assert!(!is_own_sink(name), "{name}");
+        }
     }
 }
 

--- a/src-tauri/src/commands/buses.rs
+++ b/src-tauri/src/commands/buses.rs
@@ -121,9 +121,9 @@ pub fn rename_bus(state: State<'_, AppState>, name: String, label: String) -> Re
     Ok(())
 }
 
-/// Show a mix among the recording devices (true) or the playback devices
-/// (false). The node carries its role in `media.class`, so switching means
-/// recreating it and putting its members, mic, level and sends back.
+/// Show a mix among the recording devices, or among the playback ones.
+/// A node cannot change its `media.class`, so this recreates it and puts
+/// the members, mic, level and sends back.
 #[tauri::command]
 pub fn set_bus_input(state: State<'_, AppState>, name: String, input: bool) -> Result<(), String> {
     let (def, defs, prefs, all) = {

--- a/src-tauri/src/commands/buses.rs
+++ b/src-tauri/src/commands/buses.rs
@@ -48,7 +48,7 @@ pub fn add_bus(state: State<'_, AppState>, label: String) -> Result<(), String> 
     };
     if let Err(e) = state
         .backend
-        .create_bus(&def.name, &prefs.decorate(&def.label))
+        .create_bus(&def.name, &prefs.decorate(&def.label), def.input)
     {
         let mut mixer = state.lock_mixer()?;
         let _ = mixer.buses.remove(&def.name);
@@ -96,7 +96,7 @@ pub fn rename_bus(state: State<'_, AppState>, name: String, label: String) -> Re
         .map_err(|e| e.to_string())?;
     state
         .backend
-        .create_bus(&def.name, &prefs.decorate(&def.label))
+        .create_bus(&def.name, &prefs.decorate(&def.label), def.input)
         .map_err(|e| e.to_string())?;
     state
         .backend
@@ -112,6 +112,51 @@ pub fn rename_bus(state: State<'_, AppState>, name: String, label: String) -> Re
         }
     }
     // The node is fresh; restore its saved level and send gains.
+    apply_bus_level(state.backend.as_ref(), &def);
+    apply_bus_member_gains(state.backend.as_ref(), &def);
+
+    defs.save().map_err(|e| e.to_string())?;
+    let mixer = state.lock_mixer()?;
+    crate::commands::profiles::autosave_active(&mixer);
+    Ok(())
+}
+
+/// Show a mix among the recording devices (true) or the playback devices
+/// (false). The node carries its role in `media.class`, so switching means
+/// recreating it and putting its members, mic, level and sends back.
+#[tauri::command]
+pub fn set_bus_input(state: State<'_, AppState>, name: String, input: bool) -> Result<(), String> {
+    let (def, defs, prefs, all) = {
+        let mut mixer = state.lock_mixer()?;
+        let def = mixer
+            .buses
+            .set_input(&name, input)
+            .map_err(|e| e.to_string())?;
+        (
+            def,
+            mixer.buses.clone(),
+            mixer.prefs.clone(),
+            channel_names(&mixer),
+        )
+    };
+
+    state
+        .backend
+        .destroy_bus(&name)
+        .map_err(|e| e.to_string())?;
+    state
+        .backend
+        .create_bus(&def.name, &prefs.decorate(&def.label), def.input)
+        .map_err(|e| e.to_string())?;
+    state
+        .backend
+        .set_bus_members(&def.name, &def.effective_members(&all))
+        .map_err(|e| e.to_string())?;
+    if def.mic {
+        if let Err(e) = state.backend.set_bus_mic(&def.name, true) {
+            eprintln!("sink: mic membership for mix {} failed: {e}", def.name);
+        }
+    }
     apply_bus_level(state.backend.as_ref(), &def);
     apply_bus_member_gains(state.backend.as_ref(), &def);
 

--- a/src-tauri/src/commands/buses.rs
+++ b/src-tauri/src/commands/buses.rs
@@ -130,6 +130,10 @@ pub fn set_bus_role(
     name: String,
     role: crate::persistence::buses::MixRole,
 ) -> Result<(), String> {
+    let _rebuild = state
+        .bus_rebuild
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let (def, defs, prefs, all) = {
         let mut mixer = state.lock_mixer()?;
         let def = mixer

--- a/src-tauri/src/commands/buses.rs
+++ b/src-tauri/src/commands/buses.rs
@@ -48,7 +48,7 @@ pub fn add_bus(state: State<'_, AppState>, label: String) -> Result<(), String> 
     };
     if let Err(e) = state
         .backend
-        .create_bus(&def.name, &prefs.decorate(&def.label), def.input)
+        .create_bus(&def.name, &prefs.decorate(&def.label), def.role)
     {
         let mut mixer = state.lock_mixer()?;
         let _ = mixer.buses.remove(&def.name);
@@ -96,7 +96,7 @@ pub fn rename_bus(state: State<'_, AppState>, name: String, label: String) -> Re
         .map_err(|e| e.to_string())?;
     state
         .backend
-        .create_bus(&def.name, &prefs.decorate(&def.label), def.input)
+        .create_bus(&def.name, &prefs.decorate(&def.label), def.role)
         .map_err(|e| e.to_string())?;
     state
         .backend
@@ -121,16 +121,20 @@ pub fn rename_bus(state: State<'_, AppState>, name: String, label: String) -> Re
     Ok(())
 }
 
-/// Show a mix among the recording devices, or among the playback ones.
-/// A node cannot change its `media.class`, so this recreates it and puts
-/// the members, mic, level and sends back.
+/// Which device list a mix shows up in. A node cannot change its
+/// `media.class`, so this recreates it and puts the members, mic, level
+/// and sends back.
 #[tauri::command]
-pub fn set_bus_input(state: State<'_, AppState>, name: String, input: bool) -> Result<(), String> {
+pub fn set_bus_role(
+    state: State<'_, AppState>,
+    name: String,
+    role: crate::persistence::buses::MixRole,
+) -> Result<(), String> {
     let (def, defs, prefs, all) = {
         let mut mixer = state.lock_mixer()?;
         let def = mixer
             .buses
-            .set_input(&name, input)
+            .set_role(&name, role)
             .map_err(|e| e.to_string())?;
         (
             def,
@@ -146,7 +150,7 @@ pub fn set_bus_input(state: State<'_, AppState>, name: String, input: bool) -> R
         .map_err(|e| e.to_string())?;
     state
         .backend
-        .create_bus(&def.name, &prefs.decorate(&def.label), def.input)
+        .create_bus(&def.name, &prefs.decorate(&def.label), def.role)
         .map_err(|e| e.to_string())?;
     state
         .backend

--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -362,7 +362,7 @@ pub fn init_virtual_devices(
     for bus in &buses.buses {
         if let Err(e) = state
             .backend
-            .create_bus(&bus.name, &prefs.decorate(&bus.label), bus.input)
+            .create_bus(&bus.name, &prefs.decorate(&bus.label), bus.role)
         {
             eprintln!("sink: creating mix {} failed: {e}", bus.name);
             continue;

--- a/src-tauri/src/commands/devices.rs
+++ b/src-tauri/src/commands/devices.rs
@@ -362,7 +362,7 @@ pub fn init_virtual_devices(
     for bus in &buses.buses {
         if let Err(e) = state
             .backend
-            .create_bus(&bus.name, &prefs.decorate(&bus.label))
+            .create_bus(&bus.name, &prefs.decorate(&bus.label), bus.input)
         {
             eprintln!("sink: creating mix {} failed: {e}", bus.name);
             continue;

--- a/src-tauri/src/commands/profiles.rs
+++ b/src-tauri/src/commands/profiles.rs
@@ -175,9 +175,10 @@ pub fn load_profile(
     }
     for bus in &target_buses.buses {
         if current_buses.get(&bus.name).is_none() {
-            if let Err(e) = state
-                .backend
-                .create_bus(&bus.name, &prefs.decorate(&bus.label), bus.input)
+            if let Err(e) =
+                state
+                    .backend
+                    .create_bus(&bus.name, &prefs.decorate(&bus.label), bus.input)
             {
                 eprintln!("sink: profile mix {} failed: {e}", bus.name);
                 continue;

--- a/src-tauri/src/commands/profiles.rs
+++ b/src-tauri/src/commands/profiles.rs
@@ -178,7 +178,7 @@ pub fn load_profile(
             if let Err(e) =
                 state
                     .backend
-                    .create_bus(&bus.name, &prefs.decorate(&bus.label), bus.input)
+                    .create_bus(&bus.name, &prefs.decorate(&bus.label), bus.role)
             {
                 eprintln!("sink: profile mix {} failed: {e}", bus.name);
                 continue;

--- a/src-tauri/src/commands/profiles.rs
+++ b/src-tauri/src/commands/profiles.rs
@@ -177,7 +177,7 @@ pub fn load_profile(
         if current_buses.get(&bus.name).is_none() {
             if let Err(e) = state
                 .backend
-                .create_bus(&bus.name, &prefs.decorate(&bus.label))
+                .create_bus(&bus.name, &prefs.decorate(&bus.label), bus.input)
             {
                 eprintln!("sink: profile mix {} failed: {e}", bus.name);
                 continue;

--- a/src-tauri/src/commands/profiles.rs
+++ b/src-tauri/src/commands/profiles.rs
@@ -174,7 +174,13 @@ pub fn load_profile(
         }
     }
     for bus in &target_buses.buses {
-        if current_buses.get(&bus.name).is_none() {
+        // A mix whose role differs is a different kind of node, so the live
+        // one cannot be reused.
+        let live_role = current_buses.get(&bus.name).map(|b| b.role);
+        if live_role.is_some_and(|role| role != bus.role) {
+            let _ = state.backend.destroy_bus(&bus.name);
+        }
+        if live_role != Some(bus.role) {
             if let Err(e) =
                 state
                     .backend

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -80,7 +80,7 @@ pub fn run() {
             commands::buses::set_bus_members,
             commands::buses::set_bus_mic,
             commands::buses::set_bus_exclude,
-            commands::buses::set_bus_input,
+            commands::buses::set_bus_role,
             commands::buses::set_bus_volume,
             commands::buses::set_bus_mute,
             commands::buses::set_bus_member_gain,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -80,6 +80,7 @@ pub fn run() {
             commands::buses::set_bus_members,
             commands::buses::set_bus_mic,
             commands::buses::set_bus_exclude,
+            commands::buses::set_bus_input,
             commands::buses::set_bus_volume,
             commands::buses::set_bus_mute,
             commands::buses::set_bus_member_gain,

--- a/src-tauri/src/persistence/buses.rs
+++ b/src-tauri/src/persistence/buses.rs
@@ -53,16 +53,27 @@ pub struct BusDef {
     /// member's own volume. Keyed by sink name, or "sink_mic".
     #[serde(default)]
     pub member_gains: HashMap<String, u8>,
-    /// Recording device (true) or playback device (false). On, because a
-    /// recorder picks a mix straight out of its input list, which is what
-    /// most mixes are for. Off is for everyone else, whose input list this
-    /// would otherwise clutter.
-    #[serde(default = "default_input")]
-    pub input: bool,
+    /// Which device list the mix shows up in. Named rather than a flag so
+    /// a third role can be added without rewriting anyone's config.
+    #[serde(default)]
+    pub role: MixRole,
 }
 
-fn default_input() -> bool {
-    true
+/// Where a mix appears to the rest of the system.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MixRole {
+    /// A recording device, where a recorder looks first.
+    #[default]
+    Recording,
+    /// A playback device, captured through its monitor.
+    Playback,
+}
+
+impl MixRole {
+    pub fn is_recording(self) -> bool {
+        matches!(self, Self::Recording)
+    }
 }
 
 fn default_volume() -> u8 {
@@ -102,7 +113,7 @@ impl Default for Buses {
                 muted: false,
                 mic: false,
                 member_gains: HashMap::new(),
-                input: true,
+                role: MixRole::Recording,
             }],
         }
     }
@@ -207,7 +218,7 @@ impl Buses {
                 muted: false,
                 mic: false,
                 member_gains: HashMap::new(),
-                input: true,
+                role: MixRole::Recording,
             },
         };
         def.channels = channels.to_vec();
@@ -284,7 +295,7 @@ impl Buses {
             muted: false,
             mic: false,
             member_gains: HashMap::new(),
-            input: true,
+            role: MixRole::Recording,
         };
         self.buses.push(def.clone());
         Ok(def)
@@ -341,13 +352,13 @@ impl Buses {
 
     /// The updated definition comes back because the node has to be
     /// rebuilt in the new shape from it.
-    pub fn set_input(&mut self, name: &str, input: bool) -> Result<BusDef, SinkError> {
+    pub fn set_role(&mut self, name: &str, role: MixRole) -> Result<BusDef, SinkError> {
         let def = self
             .buses
             .iter_mut()
             .find(|b| b.name == name)
             .ok_or_else(|| SinkError::UnknownSink(name.to_string()))?;
-        def.input = input;
+        def.role = role;
         Ok(def.clone())
     }
 
@@ -600,27 +611,47 @@ mod tests {
     fn device_role_persists_and_defaults_to_a_recording_device() {
         let mut b = Buses::default();
         // The default is what a recorder expects to find in its input list.
-        assert!(b.buses[0].input);
+        assert!(b.buses[0].role.is_recording());
 
-        let def = b.set_input("sink_stream", false).expect("sets the role");
-        assert!(!def.input);
-        assert!(!b.get("sink_stream").expect("master").input);
-        assert!(b.set_input("sink_stream", true).expect("sets back").input);
+        let def = b
+            .set_role("sink_stream", MixRole::Playback)
+            .expect("sets the role");
+        assert_eq!(def.role, MixRole::Playback);
+        assert_eq!(
+            b.get("sink_stream").expect("master").role,
+            MixRole::Playback
+        );
+        assert!(b
+            .set_role("sink_stream", MixRole::Recording)
+            .expect("sets back")
+            .role
+            .is_recording());
 
         let mix = b.add("Voice Only").expect("adds");
-        assert!(b.get(&mix.name).expect("mix").input, "a new mix too");
-        assert!(b.set_input("sink_missing", false).is_err());
+        assert!(
+            b.get(&mix.name).expect("mix").role.is_recording(),
+            "a new mix too"
+        );
+        assert!(b.set_role("sink_missing", MixRole::Playback).is_err());
 
-        b.set_input("sink_stream", false).expect("sets the role");
+        b.set_role("sink_stream", MixRole::Playback)
+            .expect("sets the role");
         b.sync_master(&["sink_game".into()]);
-        assert!(!b.get("sink_stream").expect("master").input);
+        assert_eq!(
+            b.get("sink_stream").expect("master").role,
+            MixRole::Playback
+        );
 
         // A buses.json written before this field keeps every mix where it
         // was: an upgrade must not take anyone's mix out of obs.
         let legacy = r#"{"buses":[{"name":"sink_stream","label":"Master Mix","channels":[],"exclude":false,"mic":true}]}"#;
         let loaded: Buses = serde_json::from_str(legacy).expect("legacy loads");
-        assert!(loaded.buses[0].input);
+        assert!(loaded.buses[0].role.is_recording());
         assert!(loaded.buses[0].mic);
+
+        // The name on disk is the word, so a new role can join it later.
+        let json = serde_json::to_string(&b).expect("serializes");
+        assert!(json.contains("\"role\":\"playback\""), "{json}");
     }
 
     #[test]

--- a/src-tauri/src/persistence/buses.rs
+++ b/src-tauri/src/persistence/buses.rs
@@ -53,10 +53,10 @@ pub struct BusDef {
     /// member's own volume. Keyed by sink name, or "sink_mic".
     #[serde(default)]
     pub member_gains: HashMap<String, u8>,
-    /// Recording device (true) or playback device (false). A recorder picks
-    /// an input straight from its list, which is what a mix is usually for,
-    /// so this is on. Off puts the mix among the outputs instead, where it
-    /// stays recordable through its monitor and can be played into.
+    /// Recording device (true) or playback device (false). On, because a
+    /// recorder picks a mix straight out of its input list, which is what
+    /// most mixes are for. Off is for everyone else, whose input list this
+    /// would otherwise clutter.
     #[serde(default = "default_input")]
     pub input: bool,
 }
@@ -339,8 +339,8 @@ impl Buses {
         Ok(())
     }
 
-    /// Switch a mix between the recording and playback device lists,
-    /// returning the updated definition for the caller to rebuild from.
+    /// The updated definition comes back because the node has to be
+    /// rebuilt in the new shape from it.
     pub fn set_input(&mut self, name: &str, input: bool) -> Result<BusDef, SinkError> {
         let def = self
             .buses
@@ -611,7 +611,6 @@ mod tests {
         assert!(b.get(&mix.name).expect("mix").input, "a new mix too");
         assert!(b.set_input("sink_missing", false).is_err());
 
-        // sync_master preserves the role across membership resyncs.
         b.set_input("sink_stream", false).expect("sets the role");
         b.sync_master(&["sink_game".into()]);
         assert!(!b.get("sink_stream").expect("master").input);

--- a/src-tauri/src/persistence/buses.rs
+++ b/src-tauri/src/persistence/buses.rs
@@ -53,6 +53,16 @@ pub struct BusDef {
     /// member's own volume. Keyed by sink name, or "sink_mic".
     #[serde(default)]
     pub member_gains: HashMap<String, u8>,
+    /// Recording device (true) or playback device (false). A recorder picks
+    /// an input straight from its list, which is what a mix is usually for,
+    /// so this is on. Off puts the mix among the outputs instead, where it
+    /// stays recordable through its monitor and can be played into.
+    #[serde(default = "default_input")]
+    pub input: bool,
+}
+
+fn default_input() -> bool {
+    true
 }
 
 fn default_volume() -> u8 {
@@ -92,6 +102,7 @@ impl Default for Buses {
                 muted: false,
                 mic: false,
                 member_gains: HashMap::new(),
+                input: true,
             }],
         }
     }
@@ -196,6 +207,7 @@ impl Buses {
                 muted: false,
                 mic: false,
                 member_gains: HashMap::new(),
+                input: true,
             },
         };
         def.channels = channels.to_vec();
@@ -272,6 +284,7 @@ impl Buses {
             muted: false,
             mic: false,
             member_gains: HashMap::new(),
+            input: true,
         };
         self.buses.push(def.clone());
         Ok(def)
@@ -324,6 +337,18 @@ impl Buses {
             .ok_or_else(|| SinkError::UnknownSink(name.to_string()))?;
         def.channels = channels;
         Ok(())
+    }
+
+    /// Switch a mix between the recording and playback device lists,
+    /// returning the updated definition for the caller to rebuild from.
+    pub fn set_input(&mut self, name: &str, input: bool) -> Result<BusDef, SinkError> {
+        let def = self
+            .buses
+            .iter_mut()
+            .find(|b| b.name == name)
+            .ok_or_else(|| SinkError::UnknownSink(name.to_string()))?;
+        def.input = input;
+        Ok(def.clone())
     }
 
     pub fn set_volume(&mut self, name: &str, volume: u8) -> Result<(), SinkError> {
@@ -569,6 +594,34 @@ mod tests {
         let legacy = r#"{"buses":[{"name":"sink_stream","label":"Master Mix","channels":[],"exclude":false}]}"#;
         let loaded: Buses = serde_json::from_str(legacy).expect("legacy loads");
         assert!(!loaded.buses[0].mic);
+    }
+
+    #[test]
+    fn device_role_persists_and_defaults_to_a_recording_device() {
+        let mut b = Buses::default();
+        // The default is what a recorder expects to find in its input list.
+        assert!(b.buses[0].input);
+
+        let def = b.set_input("sink_stream", false).expect("sets the role");
+        assert!(!def.input);
+        assert!(!b.get("sink_stream").expect("master").input);
+        assert!(b.set_input("sink_stream", true).expect("sets back").input);
+
+        let mix = b.add("Voice Only").expect("adds");
+        assert!(b.get(&mix.name).expect("mix").input, "a new mix too");
+        assert!(b.set_input("sink_missing", false).is_err());
+
+        // sync_master preserves the role across membership resyncs.
+        b.set_input("sink_stream", false).expect("sets the role");
+        b.sync_master(&["sink_game".into()]);
+        assert!(!b.get("sink_stream").expect("master").input);
+
+        // A buses.json written before this field keeps every mix where it
+        // was: an upgrade must not take anyone's mix out of obs.
+        let legacy = r#"{"buses":[{"name":"sink_stream","label":"Master Mix","channels":[],"exclude":false,"mic":true}]}"#;
+        let loaded: Buses = serde_json::from_str(legacy).expect("legacy loads");
+        assert!(loaded.buses[0].input);
+        assert!(loaded.buses[0].mic);
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -13,6 +13,9 @@ pub struct AppState {
     pub mixer: Mutex<MixerState>,
     /// Held for a whole profile load, which takes the mixer lock piecemeal.
     pub profile_switch: Mutex<()>,
+    /// Held while a mix node is torn down and built again, so two role
+    /// switches cannot interleave and leave the node in the other shape.
+    pub bus_rebuild: Mutex<()>,
     /// Lets the pactl-backend ticker yield while an on-screen window is
     /// already polling (see `lib::spawn_route_enforcer`).
     ui_stream_poll: Mutex<Option<Instant>>,
@@ -88,6 +91,7 @@ impl AppState {
             backend_native,
             mixer: Mutex::new(mixer),
             profile_switch: Mutex::new(()),
+            bus_rebuild: Mutex::new(()),
             ui_stream_poll: Mutex::new(None),
             refresh_gate: Mutex::new(()),
             identity_cache: Mutex::new(HashMap::new()),

--- a/src/components/MixerBoard/MixRoleSelect.tsx
+++ b/src/components/MixerBoard/MixRoleSelect.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
+import type { MixRole } from "../../types";
 import { Ms } from "../Icons";
 import { MenuItem } from "../MenuItem";
 import { Popover } from "../Popover";
 
 interface MixRoleSelectProps {
-  /** True: the mix is a recording device. False: a playback device. */
-  input: boolean;
-  onChange: (input: boolean) => void;
+  role: MixRole;
+  onChange: (role: MixRole) => void;
 }
 
 /**
@@ -15,9 +15,10 @@ interface MixRoleSelectProps {
  * devices", "Playback devices") so the label matches what the user sees
  * in their sound settings.
  */
-export function MixRoleSelect({ input, onChange }: Readonly<MixRoleSelectProps>) {
+export function MixRoleSelect({ role, onChange }: Readonly<MixRoleSelectProps>) {
   const [open, setOpen] = useState(false);
-  const pick = (value: boolean) => {
+  const recording = role === "recording";
+  const pick = (value: MixRole) => {
     onChange(value);
     setOpen(false);
   };
@@ -29,13 +30,13 @@ export function MixRoleSelect({ input, onChange }: Readonly<MixRoleSelectProps>)
         className="strip-route strip-route-btn"
         onClick={() => setOpen((o) => !o)}
         title={
-          input
+          recording
             ? "Shows up as a recording device, which is what a recorder captures"
             : "Shows up as a playback device; a recorder captures its monitor"
         }
       >
-        <Ms name={input ? "mic" : "speaker"} />
-        <span className="strip-route-name">{input ? "Recording" : "Playback"}</span>
+        <Ms name={recording ? "mic" : "speaker"} />
+        <span className="strip-route-name">{recording ? "Recording" : "Playback"}</span>
         <Ms name="expand_more" />
       </button>
       <Popover
@@ -47,18 +48,18 @@ export function MixRoleSelect({ input, onChange }: Readonly<MixRoleSelectProps>)
       >
         <MenuItem
           icon="mic"
-          selected={input}
+          selected={recording}
           showCheck
-          onClick={() => pick(true)}
+          onClick={() => pick("recording")}
           title="Where a recorder looks first"
         >
           Recording device
         </MenuItem>
         <MenuItem
           icon="speaker"
-          selected={!input}
+          selected={!recording}
           showCheck
-          onClick={() => pick(false)}
+          onClick={() => pick("playback")}
           title="Keeps the mix out of your microphone list; recorders capture its monitor"
         >
           Playback device

--- a/src/components/MixerBoard/MixRoleSelect.tsx
+++ b/src/components/MixerBoard/MixRoleSelect.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { Ms } from "../Icons";
+import { MenuItem } from "../MenuItem";
+import { Popover } from "../Popover";
+
+interface MixRoleSelectProps {
+  /** True: the mix is a recording device. False: a playback device. */
+  input: boolean;
+  onChange: (input: boolean) => void;
+}
+
+/**
+ * Which device list a mix shows up in, in the same strip footer where a
+ * channel picks its output. The wording is the system's own ("Recording
+ * devices", "Playback devices") so the label matches what the user sees
+ * in their sound settings.
+ */
+export function MixRoleSelect({ input, onChange }: Readonly<MixRoleSelectProps>) {
+  const [open, setOpen] = useState(false);
+  const pick = (value: boolean) => {
+    onChange(value);
+    setOpen(false);
+  };
+
+  return (
+    <div style={{ position: "relative" }}>
+      <button
+        type="button"
+        className="strip-route strip-route-btn"
+        onClick={() => setOpen((o) => !o)}
+        title={
+          input
+            ? "Shows up as a recording device, which is what a recorder captures"
+            : "Shows up as a playback device; a recorder captures its monitor"
+        }
+      >
+        <Ms name={input ? "mic" : "speaker"} />
+        <span className="strip-route-name">{input ? "Recording" : "Playback"}</span>
+        <Ms name="expand_more" />
+      </button>
+      <Popover
+        open={open}
+        onClose={() => setOpen(false)}
+        side="top"
+        align="center"
+        style={{ minWidth: 250 }}
+      >
+        <MenuItem
+          icon="mic"
+          selected={input}
+          showCheck
+          onClick={() => pick(true)}
+          title="Where a recorder looks first"
+        >
+          Recording device
+        </MenuItem>
+        <MenuItem
+          icon="speaker"
+          selected={!input}
+          showCheck
+          onClick={() => pick(false)}
+          title="Keeps the mix out of your microphone list; recorders capture its monitor"
+        >
+          Playback device
+        </MenuItem>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/MixerBoard/StreamMixStrip.tsx
+++ b/src/components/MixerBoard/StreamMixStrip.tsx
@@ -32,6 +32,7 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
   const setBusMembers = useMixerStore((s) => s.setBusMembers);
   const setBusExclude = useMixerStore((s) => s.setBusExclude);
   const setBusMic = useMixerStore((s) => s.setBusMic);
+  const setBusInput = useMixerStore((s) => s.setBusInput);
   const micEnabled = useMixerStore((s) => s.micConfig?.enabled ?? false);
   const renameBus = useMixerStore((s) => s.renameBus);
   const removeBus = useMixerStore((s) => s.removeBus);
@@ -144,6 +145,14 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
                 </MenuCheckItem>
               </>
             )}
+            <div className="menu-div" />
+            <MenuCheckItem
+              checked={bus.input}
+              title="Off: the mix sits with the output devices instead, and recorders capture its monitor"
+              onClick={() => void setBusInput(bus.name, !bus.input)}
+            >
+              <span className="menu-item-label">Show as a recording device</span>
+            </MenuCheckItem>
             <div className="menu-div" />
             <MenuItem
               icon="open_in_new"

--- a/src/components/MixerBoard/StreamMixStrip.tsx
+++ b/src/components/MixerBoard/StreamMixStrip.tsx
@@ -33,7 +33,7 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
   const setBusMembers = useMixerStore((s) => s.setBusMembers);
   const setBusExclude = useMixerStore((s) => s.setBusExclude);
   const setBusMic = useMixerStore((s) => s.setBusMic);
-  const setBusInput = useMixerStore((s) => s.setBusInput);
+  const setBusRole = useMixerStore((s) => s.setBusRole);
   const micEnabled = useMixerStore((s) => s.micConfig?.enabled ?? false);
   const renameBus = useMixerStore((s) => s.renameBus);
   const removeBus = useMixerStore((s) => s.removeBus);
@@ -191,7 +191,7 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
         </button>
       </div>
 
-      <MixRoleSelect input={bus.input} onChange={(input) => void setBusInput(bus.name, input)} />
+      <MixRoleSelect role={bus.role} onChange={(role) => void setBusRole(bus.name, role)} />
 
       <ConfirmModal
         open={confirmingDelete}

--- a/src/components/MixerBoard/StreamMixStrip.tsx
+++ b/src/components/MixerBoard/StreamMixStrip.tsx
@@ -148,7 +148,7 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
             <div className="menu-div" />
             <MenuCheckItem
               checked={bus.input}
-              title="Off: the mix sits with the output devices instead, and recorders capture its monitor"
+              title="Off: the mix sits with the output devices instead, captured as its monitor. A recorder that already has this mix selected has to pick it again."
               onClick={() => void setBusInput(bus.name, !bus.input)}
             >
               <span className="menu-item-label">Show as a recording device</span>

--- a/src/components/MixerBoard/StreamMixStrip.tsx
+++ b/src/components/MixerBoard/StreamMixStrip.tsx
@@ -8,6 +8,7 @@ import { ConfirmModal } from "../ConfirmModal";
 import { MenuCheckItem, MenuItem } from "../MenuItem";
 import { Popover } from "../Popover";
 import { Fader } from "./Fader";
+import { MixRoleSelect } from "./MixRoleSelect";
 import { StripName } from "./StripName";
 import { VuMeter } from "./VuMeter";
 
@@ -146,14 +147,6 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
               </>
             )}
             <div className="menu-div" />
-            <MenuCheckItem
-              checked={bus.input}
-              title="Off: the mix sits with the output devices instead, captured as its monitor. A recorder that already has this mix selected has to pick it again."
-              onClick={() => void setBusInput(bus.name, !bus.input)}
-            >
-              <span className="menu-item-label">Show as a recording device</span>
-            </MenuCheckItem>
-            <div className="menu-div" />
             <MenuItem
               icon="open_in_new"
               onClick={() => {
@@ -198,7 +191,7 @@ export function BusStrip({ bus }: Readonly<{ bus: BusDef }>) {
         </button>
       </div>
 
-      <div className="strip-route" title={`Capture "${bus.label}" in OBS`} />
+      <MixRoleSelect input={bus.input} onChange={(input) => void setBusInput(bus.name, input)} />
 
       <ConfirmModal
         open={confirmingDelete}

--- a/src/store/mixer.ts
+++ b/src/store/mixer.ts
@@ -111,6 +111,8 @@ interface MixerStore {
   setBusExclude: (name: string, exclude: boolean) => Promise<void>;
   /** Whether the processed virtual mic feeds this mix too; persisted. */
   setBusMic: (name: string, mic: boolean) => Promise<void>;
+  /** Show the mix among the recording devices, or among the outputs. */
+  setBusInput: (name: string, input: boolean) => Promise<void>;
   /** A mix's playback level for recorders (0-150%); persisted. */
   setBusVolume: (name: string, volume: number) => Promise<void>;
   /** Mute a mix for recorders; persisted. */
@@ -672,6 +674,18 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
     }));
     try {
       await invoke("set_bus_exclude", { name, exclude });
+    } catch (e) {
+      set({ error: String(e) });
+      await get().fetchBuses();
+    }
+  },
+
+  setBusInput: async (name, input) => {
+    set((s) => ({
+      buses: s.buses.map((b) => (b.name === name ? { ...b, input } : b)),
+    }));
+    try {
+      await invoke("set_bus_input", { name, input });
     } catch (e) {
       set({ error: String(e) });
       await get().fetchBuses();

--- a/src/store/mixer.ts
+++ b/src/store/mixer.ts
@@ -5,6 +5,7 @@ import type {
   BusDef,
   EqConfig,
   MicConfig,
+  MixRole,
   OutputDevice,
   ProfileInfo,
   SeenApp,
@@ -111,8 +112,8 @@ interface MixerStore {
   setBusExclude: (name: string, exclude: boolean) => Promise<void>;
   /** Whether the processed virtual mic feeds this mix too; persisted. */
   setBusMic: (name: string, mic: boolean) => Promise<void>;
-  /** Show the mix among the recording devices, or among the outputs. */
-  setBusInput: (name: string, input: boolean) => Promise<void>;
+  /** Which device list the mix shows up in. */
+  setBusRole: (name: string, role: MixRole) => Promise<void>;
   /** A mix's playback level for recorders (0-150%); persisted. */
   setBusVolume: (name: string, volume: number) => Promise<void>;
   /** Mute a mix for recorders; persisted. */
@@ -680,12 +681,12 @@ export const useMixerStore = create<MixerStore>((set, get) => ({
     }
   },
 
-  setBusInput: async (name, input) => {
+  setBusRole: async (name, role) => {
     set((s) => ({
-      buses: s.buses.map((b) => (b.name === name ? { ...b, input } : b)),
+      buses: s.buses.map((b) => (b.name === name ? { ...b, role } : b)),
     }));
     try {
-      await invoke("set_bus_input", { name, input });
+      await invoke("set_bus_role", { name, role });
     } catch (e) {
       set({ error: String(e) });
       await get().fetchBuses();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -141,6 +141,10 @@ export interface BusDef {
   muted: boolean;
   /** Whether the processed virtual mic feeds this mix too. Persisted. */
   mic: boolean;
+  /** True: the mix is a recording device, which is what a recorder picks
+   *  from its input list. False: a playback device instead, still
+   *  recordable through its monitor. Persisted. */
+  input: boolean;
   /** Per-member send level within this mix (0-150%); a member absent here
    *  carries at 100%. Keyed by channel sink name, or "sink_mic". */
   member_gains: Record<string, number>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -128,6 +128,9 @@ export interface SeenApp {
 }
 
 /** A user-defined mix (record bus). The label is what recorders display. */
+/** Where a mix appears to the rest of the system. */
+export type MixRole = "recording" | "playback";
+
 export interface BusDef {
   name: string;
   label: string;
@@ -141,10 +144,8 @@ export interface BusDef {
   muted: boolean;
   /** Whether the processed virtual mic feeds this mix too. Persisted. */
   mic: boolean;
-  /** True: the mix is a recording device, which is what a recorder picks
-   *  from its input list. False: a playback device instead, still
-   *  recordable through its monitor. Persisted. */
-  input: boolean;
+  /** Which device list the mix shows up in. Persisted. */
+  role: MixRole;
   /** Per-member send level within this mix (0-150%); a member absent here
    *  carries at 100%. Keyed by channel sink name, or "sink_mic". */
   member_gains: Record<string, number>;


### PR DESCRIPTION
Closes #71.

**Problem**

Every mix shows up in the system's recording list. That is on purpose, a mix is a virtual source so obs can pick it up, but if you do not record it is just clutter next to your real mics.

**Fix**

- each mix picks its own device role, in the strip footer where a channel picks its output
- recording, as today, so nobody's obs setup changes
- playback puts it with the output devices instead, still recordable through its monitor
