### PR TITLE
fix(mic): wait for the pinned capture device, and take it when it appears

### DIFF
--- a/src-tauri/src/audio/pw_native/thread.rs
+++ b/src-tauri/src/audio/pw_native/thread.rs
@@ -788,19 +788,6 @@ fn on_node(
         return;
     }
 
-    // The device the chain is pinned to turned up - plugged in, or
-    // installed by a tool like noisetorch that starts after we do.
-    if is_capture_class(&media_class)
-        && s.mic_config.enabled
-        && s.mic_config.input_device.as_deref() == Some(node_name.as_str())
-    {
-        s.mic_streams = None;
-        drop(s);
-        build_mic_streams(state);
-        ensure_all_links(state);
-        return;
-    }
-
     // The virtual mic source came up: attach the DSP streams and link it
     // into any mix that carries the mic.
     if media_class == VIRTUAL_SOURCE_CLASS && node_name == MIC_NODE {
@@ -825,6 +812,19 @@ fn on_node(
         return;
     }
 
+    // A chain waiting for its device: plugged in now, or installed by a
+    // tool that starts after we do.
+    if s.mic_streams.is_none()
+        && s.mic_config.enabled
+        && s.mic_config.input_device.as_deref() == Some(node_name.as_str())
+        && is_capture_class(&media_class)
+    {
+        drop(s);
+        build_mic_streams(state);
+        ensure_all_links(state);
+        return;
+    }
+
     drop(s);
     // A new hardware sink may be the (returning) target of a channel.
     if media_class == SINK_CLASS {
@@ -832,8 +832,7 @@ fn on_node(
     }
 }
 
-/// Something the mic chain could capture from: a real source, or a virtual
-/// one like noisetorch's or another app's.
+/// A virtual source counts: noisetorch and friends install their mic as one.
 fn is_capture_class(media_class: &str) -> bool {
     media_class == SOURCE_CLASS || media_class == VIRTUAL_SOURCE_CLASS
 }
@@ -848,11 +847,9 @@ fn build_mic_streams(state: &Rc<RefCell<State>>) {
     if !s.mic_config.enabled {
         return;
     }
-    // A pinned device that is not here yet (noisetorch and friends install
-    // their source after we start) cannot be targeted: the session manager
-    // would connect the capture to whatever it likes instead, including our
-    // own virtual mic, and `dont-reconnect` then keeps it there. Wait for
-    // the node to appear - `on_node` builds the chain when it does.
+    // Targeting a device that is not here yet gets the capture connected
+    // to something else, which dont-reconnect then pins. Wait; `on_node`
+    // builds the chain when the device turns up.
     if let Some(pinned) = &s.mic_config.input_device {
         if !s
             .nodes
@@ -2105,8 +2102,6 @@ mod tests {
 
     #[test]
     fn a_mic_can_be_pinned_to_a_virtual_source_too() {
-        // noisetorch, easyeffects and the like install a virtual source,
-        // so the chain has to accept one as its capture device.
         assert!(is_capture_class(SOURCE_CLASS));
         assert!(is_capture_class(VIRTUAL_SOURCE_CLASS));
         assert!(!is_capture_class(SINK_CLASS));

--- a/src-tauri/src/audio/pw_native/thread.rs
+++ b/src-tauri/src/audio/pw_native/thread.rs
@@ -788,6 +788,19 @@ fn on_node(
         return;
     }
 
+    // The device the chain is pinned to turned up - plugged in, or
+    // installed by a tool like noisetorch that starts after we do.
+    if is_capture_class(&media_class)
+        && s.mic_config.enabled
+        && s.mic_config.input_device.as_deref() == Some(node_name.as_str())
+    {
+        s.mic_streams = None;
+        drop(s);
+        build_mic_streams(state);
+        ensure_all_links(state);
+        return;
+    }
+
     // The virtual mic source came up: attach the DSP streams and link it
     // into any mix that carries the mic.
     if media_class == VIRTUAL_SOURCE_CLASS && node_name == MIC_NODE {
@@ -819,6 +832,12 @@ fn on_node(
     }
 }
 
+/// Something the mic chain could capture from: a real source, or a virtual
+/// one like noisetorch's or another app's.
+fn is_capture_class(media_class: &str) -> bool {
+    media_class == SOURCE_CLASS || media_class == VIRTUAL_SOURCE_CLASS
+}
+
 /// (Re)build the mic capture/DSP/playback streams. The loop links the
 /// playback stream to the virtual source by name, so no id is needed.
 fn build_mic_streams(state: &Rc<RefCell<State>>) {
@@ -828,6 +847,21 @@ fn build_mic_streams(state: &Rc<RefCell<State>>) {
     let mut s = state.borrow_mut();
     if !s.mic_config.enabled {
         return;
+    }
+    // A pinned device that is not here yet (noisetorch and friends install
+    // their source after we start) cannot be targeted: the session manager
+    // would connect the capture to whatever it likes instead, including our
+    // own virtual mic, and `dont-reconnect` then keeps it there. Wait for
+    // the node to appear - `on_node` builds the chain when it does.
+    if let Some(pinned) = &s.mic_config.input_device {
+        if !s
+            .nodes
+            .values()
+            .any(|n| n.props.get("node.name") == Some(pinned) && is_capture_class(&n.media_class))
+        {
+            eprintln!("sink: mic chain waiting for {pinned}");
+            return;
+        }
     }
     // Resolve "follow default" to the actual hardware source at build
     // time - the capture must be pinned (and must never point at our own
@@ -2067,6 +2101,16 @@ mod tests {
     #[test]
     fn resolve_source_prefers_live_eq_playback() {
         assert_eq!(resolve_source(Some(77), 10), 77);
+    }
+
+    #[test]
+    fn a_mic_can_be_pinned_to_a_virtual_source_too() {
+        // noisetorch, easyeffects and the like install a virtual source,
+        // so the chain has to accept one as its capture device.
+        assert!(is_capture_class(SOURCE_CLASS));
+        assert!(is_capture_class(VIRTUAL_SOURCE_CLASS));
+        assert!(!is_capture_class(SINK_CLASS));
+        assert!(!is_capture_class(STREAM_CLASS));
     }
 
     #[test]

--- a/src-tauri/src/audio/pw_native/thread.rs
+++ b/src-tauri/src/audio/pw_native/thread.rs
@@ -383,6 +383,14 @@ fn setup_and_run(
                         s.meters.remove(&name);
                         s.adopted_sinks.remove(&name);
                     }
+                    // The mic chain's device left: unplugged, or a card that
+                    // switched profile. Drop the chain so it is rebuilt when
+                    // the device comes back rather than running on a corpse.
+                    if is_capture_class(&node.media_class)
+                        && s.mic_config.input_device.as_deref() == Some(name.as_str())
+                    {
+                        s.mic_streams = None;
+                    }
                     match s.desired.get(&name).cloned() {
                         Some((label, kind)) => {
                             // Drop any dangling proxy so the heal isn't
@@ -832,7 +840,8 @@ fn on_node(
     }
 }
 
-/// A virtual source counts: noisetorch and friends install their mic as one.
+/// Both classes: a noise suppressor publishes its cleaned-up mic as a
+/// virtual source, not a real device, and the chain can capture either.
 fn is_capture_class(media_class: &str) -> bool {
     media_class == SOURCE_CLASS || media_class == VIRTUAL_SOURCE_CLASS
 }

--- a/src/components/Mic/MicScreen.tsx
+++ b/src/components/Mic/MicScreen.tsx
@@ -37,8 +37,11 @@ function MicLevel() {
   );
 }
 
-function micStatusLabel(enabled: boolean, muted: boolean): string {
+function micStatusLabel(enabled: boolean, muted: boolean, waiting: boolean): string {
   if (!enabled) return "Off";
+  // A device that is not here yet (plugged in later, or installed by a tool
+  // that starts after us) is the one case where the chain is on but silent.
+  if (waiting) return "Waiting";
   if (muted) return "Muted";
   return "Live";
 }
@@ -62,6 +65,7 @@ export function MicScreen() {
   }
 
   const currentDevice = inputDevices.find((d) => d.name === micConfig.input_device);
+  const waiting = micConfig.input_device !== null && currentDevice === undefined;
   const deviceLabel =
     micConfig.input_device === null
       ? "System default"
@@ -72,9 +76,14 @@ export function MicScreen() {
       <div className="screen-head">
         <h1>Microphone</h1>
         <div className="screen-head-actions">
-          <span className={"tag" + (!micConfig.enabled || micConfig.muted ? " tag-off" : " live")}>
+          <span
+            className={
+              "tag" + (!micConfig.enabled || micConfig.muted || waiting ? " tag-off" : " live")
+            }
+            title={waiting ? `Waiting for ${micConfig.input_device}` : undefined}
+          >
             <Ms name="fiber_manual_record" style={{ fontSize: 11 }} />
-            {micStatusLabel(micConfig.enabled, micConfig.muted)}
+            {micStatusLabel(micConfig.enabled, micConfig.muted, waiting)}
           </span>
           <Toggle
             on={micConfig.enabled}


### PR DESCRIPTION
**Problem**

If the mic chain is pinned to a device that is not there yet, the capture stream gets connected to whatever the session manager picks instead, and `dont-reconnect` keeps it there. You end up with a mic chain capturing the wrong thing, or in testing our own virtual mic, until you re-pick the device by hand. Anything that installs its source after login hits this every session, noisetorch included, and so does a mic plugged in later. Reported in #71.

**Fix**

- the chain waits for its device instead of letting something else be chosen
- it builds as soon as that node appears, the same way it already rebuilds when the default source changes
